### PR TITLE
Adding the flag --include-script to build. 

### DIFF
--- a/examples/mathjax-script.js
+++ b/examples/mathjax-script.js
@@ -1,0 +1,21 @@
+<script type="text/javascript" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js">
+  MathJax.Hub.Config({
+    extensions: ["tex2jax.js"],
+    jax: ["input/TeX", "output/HTML-CSS"],
+    tex2jax: {
+      inlineMath: [ ['$','$'], ["\\(","\\)"] ],
+      displayMath: [ ['$$','$$'], ["\\[","\\]"] ],
+      processEscapes: true
+    },
+    "HTML-CSS": { availableFonts: ["TeX"] }
+  });
+</script>
+<script>
+var UpdateMath = function () {
+                     MathJax.Hub.Queue(["Typeset",MathJax.Hub]); 
+                     window.setTimeout(UpdateMath, 1000*1);                                      
+                     return true;
+                 };
+window.setTimeout(UpdateMath, 1000*1);
+</script>
+

--- a/examples/mathjax.rkt
+++ b/examples/mathjax.rkt
@@ -1,0 +1,22 @@
+#lang planet dyoo/whalesong
+(require (planet dyoo/whalesong/web-world))
+
+;;; This demonstrates how to use MathJax to write equations.
+;;; Use  --include-script mathjax-script.js  to include the MathJax.
+;;; racket whalesong.rkt build --include-script mathjax-script.js mathjax.rkt
+
+;; tick: world view -> world
+(define (tick n view)
+  (add1 n))
+ 
+;; draw: world view -> view
+(define (draw n view)
+  (->view
+   (xexp->dom `(p "This equation has no integer solutions: "
+                  ,(let ([n (number->string n)])
+                     (format "$$ x^~a + y^~a = z^~a $$" n n n))))))
+ 
+(big-bang 3 
+          (initial-view (xexp->dom '(html (head) (body))))
+          (on-tick tick 5)
+          (to-draw draw))

--- a/js-assembler/package.rkt
+++ b/js-assembler/package.rkt
@@ -444,7 +444,7 @@ M.modules[~s] =
 
 ;; package-standalone-xhtml: X output-port -> void
 (define (package-standalone-xhtml source-code op)
-  (display *header* op)
+  (display (get-header) op)
   (display (quote-cdata
             (string-append (get-runtime)
                            (get-inert-code source-code
@@ -513,11 +513,18 @@ M.modules[~s] =
   (force *the-runtime*))
 
 
+(define (append-text-files paths)
+  (string-join (map (λ (p) (if (file-exists? p)
+                               (bytes->string/utf-8 (call-with-input-file p port->bytes))
+                               ""))
+                    paths)
+               "\n"))
 
 
 
-;; *header* : string
-(define *header*
+;; get-header : -> string
+(define (get-header)  
+    (format
   #<<EOF
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
@@ -525,11 +532,12 @@ M.modules[~s] =
     <meta name="viewport" content="initial-scale=1.0, width=device-width, height=device-height, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no" />
     <meta charset="utf-8"/>
     <title></title>
+    ~a
   </head>
   <script>
 
 EOF
-  )
+  (append-text-files (current-header-scripts))))
 
 
 ;; get-html-template: (listof string) (#:manifest path) -> string
@@ -548,6 +556,7 @@ EOF
     <meta charset="utf-8"/>
     <title>~a</title>
 ~a
+~a
   <script>
   ~a
   </script>
@@ -561,6 +570,7 @@ EOF
       "<meta http-equiv='X-UA-Compatible' content='IE=7,chrome=1'><!--[if lt IE 9]><script src='excanvas.js' type='text/javascript'></script><script src='canvas.text.js'></script><script src='optimer-normal-normal.js'></script><![endif]-->"
       "")
   title
+  (append-text-files (current-header-scripts))
   (string-join (map (lambda (js)
                       (format "  <script src='~a'></script>\n" js))
                     js-files)

--- a/parameters.rkt
+++ b/parameters.rkt
@@ -25,7 +25,7 @@
          current-one-module-per-file?
          current-with-cache?
          current-with-legacy-ie-support?
-         
+         current-header-scripts         
          
          current-report-port
          current-timing-port
@@ -103,6 +103,9 @@
 (define current-with-legacy-ie-support? (make-parameter #t))
 
 
+;; Keeps list of Javascript files to be included in the header.
+(: current-header-scripts (Parameterof (Listof Path)))
+(define current-header-scripts (make-parameter '()))
 
 
 (: current-report-port (Parameterof Output-Port))

--- a/whalesong-cmd.rkt
+++ b/whalesong-cmd.rkt
@@ -105,6 +105,12 @@
             [("--as-standalone-xhtml")
              ("Write single standalone xhtml file")
              (as-standalone-html? #t)]
+            #:multi
+            [("--include-script")
+             script-path
+             ("Include a Javascript file in the header.")
+             (current-header-scripts (cons (string->path script-path) (current-header-scripts)))]
+
             #:args (path)
 
             (maybe-with-profiling


### PR DESCRIPTION
Javascript libraries are often included in the header.
The flag --include-script can be used to inject Javascript into the header of the html file that Whalesong builds.
An example using the Mathjax library is in examples/mathjax.rkt.
