### PR TITLE
Add $() around clone in appendChild. 

### DIFF
--- a/web-world/js-impl.js
+++ b/web-world/js-impl.js
@@ -565,8 +565,8 @@
             function(eventHandlers) { return eventHandlers; },
             function(view) {
                 var clone = $(deepClone(domNode));
-                clone.appendTo($(view.focus));
-                view.focus = clone.get(0);
+                $(clone).appendTo($(view.focus));
+                view.focus = $(clone).get(0);
             }
         );
     };


### PR DESCRIPTION
Crome (and others?) otherways complains that certain HTML Elements (p and div) does not have the appendTo nor the get method.
