### PR TITLE
Behaviour of (letrec ([x x]) x) changed in Racket

### DIFF
--- a/whalesong/lang/private/shared.rkt
+++ b/whalesong/lang/private/shared.rkt
@@ -6,13 +6,13 @@
                      syntax/struct
                      racket/struct-info
                      scheme/include)
+         racket/undefined
          "traced-app.rkt")
 
 (provide shared)
 
 (define-for-syntax code-insp (current-code-inspector))
 
-(define undefined (letrec ([x x]) x))
 (require (only-in "../kernel.rkt" [cons the-cons]))
 
 (define-syntax shared


### PR DESCRIPTION
The latest Racket has changed the behaviour of (letrec ([x x]) x).
Currently any program beginning with #lang whalesong fails due
to an "x undefined" error. The undefined value is now exported
from racket/undefined.
