### PR TITLE
Allow #f as a valid source location

### DIFF
--- a/whalesong/js-assembler/runtime-src/baselib-check.js
+++ b/whalesong/js-assembler/runtime-src/baselib-check.js
@@ -143,6 +143,11 @@
         baselib.numbers.isNatural,
         'natural');
 
+    var checkNaturalOrFalse = makeCheckArgumentType(
+        function(x) { return (baselib.numbers.isNatural(x) || 
+                              x === false); },
+        'natural or false');
+
     var checkByte = makeCheckArgumentType(
         baselib.numbers.isByte,
         'byte');
@@ -284,6 +289,7 @@
     exports.checkReal = checkReal;
     exports.checkNonNegativeReal = checkNonNegativeReal;
     exports.checkNatural = checkNatural;
+    exports.checkNaturalOrFalse = checkNaturalOrFalse;
     exports.checkNaturalInRange = checkNaturalInRange;
     exports.checkByte = checkByte;
     exports.checkBytes = checkBytes;

--- a/whalesong/js-assembler/runtime-src/baselib-primitives.js
+++ b/whalesong/js-assembler/runtime-src/baselib-primitives.js
@@ -84,6 +84,7 @@
     var checkReal = baselib.check.checkReal;
     var checkNonNegativeReal = baselib.check.checkNonNegativeReal;
     var checkNatural = baselib.check.checkNatural;
+    var checkNaturalOrFalse = baselib.check.checkNaturalOrFalse;
     var checkNaturalInRange = baselib.check.checkNaturalInRange;
     var checkInteger = baselib.check.checkInteger;
     var checkIntegerForChar = baselib.check.makeCheckArgumentType(
@@ -2736,10 +2737,10 @@
         5,
         function(M) {
             var source = M.e[M.e.length - 1];
-            var line = checkNatural(M, 'srcloc', 1);
-            var column = checkNatural(M, 'srcloc', 2);
-            var position = checkNatural(M, 'srcloc', 3);
-            var span = checkNatural(M, 'srcloc', 4);
+            var line = checkNaturalOrFalse(M, 'srcloc', 1);
+            var column = checkNaturalOrFalse(M, 'srcloc', 2);
+            var position = checkNaturalOrFalse(M, 'srcloc', 3);
+            var span = checkNaturalOrFalse(M, 'srcloc', 4);
             return baselib.srclocs.makeSrcloc(source, line, column, position, span);
         });
 
@@ -2748,10 +2749,10 @@
         5,
         function(M) {
             var source = M.e[M.e.length - 1];
-            var line = checkNatural(M, 'make-srcloc', 1);
-            var column = checkNatural(M, 'make-srcloc', 2);
-            var position = checkNatural(M, 'make-srcloc', 3);
-            var span = checkNatural(M, 'make-srcloc', 4);
+            var line = checkNaturalOrFalse(M, 'make-srcloc', 1);
+            var column = checkNaturalOrFalse(M, 'make-srcloc', 2);
+            var position = checkNaturalOrFalse(M, 'make-srcloc', 3);
+            var span = checkNaturalOrFalse(M, 'make-srcloc', 4);
             return baselib.srclocs.makeSrcloc(source, line, column, position, span);
         });
 


### PR DESCRIPTION
The documentation for srclocs says that (or/c #f natural) are appropriate arguments.  This commit adds a checker for that contract and changes the checkers on srcloc to use that instead.

http://docs.racket-lang.org/reference/exns.html#%28def._%28%28lib._racket%2Fprivate%2Fbase..rkt%29._srcloc%29%29

(Noticed because Pyret has a few "dummy" positions with #f locations, which threw a runtime error from Whalesong-compiled Pyret.)
