### PR TITLE
Fix build problem with latest Racket release (aka fix the "x undefined" error)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+Whalesong
+=========
+
+This fork of Whalesong differs from dyoo/whalesong in the following ways:
+
+  * Builds on latest release of Racket
+    (fixes the x undefined problem)
+  * Adds for
+    (require whalesong/lang/for)
+  * Adds match
+    (require whalesong/lang/match)
+  * Adds parameters
+    (require whalesong/lang/parameters)
+    
+Note: The implementation of parameters works fine,
+      as long as you don't mix parameterize with non-local-exits
+      and reentries (i.e. call/cc and friends)
+      
+/soegaard

--- a/README.md
+++ b/README.md
@@ -9,9 +9,11 @@ This fork of Whalesong differs from dyoo/whalesong in the following ways:
     (require whalesong/lang/for)
   * Adds match
     (require whalesong/lang/match)
+  * Adds on-release
+    (as a complement to on-key)
   * Adds parameters
     (require whalesong/lang/parameters)
-    
+ 
 Note: The implementation of parameters works fine,
       as long as you don't mix parameterize with non-local-exits
       and reentries (i.e. call/cc and friends)

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Installation
 raco pkg install -j 1 --force --deps search-auto --scope installation whalesong
 
 Important: Use -j 1 to build Whalesong (this turns off parallel builds)
+           This also means, that you can't install Whalesong from the DrRacket package manager.
 
 This fork of Whalesong differs from dyoo/whalesong in the following ways:
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Installation
 
 raco pkg install -j 1 --force --deps search-auto --scope installation whalesong
 
-Imporatnt: Use -j 1 to build Whalesong (this turns off parallel builds)
+Important: Use -j 1 to build Whalesong (this turns off parallel builds)
 
 This fork of Whalesong differs from dyoo/whalesong in the following ways:
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Important: Use -j 1 to build Whalesong (this turns off parallel builds)
 
 This fork of Whalesong differs from dyoo/whalesong in the following ways:
 
-  * Builds on latest release of Racket
+  * Builds on version 6.2 of Racket
     (fixes the x undefined problem)
   * Adds for
     (require whalesong/lang/for)

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ This fork of Whalesong differs from dyoo/whalesong in the following ways:
   * Extended whalesong/image and whalesong/images
     (more functions, bug fixes, now matches WeScheme)
     Contributed by Emmanuel Schanzer
+  * Adds play-sound
+    (assumes a browser with html5 audio support)
 
 Note: The implementation of parameters works fine,
       as long as you don't mix parameterize with non-local-exits

--- a/README.md
+++ b/README.md
@@ -11,9 +11,13 @@ This fork of Whalesong differs from dyoo/whalesong in the following ways:
     (require whalesong/lang/match)
   * Adds on-release
     (as a complement to on-key)
+    Contributed by Darren Cruse
   * Adds parameters
     (require whalesong/lang/parameters)
- 
+  * Extended whalesong/image and whalesong/images
+    (more functions, bug fixes, not matches WeScheme)
+    Contributed by Emmanuel Schanzer
+
 Note: The implementation of parameters works fine,
       as long as you don't mix parameterize with non-local-exits
       and reentries (i.e. call/cc and friends)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 Whalesong
 =========
 
+IMPORTANT: Use -j 1 to build Whalesong (this turns off parallel builds)
+
 This fork of Whalesong differs from dyoo/whalesong in the following ways:
 
   * Builds on latest release of Racket

--- a/README.md
+++ b/README.md
@@ -1,6 +1,13 @@
 Whalesong
 =========
 
+Important
+---------
+
+Whalesong needs Racket 5.2.
+As is Whalesong doesn't work on version 5.3 or greater.
+See https://github.com/soegaard/whalesong/issues/48
+
 Installation
 ------------
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ This fork of Whalesong differs from dyoo/whalesong in the following ways:
     Contributed by Emmanuel Schanzer
   * Adds play-sound
     (assumes a browser with html5 audio support)
+    Contributed by Emmanuel Schanzer and Darren Cruse
 
 Note: The implementation of parameters works fine,
       as long as you don't mix parameterize with non-local-exits

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This fork of Whalesong differs from dyoo/whalesong in the following ways:
   * Adds parameters
     (require whalesong/lang/parameters)
   * Extended whalesong/image and whalesong/images
-    (more functions, bug fixes, not matches WeScheme)
+    (more functions, bug fixes, now matches WeScheme)
     Contributed by Emmanuel Schanzer
 
 Note: The implementation of parameters works fine,

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ Whalesong
 Important
 ---------
 
-Whalesong needs Racket 5.2.
-As is Whalesong doesn't work on version 5.3 or greater.
+Whalesong needs Racket 6.2.
+As is Whalesong doesn't work on version 6.3 or greater.
 See https://github.com/soegaard/whalesong/issues/48
 
 Installation

--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ This fork of Whalesong differs from dyoo/whalesong in the following ways:
   * Adds play-sound
     (assumes a browser with html5 audio support)
     Contributed by Emmanuel Schanzer and Darren Cruse
+  * Bug fixes by Vishesh Yadav
+  * The flag --as-standalone-xhtml is now --as-standalone-html
+    and produces standalone html rather than xhtml.
 
 Note: The implementation of parameters works fine,
       as long as you don't mix parameterize with non-local-exits

--- a/README.md
+++ b/README.md
@@ -1,7 +1,12 @@
 Whalesong
 =========
 
-IMPORTANT: Use -j 1 to build Whalesong (this turns off parallel builds)
+Installation
+------------
+
+raco pkg install -j 1 --force --deps search-auto --scope installation whalesong
+
+Imporatnt: Use -j 1 to build Whalesong (this turns off parallel builds)
 
 This fork of Whalesong differs from dyoo/whalesong in the following ways:
 

--- a/whalesong/README
+++ b/whalesong/README
@@ -29,11 +29,10 @@ amount of time.
 Example usage
 
 
-
-Create a simple, standalong executable of your program.  At the
-moment, the program must be written in the base language of whalesong.
-(This restriction currently prevents arbitrary racket/base programs
-from compiling, and we'll be working to remove this restriction.)
+Create a simple, executable of your program.  At the moment, the program must
+be written in the base language of whalesong.  (This restriction currently
+prevents arbitrary racket/base programs from compiling, and we'll be working to
+remove this restriction.)
 
     $ cat hello.rkt 
     #lang whalesong
@@ -42,8 +41,18 @@ from compiling, and we'll be working to remove this restriction.)
 
     $ ./whalesong.rkt build hello.rkt
 
-    $ ls -l hello.xhtml
-    -rw-rw-r-- 1 dyoo nogroup 692213 Jun  7 18:00 hello.xhtml
+    $ ls -l hello.html
+    -rw-rw-r-- 1 dyoo nogroup 692213 Jun  7 18:00 hello.html
+
+To build standalone executable of your program, provide --as-standalone-html
+flag.
+
+    $ ./whalesong.rkt build --as-standalone-html hello.rkt
+
+    $ ls -l
+    -rw-rw-r-- 1 dyoo nogroup 692213 Jun  7 18:00 hello.html
+
+NOTE: Earlier versions had --as-standalone-xhtml flag, which is now removed.
 
 
 [FIXME: add more examples]

--- a/whalesong/compiler/expression-structs.rkt
+++ b/whalesong/compiler/expression-structs.rkt
@@ -163,11 +163,24 @@
 (define current-short-labels? (make-parameter #t))
 
 
+(define make-label-counter 0)
+
+(: reset-make-label-counter (-> Void))
+(define (reset-make-label-counter)
+  (set! make-label-counter 0))
+
 (: make-label (Symbol -> Symbol))
-(define make-label
+#;(define make-label
   (let ([n 0])
     (lambda (l)
       (set! n (add1 n))
       (if (current-short-labels?)
           (string->symbol (format "_~a" n))
           (string->symbol (format "~a~a" l n))))))
+
+(define (make-label l)
+  (set! make-label-counter (+ make-label-counter 1))
+  (define n make-label-counter)
+  (if (current-short-labels?)
+      (string->symbol (format "_~a" n))
+      (string->symbol (format "~a~a" l n))))

--- a/whalesong/image/main.rkt
+++ b/whalesong/image/main.rkt
@@ -1,7 +1,9 @@
 #lang s-exp "../lang/base.rkt"
 
 (require "private/main.rkt"
-         "private/color.rkt")
+         "private/color.rkt"
+         "private/image.rkt")
 
 (provide (all-from-out "private/main.rkt")
-         (all-from-out "private/color.rkt"))
+         (all-from-out "private/color.rkt")
+         (all-from-out "private/image.rkt"))

--- a/whalesong/image/private/image.rkt
+++ b/whalesong/image/private/image.rkt
@@ -1,13 +1,15 @@
 #lang s-exp "../../lang/base.rkt"
 
 ;; Image functions that be implemented using racket based on primitives
+;; NOTE: Modifications here may require rebuilding of Whalesong
 
 (require "main.rkt"
          "../../lang/for.rkt"
          "../../lang/posn.rkt")
 
 (provide place-images
-         place-images/align)
+         place-images/align
+         empty-image)
 
 ; place-images : (listof image?) (listof posn?) image? -> image?
 (define (place-images images posns scene)
@@ -20,3 +22,5 @@
   (for/fold ([acc scene])
             ([img images] [posn posns])
             (place-image/align img (posn-x posn) (posn-y posn) x-place y-place acc)))
+
+(define empty-image (rectangle 0 0 "solid" "black"))

--- a/whalesong/image/private/image.rkt
+++ b/whalesong/image/private/image.rkt
@@ -1,0 +1,22 @@
+#lang s-exp "../../lang/base.rkt"
+
+;; Image functions that be implemented using racket based on primitives
+
+(require "main.rkt"
+         "../../lang/for.rkt"
+         "../../lang/posn.rkt")
+
+(provide place-images
+         place-images/align)
+
+; place-images : (listof image?) (listof posn?) image? -> image?
+(define (place-images images posns scene)
+  (for/fold ([acc scene])
+            ([img images] [posn posns])
+            (place-image img (posn-x posn) (posn-y posn) acc)))
+
+; place-images : (listof image?) (listof posn?) x-place? y-place? image? -> image?
+(define (place-images/align images posns x-place y-place scene)
+  (for/fold ([acc scene])
+            ([img images] [posn posns])
+            (place-image/align img (posn-x posn) (posn-y posn) x-place y-place acc)))

--- a/whalesong/image/private/js-impl.js
+++ b/whalesong/image/private/js-impl.js
@@ -689,7 +689,7 @@ EXPORTS['empty-scene'] =
 	    var height = checkNonNegativeReal(MACHINE, 'empty-scene', 1);
             var color = (MACHINE.a===3)? checkColor(MACHINE, 'empty-scene', 2) : null;
 
-            return new SceneImage(jsnums.toFixnum(width),
+            return makeSceneImage(jsnums.toFixnum(width),
                                   jsnums.toFixnum(height),
                                   color,
                                   [],
@@ -708,10 +708,11 @@ EXPORTS['put-image'] =
 	    if (isScene(background)) {
 		return background.add(picture, jsnums.toFixnum(x), background.getHeight() - jsnums.toFixnum(y));
 	    } else {
-		var newScene = makeSceneImage(background.getWidth(),
-					      background.getHeight(),
-					      [], 
-					      false);
+                var newScene = makeSceneImage(background.getWidth(),
+                                              background.getHeight(),
+                                              null,
+                                              [],
+                                              false);
 		newScene = newScene.add(background, background.getWidth()/2, background.getHeight()/2);
           newScene = newScene.add(picture, jsnums.toFixnum(x), background.getHeight() - jsnums.toFixnum(y));
 		return newScene;
@@ -732,10 +733,11 @@ EXPORTS['place-image'] =
 	    if (isScene(background)) {
 		return background.add(picture, jsnums.toFixnum(x), jsnums.toFixnum(y));
 	    } else {
-		var newScene = makeSceneImage(background.getWidth(),
-					      background.getHeight(),
-					      [], 
-					      false);
+                var newScene = makeSceneImage(background.getWidth(),
+                                              background.getHeight(),
+                                              null,
+                                              [],
+                                              false);
 		newScene = newScene.add(background, background.getWidth()/2, background.getHeight()/2);
           newScene = newScene.add(picture, jsnums.toFixnum(x), jsnums.toFixnum(y));
 		return newScene;
@@ -766,10 +768,11 @@ EXPORTS['place-image/align'] =
 	    if (isScene(background)) {
 		return background.add(img, jsnums.toFixnum(x), jsnums.toFixnum(y));
 	    } else {
-		var newScene = makeSceneImage(background.getWidth(),
-					      background.getHeight(),
-					      [], 
-					      false);
+                var newScene = makeSceneImage(background.getWidth(),
+                                              background.getHeight(),
+                                              null,
+                                              [],
+                                              false);
 		newScene = newScene.add(background, background.getWidth()/2, background.getHeight()/2);
     newScene = newScene.add(img, jsnums.toFixnum(x), jsnums.toFixnum(y));
 		return newScene;
@@ -921,10 +924,11 @@ EXPORTS['scene+line'] =
 	    var y2 = checkReal(MACHINE,	"scene+line", 4);
 	    var c = checkColor(MACHINE, "scene+line", 5);
 	    // make a scene containing the image
-	    var newScene = makeSceneImage(jsnums.toFixnum(img.getWidth()), 
-                                    jsnums.toFixnum(img.getHeight()),
-                                    [],
-                                    false);
+            var newScene = makeSceneImage(jsnums.toFixnum(img.getWidth()), 
+                                          jsnums.toFixnum(img.getHeight()),
+                                          null,
+                                          [],
+                                          false);
 	    newScene = newScene.add(img, img.getWidth()/2, img.getHeight()/2);
 	    // make an image containing the line
 	    var line = makeLineImage(jsnums.toFixnum(x2-x1),

--- a/whalesong/image/private/js-impl.js
+++ b/whalesong/image/private/js-impl.js
@@ -687,8 +687,9 @@ EXPORTS['empty-scene'] =
 	function(MACHINE) {
 	    var width = checkNonNegativeReal(MACHINE, 'empty-scene', 0);
 	    var height = checkNonNegativeReal(MACHINE, 'empty-scene', 1);
-      var color = (MACHINE.a===3)? checkColor(MACHINE, 'empty-scene', 2) : null;
-	    return makeSceneImage(jsnums.toFixnum(width),
+            var color = (MACHINE.a===3)? checkColor(MACHINE, 'empty-scene', 2) : null;
+
+            return new SceneImage(jsnums.toFixnum(width),
                                   jsnums.toFixnum(height),
                                   color,
                                   [],

--- a/whalesong/image/private/js-impl.js
+++ b/whalesong/image/private/js-impl.js
@@ -754,20 +754,23 @@ EXPORTS['place-image/align'] =
         6,
         function(MACHINE) {
 	    var img = checkImage(MACHINE, "place-image/align", 0);
-	    var x = checkReal(MACHINE, "place-image/align", 1);
-	    var y = checkReal(MACHINE, "place-image/align", 2);
+	    var x = jsnums.toFixnum(checkReal(MACHINE, "place-image/align", 1));
+	    var y = jsnums.toFixnum(checkReal(MACHINE, "place-image/align", 2));
 	    var placeX = checkPlaceX(MACHINE, "place-image/align", 3);
 	    var placeY = checkPlaceY(MACHINE, "place-image/align", 4);
 	    var background = checkImageOrScene(MACHINE, "place-image/align", 5);
 	    
+            var pinholeX = img.pinholeX || img.getWidth() / 2;
+            var pinholeY = img.pinholeY || img.getHeight() / 2;
+
 	    // calculate x and y based on placeX and placeY
-	    if (placeX == "left") x = x + img.pinholeX;
-	    else if (placeX == "right") x = x - img.pinholeX;
-	    if (placeY == "top") y = y + img.pinholeY;
-	    else if (placeY == "bottom") y = y - img.pinholeY;
+	    if (placeX == "left") x = x + pinholeX;
+	    else if (placeX == "right") x = x - pinholeX;
+	    if (placeY == "top") y = y + pinholeY;
+	    else if (placeY == "bottom") y = y - pinholeY;
 
 	    if (isScene(background)) {
-		return background.add(img, jsnums.toFixnum(x), jsnums.toFixnum(y));
+		return background.add(img, x, y);
 	    } else {
                 var newScene = makeSceneImage(background.getWidth(),
                                               background.getHeight(),
@@ -775,7 +778,7 @@ EXPORTS['place-image/align'] =
                                               [],
                                               false);
 		newScene = newScene.add(background, background.getWidth()/2, background.getHeight()/2);
-    newScene = newScene.add(img, jsnums.toFixnum(x), jsnums.toFixnum(y));
+                newScene = newScene.add(img, x, y);
 		return newScene;
             }
         });

--- a/whalesong/image/private/js-impl.js
+++ b/whalesong/image/private/js-impl.js
@@ -633,12 +633,14 @@ EXPORTS['above/align'] =
 EXPORTS['empty-scene'] =
     makePrimitiveProcedure(
         'empty-scene',
-	2,
+        plt.baselib.lists.makeList(2, 3),
 	function(MACHINE) {
 	    var width = checkNonNegativeReal(MACHINE, 'empty-scene', 0);
 	    var height = checkNonNegativeReal(MACHINE, 'empty-scene', 1);
-	    return makeSceneImage(jsnums.toFixnum(width), 
+      var color = (MACHINE.a===3)? checkColor(MACHINE, 'empty-scene', 2) : null;
+	    return makeSceneImage(jsnums.toFixnum(width),
                                   jsnums.toFixnum(height),
+                                  color,
                                   [],
                                   true);
 	});

--- a/whalesong/image/private/js-impl.js
+++ b/whalesong/image/private/js-impl.js
@@ -89,8 +89,6 @@ var less = function(lhs, rhs) {
   return (rhs - lhs) > 0.00001;
 }
 
-
-
 var checkString = plt.baselib.check.checkString;
 var checkStringOrFalse = plt.baselib.check.makeCheckArgumentType(
     function(x) { return plt.baselib.strings.isString(x) || x === false; },
@@ -782,26 +780,24 @@ EXPORTS['place-image/align'] =
             }
         });
 
-
-
-
-
-
-
+//////////////////////////////////////////////////////////////////////
+// rotate: angle image -> image
+// Rotates image by angle degrees in a counter-clockwise direction.
 EXPORTS['rotate'] = 
     makePrimitiveProcedure(
         'rotate',
         2,
         function(MACHINE) {
 	    var angle = checkRotateAngle(MACHINE, "rotate", 0);
+	    var angle360 = angle % 360;
 	    var img = checkImage(MACHINE, "rotate", 1);
-            if (jsnums.lessThan(angle, 0)) {
-		return makeRotateImage(jsnums.toFixnum(-(360 + angle)), img);
+	    // convert to clockwise rotation for makeRotateImage
+	    if (angle360 < 0) {
+		return makeRotateImage(jsnums.toFixnum(-(360 + angle360)), img);
 	    } else {
-		return makeRotateImage(jsnums.toFixnum(-angle), img);
+		return makeRotateImage(jsnums.toFixnum(-angle360), img);
 	    }
         });
-
 
 
 EXPORTS['scale'] = 

--- a/whalesong/image/private/js-impl.js
+++ b/whalesong/image/private/js-impl.js
@@ -474,6 +474,22 @@ EXPORTS['overlay/xy'] =
 				    jsnums.toFixnum(deltaY));
         });
 
+EXPORTS['overlay/offset'] = 
+    makePrimitiveProcedure(
+        'overlay/offset',
+        4,
+        function(MACHINE) {
+	    var img1 = checkImage(MACHINE, "overlay/offset", 0);
+	    var deltaX = checkReal(MACHINE, "overlay/offset", 1);
+	    var deltaY = checkReal(MACHINE, "overlay/offset", 2);
+	    var img2 = checkImage(MACHINE, "overlay/offset", 3);
+            var middleX = (img1.getWidth() - img2.getWidth()) / 2;
+            var middleY = (img1.getHeight() - img2.getHeight()) / 2;
+	    return makeOverlayImage(img1,
+				    img2,
+				    jsnums.toFixnum(middleX + deltaX),
+				    jsnums.toFixnum(middleY + deltaY));
+        });
 
 
  EXPORTS['overlay/align'] = 
@@ -538,6 +554,23 @@ EXPORTS['underlay/xy'] =
 				    img1.updatePinhole(0, 0),
 				    -(jsnums.toFixnum(deltaX)),
 				    -(jsnums.toFixnum(deltaY)));
+        });
+
+EXPORTS['underlay/offset'] = 
+    makePrimitiveProcedure(
+        'underlay/offset',
+        4,
+        function(MACHINE) {
+	    var img1 = checkImage(MACHINE, "underlay/offset", 0);
+	    var deltaX = checkReal(MACHINE, "underlay/offset", 1);
+	    var deltaY = checkReal(MACHINE, "underlay/offset", 2);
+	    var img2 = checkImage(MACHINE, "underlay/offset", 3);
+            var middleX = (img1.getWidth() - img2.getWidth()) / 2;
+            var middleY = (img1.getHeight() - img2.getHeight()) / 2;
+	    return makeOverlayImage(img2,
+				    img1,
+				    -jsnums.toFixnum(middleX + deltaX),
+				    -jsnums.toFixnum(middleY + deltaY));
         });
 
 EXPORTS['underlay/align'] = 

--- a/whalesong/image/private/js-impl.js
+++ b/whalesong/image/private/js-impl.js
@@ -154,6 +154,9 @@ var checkPlaceY = plt.baselib.check.makeCheckArgumentType(
 var checkAngle = plt.baselib.check.makeCheckArgumentType(
     isAngle,
     "finite real number between 0 and 360");
+var checkRotateAngle = plt.baselib.check.makeCheckArgumentType(
+    isRotateAngle,
+    "finite real number between -360 and 360");
 
 
 var checkMode = plt.baselib.check.makeCheckArgumentType(
@@ -790,9 +793,13 @@ EXPORTS['rotate'] =
         'rotate',
         2,
         function(MACHINE) {
-	    var angle = checkAngle(MACHINE, "rotate", 0);
+	    var angle = checkRotateAngle(MACHINE, "rotate", 0);
 	    var img = checkImage(MACHINE, "rotate", 1);
-	    return makeRotateImage(jsnums.toFixnum(-angle), img);
+            if (jsnums.lessThan(angle, 0)) {
+		return makeRotateImage(jsnums.toFixnum(-(360 + angle)), img);
+	    } else {
+		return makeRotateImage(jsnums.toFixnum(-angle), img);
+	    }
         });
 
 

--- a/whalesong/image/private/js-impl.js
+++ b/whalesong/image/private/js-impl.js
@@ -487,8 +487,8 @@ EXPORTS['overlay/offset'] =
             var middleY = (img1.getHeight() - img2.getHeight()) / 2;
 	    return makeOverlayImage(img1,
 				    img2,
-				    jsnums.toFixnum(middleX + deltaX),
-				    jsnums.toFixnum(middleY + deltaY));
+				    jsnums.toFixnum(middleX) + deltaX,
+				    jsnums.toFixnum(middleY) + deltaY);
         });
 
 
@@ -569,8 +569,8 @@ EXPORTS['underlay/offset'] =
             var middleY = (img1.getHeight() - img2.getHeight()) / 2;
 	    return makeOverlayImage(img2,
 				    img1,
-				    -jsnums.toFixnum(middleX + deltaX),
-				    -jsnums.toFixnum(middleY + deltaY));
+				    -(jsnums.toFixnum(middleX) + deltaX),
+				    -(jsnums.toFixnum(middleY) + deltaY));
         });
 
 EXPORTS['underlay/align'] = 

--- a/whalesong/image/private/kernel.js
+++ b/whalesong/image/private/kernel.js
@@ -300,7 +300,7 @@ var SceneImage = function(width, height, color, children, withBorder) {
 SceneImage.prototype = heir(BaseImage.prototype);
 
 // add: image primitive-number primitive-number -> Scene
-SceneImage.prototype.add = function(anImage, x, color) {
+SceneImage.prototype.add = function(anImage, x, y) {
   return new SceneImage(this.width,
                         this.height,
                         this.children.concat([[anImage,

--- a/whalesong/image/private/kernel.js
+++ b/whalesong/image/private/kernel.js
@@ -45,14 +45,12 @@ var isColorOrColorString = function(thing) {
 
 
 //////////////////////////////////////////////////////////////////////
-// colorString : hexColor Style -> rgba
-// Style can be "solid" (1.0), "outline" (1.0), a number (0-1.0) or null (1.0)
-var colorString = function(aColor, aStyle) {
-  var alpha = isNaN(aStyle)? 1.0 : aStyle/255;
+// colorString : hexColor -> rgba
+var colorString = function(aColor) {
   return "rgba(" + colorRed(aColor) + "," +
                   colorGreen(aColor) + ", " +
                   colorBlue(aColor) + ", " +
-                  alpha + ")";
+                  (colorAlpha(aColor) || 255)/255.0 + ")";
 };
 
 
@@ -163,7 +161,7 @@ BaseImage.prototype.render = function(ctx, x, y) {
     ctx.strokeStyle = colorString(this.color);
     ctx.stroke();
   } else {
-    ctx.fillStyle = colorString(this.color, this.style);
+    ctx.fillStyle = colorString(this.color);
     ctx.fill();
   }
   ctx.restore();
@@ -1211,7 +1209,7 @@ EllipseImage.prototype.render = function(ctx, aX, aY) {
     ctx.stroke();
   }
   else {
-    ctx.fillStyle = colorString(this.color, this.style);
+    ctx.fillStyle = colorString(this.color);
     ctx.fill();
   }
   

--- a/whalesong/image/private/kernel.js
+++ b/whalesong/image/private/kernel.js
@@ -303,6 +303,7 @@ SceneImage.prototype = heir(BaseImage.prototype);
 SceneImage.prototype.add = function(anImage, x, y) {
   return new SceneImage(this.width,
                         this.height,
+                        null,
                         this.children.concat([[anImage,
                                                x - anImage.getWidth()/2,
                                                y - anImage.getHeight()/2]]),
@@ -1311,7 +1312,7 @@ var colorListToImage = function(listOfColors,
 
 
 var makeSceneImage = function(width, height, children, withBorder) {
-    return new SceneImage(width, height, children, withBorder);
+    return new SceneImage(width, height, null, children, withBorder);
 };
 var makeCircleImage = function(radius, style, color) {
     return new EllipseImage(2*radius, 2*radius, style, color);

--- a/whalesong/image/private/kernel.js
+++ b/whalesong/image/private/kernel.js
@@ -28,9 +28,7 @@ var isAngle = function(x) {
 };
 // differentiate between rotation angle and other angles
 var isRotateAngle = function(x) {
-    return plt.baselib.numbers.isReal(x) &&
-        jsnums.greaterThan(x, -360) &&
-        jsnums.lessThan(x, 360);
+    return plt.baselib.numbers.isReal(x);
 };
 
 
@@ -672,8 +670,9 @@ OverlayImage.prototype.equals = function(other, aUnionFind) {
 
 
 //////////////////////////////////////////////////////////////////////
-// rotate: angle image -> image
-// Rotates image by angle degrees in a counter-clockwise direction.
+// RotateImage: angle image -> image
+// Rotates image by angle degrees in a *clockwise* direction.
+// NOTE: the angle direction differs from the rotate function.
 // TODO: special case for ellipse?
 var RotateImage = function(angle, img) {
   BaseImage.call(this);

--- a/whalesong/image/private/kernel.js
+++ b/whalesong/image/private/kernel.js
@@ -26,6 +26,12 @@ var isAngle = function(x) {
         jsnums.greaterThanOrEqual(x, 0) &&
         jsnums.lessThan(x, 360);
 };
+// differentiate between rotation angle and other angles
+var isRotateAngle = function(x) {
+    return plt.baselib.numbers.isReal(x) &&
+        jsnums.greaterThan(x, -360) &&
+        jsnums.lessThan(x, 360);
+};
 
 
 // Produces true if the value is a color or a color string.
@@ -1469,6 +1475,7 @@ EXPORTS.isImage = isImage;
 EXPORTS.isScene = isScene;
 EXPORTS.isColorOrColorString = isColorOrColorString;
 EXPORTS.isAngle = isAngle;
+EXPORTS.isRotateAngle = isRotateAngle;
 EXPORTS.isSideCount = isSideCount;
 EXPORTS.isStepCount = isStepCount;
 EXPORTS.isPointsCount = isPointsCount;

--- a/whalesong/image/private/kernel.js
+++ b/whalesong/image/private/kernel.js
@@ -456,7 +456,7 @@ FileImage.prototype.equals = function(other, aUnionFind) {
 };
 
 //////////////////////////////////////////////////////////////////////
-// FileVideoe: String Node -> Video
+// FileVideo: String Node -> Video
 var FileVideo = function(src, rawVideo) {
     BaseImage.call(this);
     var self = this;
@@ -507,51 +507,38 @@ FileVideo.prototype.render = function(ctx, x, y) {
     ctx.drawImage(this.video, x, y);
 };
 FileVideo.prototype.equals = function(other, aUnionFind) {
-  return (other instanceof FileVideo) && (this.src === other.src);
+    return (other instanceof FileVideo) && (this.src === other.src);
 };
 
 //////////////////////////////////////////////////////////////////////
-// FileAudio: String Node -> Video
+// FileAudio: String Boolean Audio -> FileAudio
 var FileAudio = function(src, loop, rawAudio) {
-  this.src = src;
-  var that = this;
-  if (rawAudio && (rawAudio.readyState===4)) {
-    that.audio                  = rawAudio;
-    that.audio.autoplay         = true;
-    that.audio.autobuffer       = true;
-    that.audio.currentTime      = 0;
-    that.audio.loop             = loop;
-    that.audio.play();
-  } else {
-    // fixme: we may want to do something blocking here for
-    // onload, since we don't know at this time what the file size
-    // should be, nor will drawImage do the right thing until the
-    // file is loaded.
-    that.audio = document.createElement('audio');
-    that.audio.src = src;
-    that.audio.addEventListener('canplay', function() {
-                                that.audio.autoplay     = true;
-                                that.audio.autobuffer   = true;
-                                that.audio.currentTime  = 0;
-                                that.audio.loop         = loop;
-                                that.audio.play();
-                                });
-  }
-  return true;
+    this.src = src;
+    if(rawAudio) {
+        this.audio = rawAudio;
+    }
+    else {
+        this.audio = document.createElement('audio');
+    }
+    this.audio.src = src;
+    this.audio.autoplay         = false;
+    this.audio.autobuffer       = true;
+    // the below caused firefox to hang (but things work ok without it)
+    // this.audio.currentTime      = 0;
+    this.audio.loop             = loop;
+    return true;
 };
-var audioCache = {};
+
 FileAudio.makeInstance = function(path, loop, rawAudio) {
-  /*        if (! (path in audioCache)) {
-   audioCache[path] = new FileAudio(path, loop, rawAudio, afterInit);
-   return audioCache[path];
-   } else {
-   audioCache[path].audio.play();
-   afterInit(audioCache[path]);
-   return audioCache[path];
-   }
-   */
-  return new FileAudio(path, loop, rawAudio);
+    return new FileAudio(path, loop, rawAudio);
 };
+
+FileAudio.prototype.play = function () {
+    this.audio.play();
+    return true;
+}
+
+
 
 //////////////////////////////////////////////////////////////////////
 // ImageDataImage: imageData -> image
@@ -1384,8 +1371,8 @@ var makeFileImage = function(path, rawImage) {
 var makeFileVideo = function(path, rawVideo) {
     return FileVideo.makeInstance(path, rawVideo);
 };
-var makeFileAudio = function(path, rawAudio){
-  return FileAudio.makeInstance(path, rawAudio)
+var makeFileAudio = function(path, loop, rawAudio){
+  return FileAudio.makeInstance(path, loop, rawAudio)
 };
 
 
@@ -1409,7 +1396,7 @@ var isFlipImage	= function(x) { return x instanceof FlipImage; };
 var isTextImage	= function(x) { return x instanceof TextImage; };
 var isFileImage	= function(x) { return x instanceof FileImage; };
 var isFileVideo	= function(x) { return x instanceof FileVideo; };
-
+var isFileAudio = function(x) { return x instanceof FileAudio; };
 
 
 
@@ -1503,7 +1490,7 @@ EXPORTS.isFlipImage = isFlipImage;
 EXPORTS.isTextImage = isTextImage;
 EXPORTS.isFileImage = isFileImage;
 EXPORTS.isFileVideo = isFileVideo;
-//EXPORTS.isFileAudio = isFileAudio;
+EXPORTS.isFileAudio = isFileAudio;
 
 
 EXPORTS.makeColor = makeColor;

--- a/whalesong/image/private/kernel.js
+++ b/whalesong/image/private/kernel.js
@@ -288,18 +288,19 @@ var isScene = function(x) {
 
 
 //////////////////////////////////////////////////////////////////////
-// SceneImage: primitive-number primitive-number (listof image) -> Scene
-var SceneImage = function(width, height, children, withBorder) {
+// SceneImage: primitive-number primitive-number color (listof image) -> Scene
+var SceneImage = function(width, height, color, children, withBorder) {
   BaseImage.call(this);
   this.width    = width;
   this.height   = height;
   this.children = children; // arrayof [image, number, number]
   this.withBorder = withBorder;
+  this.color    = color;
 };
 SceneImage.prototype = heir(BaseImage.prototype);
 
 // add: image primitive-number primitive-number -> Scene
-SceneImage.prototype.add = function(anImage, x, y) {
+SceneImage.prototype.add = function(anImage, x, color) {
   return new SceneImage(this.width,
                         this.height,
                         this.children.concat([[anImage,
@@ -314,7 +315,8 @@ SceneImage.prototype.render = function(ctx, x, y) {
   var childImage, childX, childY;
   // create a clipping region around the boundaries of the Scene
   ctx.save();
-  ctx.fillStyle = "rgba(0,0,0,0)";
+  // if no color is defined, default to transparent
+  ctx.fillStyle = this.color? colorString(this.color) : "rgba(0,0,0,0)";
   ctx.fillRect(x, y, this.width, this.height);
   ctx.restore();
   // save the context, reset the path, and clip to the path around the scene edge

--- a/whalesong/image/private/kernel.js
+++ b/whalesong/image/private/kernel.js
@@ -288,7 +288,7 @@ var isScene = function(x) {
 
 
 //////////////////////////////////////////////////////////////////////
-// SceneImage: primitive-number primitive-number color (listof image) -> Scene
+// SceneImage: primitive-number primitive-number color (listof image) boolean -> Scene
 var SceneImage = function(width, height, color, children, withBorder) {
   BaseImage.call(this);
   this.width    = width;
@@ -1311,8 +1311,8 @@ var colorListToImage = function(listOfColors,
 
 
 
-var makeSceneImage = function(width, height, children, withBorder) {
-    return new SceneImage(width, height, null, children, withBorder);
+var makeSceneImage = function(width, height, color, children, withBorder) {
+    return new SceneImage(width, height, color, children, withBorder);
 };
 var makeCircleImage = function(radius, style, color) {
     return new EllipseImage(2*radius, 2*radius, style, color);

--- a/whalesong/image/private/main.rkt
+++ b/whalesong/image/private/main.rkt
@@ -12,11 +12,12 @@
                "js-impl.js")
  #:provided-values (text
                     text/font
-
+                    
                     bitmap/url
                     image-url      ;; older name for bitmap/url
                     open-image-url ;; older name for bitmap/url
-
+                    video/url
+                    play-sound
                     overlay
                     overlay/xy
                     overlay/align
@@ -28,6 +29,7 @@
                     above
                     above/align
                     empty-scene
+                    put-image
                     place-image
                     place-image/align
                     rotate
@@ -43,9 +45,17 @@
                     circle
                     square
                     rectangle
+                    polygon
                     regular-polygon
                     ellipse
                     triangle
+                    triangle/sas
+                    triangle/sss
+                    triangle/ass
+                    triangle/ssa
+                    triangle/aas
+                    triangle/asa
+                    triangle/saa
                     right-triangle
                     isosceles-triangle
                     star
@@ -66,6 +76,6 @@
                     side-count?
                     step-count?
                     image?
-
+                    image=?
                     name->color
                     ))

--- a/whalesong/image/private/main.rkt
+++ b/whalesong/image/private/main.rkt
@@ -19,9 +19,11 @@
                     video/url
                     play-sound
                     overlay
+                    overlay/offset
                     overlay/xy
                     overlay/align
                     underlay
+                    underlay/offset
                     underlay/xy
                     underlay/align
                     beside

--- a/whalesong/image/private/racket-impl.rkt
+++ b/whalesong/image/private/racket-impl.rkt
@@ -15,6 +15,7 @@
          above
          above/align
          empty-scene
+         put-image
          place-image
          place-image/align
          rotate
@@ -30,9 +31,17 @@
          circle
          square
          rectangle
+         polygon
          regular-polygon
          ellipse
          triangle
+         triangle/sas
+         triangle/sss
+         triangle/ass
+         triangle/ssa
+         triangle/aas
+         triangle/asa
+         triangle/saa
          right-triangle
          isosceles-triangle
          star
@@ -51,19 +60,22 @@
          angle?
          side-count?
          image?
+         image=?
          ;; Something funky is happening on the Racket side of things with regards
          ;; to step-count?  See:  http://bugs.racket-lang.org/query/?cmd=view&pr=12031
          ;; step-count?
-
+         
          bitmap/url
-
+         video/url
+         play-sound
+         
          name->color
-
+         
          step-count?
          image-url
          open-image-url
          color-list->bitmap
-
+         
          )
 
 
@@ -99,6 +111,7 @@
   above
   above/align
   empty-scene
+  put-image
   place-image
   place-image/align
   rotate
@@ -114,9 +127,17 @@
   circle
   square
   rectangle
+  polygon
   regular-polygon
   ellipse
   triangle
+  triangle/sas
+  triangle/sss
+  triangle/ass
+  triangle/ssa
+  triangle/aas
+  triangle/asa
+  triangle/saa
   right-triangle
   isosceles-triangle
   star
@@ -134,12 +155,15 @@
   y-place?
   angle?
   side-count?
-
+  
   image?
+  image=?
   ;; Something funky is happening on the Racket side of things with regards
   ;; to step-count?  See:  http://bugs.racket-lang.org/query/?cmd=view&pr=12031
   ;; step-count?
   bitmap/url
+  video/url
+  play-sound
   name->color
   step-count?
   image-url
@@ -149,7 +173,7 @@
 
 
 
-  
+
 
 ;(define (my-step-count? x)
 ;  (and (integer? x)
@@ -161,9 +185,9 @@
 
 
 #;(define (name->color n)
-  (error 'name->color "not implemented yet"))
+    (error 'name->color "not implemented yet"))
 
 
 #;(provide (rename-out [my-step-count? step-count?]
-                     [bitmap/url image-url]
-                     [bitmap/url open-image-url]))
+                       [bitmap/url image-url]
+                       [bitmap/url open-image-url]))

--- a/whalesong/image/private/racket-impl.rkt
+++ b/whalesong/image/private/racket-impl.rkt
@@ -5,9 +5,11 @@
 (provide text
          text/font
          overlay
+         overlay/offset
          overlay/xy
          overlay/align
          underlay
+         underlay/offset
          underlay/xy
          underlay/align
          beside
@@ -101,9 +103,11 @@
   text
   text/font
   overlay
+  overlay/offset
   overlay/xy
   overlay/align
   underlay
+  underlay/offset
   underlay/xy
   underlay/align
   beside

--- a/whalesong/info.rkt
+++ b/whalesong/info.rkt
@@ -24,6 +24,7 @@
                              "sandbox"
                              "examples"
                              "experiments"
+                             "selfhost"
                              "simulator"
                              "tmp"))
 (define can-be-loaded-with 'all)

--- a/whalesong/js-assembler/assemble.rkt
+++ b/whalesong/js-assembler/assemble.rkt
@@ -65,6 +65,7 @@
     (display (assemble-current-interned-constant-closure-table) op)
     
     (display "M.params.currentErrorHandler = fail;\n" op)
+    (display "M.params.currentSuccessHandler = success;\n" op)
     (display  #<<EOF
 for (param in params) {
     if (Object.hasOwnProperty.call(params, param)) {
@@ -79,7 +80,6 @@ EOF
                     (assemble-label (make-Label (BasicBlock-name (first basic-blocks)))))]
           [else
            ;; Otherwise, we want to run under a trampolining context.
-           (display "M.c.push(new RT.CallFrame(function(M){ setTimeout(success, 0); },M.p));\n" op)
            (fprintf op "M.trampoline(~a, ~a); })"
                     (assemble-label (make-Label (BasicBlock-name (first basic-blocks))))
                     (cond [(eq? trampoline-option 'with-preemption)

--- a/whalesong/js-assembler/package.rkt
+++ b/whalesong/js-assembler/package.rkt
@@ -1,7 +1,6 @@
 #lang racket/base
 
 (require "assemble.rkt"
-         "quote-cdata.rkt"
          "../logger.rkt"
          "../make/make.rkt"
          "../make/make-structs.rkt"
@@ -43,7 +42,7 @@
 
 (provide package
 	 package-anonymous
-         package-standalone-xhtml
+         package-standalone-html
          get-inert-code
          get-standalone-code
          write-standalone-code
@@ -506,14 +505,13 @@ M.installedModules[~s] = function() {
 
 
 
-;; package-standalone-xhtml: X output-port -> void
-(define (package-standalone-xhtml source-code op)
+;; package-standalone-html: X output-port -> void
+(define (package-standalone-html source-code op)
   (display (get-header) op)
-  (display (quote-cdata
-            (string-append (get-runtime)
-                           (get-inert-code source-code
-                                           (lambda () (error 'package-standalone-xhtml)))
-                           invoke-main-module-code)) op)
+  (display (string-append (get-runtime)
+                          (get-inert-code source-code
+                                          (lambda () (error 'package-standalone-html)))
+                          invoke-main-module-code) op)
   (display *footer* op))
 
 
@@ -591,7 +589,7 @@ M.installedModules[~s] = function() {
     (format
   #<<EOF
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
+<html xml:lang="en">
   <head>
     <meta name="viewport" content="initial-scale=1.0, width=device-width, height=device-height, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no" />
     <meta charset="utf-8"/>

--- a/whalesong/js-assembler/runtime-src/runtime.js
+++ b/whalesong/js-assembler/runtime-src/runtime.js
@@ -297,6 +297,7 @@
 	    'currentOutputPort': new StandardOutputPort(),
 	    'currentErrorPort': new StandardErrorPort(),
             'currentInputPort': new StandardInputPort(),
+	    'currentSuccessHandler': function(MACHINE) {},
 	    'currentErrorHandler': function(MACHINE, exn) {
                 MACHINE.params.currentErrorDisplayer(
                     MACHINE,
@@ -752,6 +753,7 @@
 
         that.running = false;
         that.breakScheduled = false;
+        that.params.currentSuccessHandler(that);
         release();
         return;
 

--- a/whalesong/lang/for.rkt
+++ b/whalesong/lang/for.rkt
@@ -1,0 +1,2062 @@
+#lang whalesong
+(require (for-syntax racket))
+(provide for/fold for*/fold
+         for for*
+         for/list for*/list
+         for/vector for*/vector
+         for/lists for*/lists
+         for/and for*/and
+         for/or for*/or
+         for/first for*/first
+         for/last for*/last
+         for/sum for*/sum
+         for/product for*/product
+         for/hash for*/hash
+         for/hasheq for*/hasheq
+         for/hasheqv for*/hasheqv
+         
+         for/fold/derived for*/fold/derived
+         (for-syntax split-for-body)
+         (for-syntax (rename-out [expand-clause expand-for-clause]))
+         
+         (rename-out [*in-range in-range])
+         (rename-out [*in-naturals in-naturals])
+         (rename-out [*in-list in-list])
+         ;(rename *in-mlist in-mlist)
+         (rename-out [*in-vector in-vector])
+         (rename-out [*in-string in-string])
+         ;(rename *in-bytes in-bytes)
+         ;(rename *in-stream in-stream)
+         ;(rename *in-input-port-bytes in-input-port-bytes)
+         ;(rename *in-input-port-chars in-input-port-chars)
+         ;(rename *in-port in-port)
+         ;(rename *in-lines in-lines)
+         ;(rename *in-bytes-lines in-bytes-lines)
+         ;in-hash
+         ;in-hash-keys
+         ;in-hash-values
+         ;in-hash-pairs
+         ;in-directory
+         
+         in-sequences
+         in-cycle
+         in-parallel
+         in-values-sequence
+         in-values*-sequence
+         stop-before
+         stop-after
+         (rename-out [*in-producer in-producer])
+         (rename-out [*in-indexed in-indexed])
+         (rename-out [*in-value in-value])
+         
+         stream?
+         stream-empty?
+         stream-first
+         stream-rest
+         ;prop:stream
+         stream-ref 
+         ; stream-via-prop? ; only provided for racket/stream
+         ;sequence->stream
+         ;empty-stream 
+         ; make-do-stream
+         
+         sequence?
+         sequence-generate
+         sequence-generate*
+         ;prop:sequence
+         
+         define-sequence-syntax
+         make-do-sequence
+         :do-in
+         
+         define-in-vector-like
+         define-:vector-like-gen
+         (for-syntax make-in-vector-like
+                     for-clause-syntax-protect))
+
+;; ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; sequence transformers:
+
+(begin-for-syntax
+  (struct sequence-transformer (expr-transformer clause-transformer))
+  (define make-sequence-transformer sequence-transformer)
+  (define (sequence-transformer-ref st i)
+    (cond [(= i 0) (sequence-transformer-expr-transformer st)]
+          [(= i 1) (sequence-transformer-clause-transformer st)]
+          [else (error 'sequence-transformer-ref (~s "got: " i))]))
+  
+  #;(define-values (struct:sequence-transformer
+                  make-sequence-transformer
+                  sequence-transformer?
+                  sequence-transformer-ref
+                  sequence-transformer-set!)
+    (make-struct-type 'sequence-transformer ; name
+                      #f                    ; super-type
+                      2                     ; init-field-count
+                      0                     ; auto-field-count
+                      #f                    ; auto-v
+                      null                  ; props
+                      (current-inspector)   ; inspector
+                      0))                   ; proc-spec = 0 => acts as procedure
+  
+  (define (create-sequence-transformer proc1 proc2)
+    (unless (and (procedure? proc1)
+                 (or (procedure-arity-includes? proc1 1)
+                     (procedure-arity-includes? proc1 0)))
+      (raise-argument-error 'define-sequence-syntax
+                            "(or/c (procedure-arity-includes/c 0) (procedure-arity-includes/c 1))"
+                            0
+                            proc1 proc2))
+    (unless (and (procedure? proc2)
+                 (procedure-arity-includes? proc2 1))
+      (raise-argument-error 'define-sequence-syntax
+                            "(procedure-arity-includes/c 1)"
+                            1
+                            proc1 proc2))
+    (make-sequence-transformer
+     (if (procedure-arity-includes? proc1 0)
+         (lambda (stx)
+           (if (identifier? stx)
+               (proc1)
+               (datum->syntax stx
+                              ;; Use cons, not #`(#,op #,@args), to avoid replacing implicit #%app binding
+                              (cons (proc1) (cdr (syntax-e stx)))
+                              stx
+                              stx)))
+         proc1)
+     proc2))
+  
+  (define (arm-for-clause clause cert)
+    (define (map-cert s) (map cert (syntax->list s)))
+    (syntax-case clause (:do-in)
+      [[(id ...) (:do-in ([(outer-id ...) outer-expr] ...)
+                         outer-check
+                         ([loop-id loop-expr] ...)
+                         pos-guard
+                         ([(inner-id ...) inner-expr] ...)
+                         pre-guard
+                         post-guard
+                         (loop-arg ...))]
+       (with-syntax ([((outer-id ...) ...)
+                      (map map-cert
+                           (syntax->list #'((outer-id ...) ...)))]
+                     [(outer-expr ...) (map-cert #'(outer-expr ...))]
+                     [outer-check (cert #'outer-check)]
+                     [(loop-expr ...) (map-cert #'(loop-expr ...))]
+                     [pos-guard (cert #'pos-guard)]
+                     [((inner-id ...) ...)
+                      (map map-cert (syntax->list #'((inner-id ...) ...)))]
+                     [pre-guard (cert #'pre-guard)]
+                     [post-guard (cert #'post-guard)]
+                     [(loop-arg ...) (map-cert #'(loop-arg ...))])
+         #`[(id ...) (:do-in ([(outer-id ...) outer-expr] ...)
+                             outer-check
+                             ([loop-id loop-expr] ...)
+                             pos-guard
+                             ([(inner-id ...) inner-expr] ...)
+                             pre-guard
+                             post-guard
+                             (loop-arg ...))])]
+      [[(id ...) rhs]
+       #`[(id ...) #,(cert #'rhs)]]
+      [_
+       ;; ill-formed clause...
+       clause]))
+  
+  (define orig-insp (variable-reference->module-declaration-inspector
+                     (#%variable-reference)))
+  
+  (define (for-clause-syntax-protect clause)
+    ;; This is slightly painful. The expansion into `:do-in' involves a lot
+    ;; of pieces that are no treated as sub-expressions. We have to push the
+    ;; taints down to all the relevant identifiers and expressions:
+    (arm-for-clause clause syntax-arm))
+  
+  (define sequence-specialization-logger
+    (make-logger 'sequence-specialization (current-logger)))
+  
+  (define (expand-clause orig-stx clause)
+    (define (unpack stx)
+      (syntax-case stx ()
+        [[ids rhs] ; remove dye pack on `rhs' in case it's `(form . rest)'
+         #`[ids #,(syntax-disarm #'rhs orig-insp)]]
+        [_ stx]))
+    (define (make-rearm)
+      (syntax-case clause ()
+        [(_ rhs)
+         (lambda (stx)
+           (syntax-rearm stx #'rhs))]))
+    (let eloop ([use-transformer? #t])
+      (define unpacked-clause (unpack clause))
+      (syntax-case unpacked-clause (values in-parallel stop-before stop-after :do-in)
+        [[(id ...) rhs]
+         (let ([ids (syntax->list #'(id ...))])
+           (for-each (lambda (id)
+                       (unless (identifier? id)
+                         (raise-syntax-error
+                          #f
+                          "expected an identifier to bind"
+                          orig-stx
+                          id)))
+                     ids)
+           (let ([dup (check-duplicate-identifier (syntax->list #'(id ...)))])
+             (when dup
+               (raise-syntax-error #f
+                                   "duplicate identifier as sequence binding" orig-stx dup)))
+           #f)
+         'just-checking]
+        [[(id ...) (form . rest)]
+         (and use-transformer?
+              (identifier? #'form)
+              (sequence-transformer? (syntax-local-value #'form (lambda () #f))))
+         (let ([m (syntax-local-value #'form)])
+           (let ([xformer (sequence-transformer-ref m 1)]
+                 [introducer (make-syntax-introducer)])
+             (let ([xformed (xformer (introducer (syntax-local-introduce unpacked-clause)))])
+               (if xformed
+                   (let ([r (expand-clause orig-stx
+                                           (arm-for-clause
+                                            (syntax-local-introduce (introducer xformed))
+                                            (make-rearm)))])
+                     (syntax-property r
+                                      'disappeared-use
+                                      (cons (syntax-local-introduce #'form)
+                                            (or (syntax-property r 'disappeared-use)
+                                                null))))
+                   (eloop #f)))))]
+        [[(id ...) (:do-in . body)]
+         (syntax-case #'body ()
+           [(([(outer-id ...) outer-rhs] ...)
+             outer-check
+             ([loop-id loop-expr] ...)
+             pos-guard
+             ([(inner-id ...) inner-rhs] ...)
+             pre-guard
+             post-guard
+             (loop-arg ...)) #'body]
+           [else (raise-syntax-error #f "bad :do-in clause" orig-stx clause)])]
+        [[(id) (values rhs)]
+         (expand-clause orig-stx #'[(id) rhs])]
+        [[(id ...) (in-parallel rhs ...)]
+         (and (= (length (syntax->list #'(id ...)))
+                 (length (syntax->list #'(rhs ...)))))
+         ;; flatten in-parallel iterations:
+         (with-syntax ([(((outer-binding ...)
+                          outer-check
+                          (loop-binding ...)
+                          pos-guard
+                          (inner-binding ...)
+                          pre-guard
+                          post-guard
+                          (loop-arg ...)) ...)
+                        (map (lambda (id rhs)
+                               (expand-clause orig-stx #`[(#,id) #,rhs]))
+                             (syntax->list #'(id ...))
+                             (syntax->list #'(rhs ...)))])
+           #`((outer-binding ... ...)
+              (and outer-check ...)
+              (loop-binding ... ...)
+              (and pos-guard ...)
+              (inner-binding ... ...)
+              (and pre-guard ...)
+              (and post-guard ...)
+              (loop-arg ... ...)))]
+        [[(id ...) (stop-before gen-expr pred)]
+         (with-syntax ([((outer-binding ...)
+                         outer-check
+                         (loop-binding ...)
+                         pos-guard
+                         (inner-binding ...)
+                         pre-guard
+                         post-guard
+                         (loop-arg ...))
+                        (expand-clause orig-stx #`[(id ...) gen-expr])])
+           #`((outer-binding ...)
+              outer-check
+              (loop-binding ...)
+              pos-guard
+              (inner-binding ...)
+              (and pre-guard (not (pred id ...)))
+              post-guard
+              (loop-arg ...)))]
+        [[(id ...) (stop-after gen-expr pred)]
+         (with-syntax ([((outer-binding ...)
+                         outer-check
+                         (loop-binding ...)
+                         pos-guard
+                         (inner-binding ...)
+                         pre-guard
+                         post-guard
+                         (loop-arg ...))
+                        (expand-clause orig-stx #`[(id ...) gen-expr])])
+           #`((outer-binding ...)
+              outer-check
+              (loop-binding ...)
+              pos-guard
+              (inner-binding ...)
+              pre-guard
+              (and post-guard (not (pred id ...)))
+              (loop-arg ...)))]
+        [[(id ...) rhs]
+         #t
+         (let ([introducer (make-syntax-introducer)])
+           ;; log non-specialized clauses, for performance tuning
+           (when (log-level? sequence-specialization-logger 'debug)
+             (log-message sequence-specialization-logger
+                          'debug
+                          (format "non-specialized for clause: ~a:~a:~a"
+                                  (syntax-source #'rhs)
+                                  (syntax-line   #'rhs)
+                                  (syntax-column #'rhs))
+                          #'rhs))
+           (with-syntax ([[(id ...) rhs] (introducer (syntax-local-introduce clause))])
+             (arm-for-clause
+              (syntax-local-introduce
+               (introducer
+                #`(([(pos->vals pos-next init pos-cont? val-cont? all-cont?)
+                     #,(syntax-property
+                        (syntax/loc #'rhs (make-sequence '(id ...) rhs))
+                        'feature-profile:generic-sequence #t)])
+                   (void)
+                   ([pos init])
+                   #,(syntax-property
+                      (syntax/loc #'rhs (if pos-cont? (pos-cont? pos) #t))
+                      'feature-profile:generic-sequence #t)
+                   ([(id ...) #,(syntax-property
+                                 (syntax/loc #'rhs (pos->vals pos))
+                                 'feature-profile:generic-sequence #t)])
+                   #,(syntax-property
+                      (syntax/loc #'rhs (if val-cont? (val-cont? id ...) #t))
+                      'feature-profile:generic-sequence #t)
+                   #,(syntax-property
+                      (syntax/loc #'rhs (if all-cont? (all-cont? pos id ...) #t))
+                      'feature-profile:generic-sequence #t)
+                   #,(syntax-property
+                      (syntax/loc #'rhs ((pos-next pos)))
+                      'feature-profile:generic-sequence #t))))
+              (make-rearm))))]
+        [_
+         (raise-syntax-error #f
+                             "bad sequence binding clause" orig-stx clause)]))))
+
+(define-syntax (:do-in stx)
+  (raise-syntax-error #f
+                      "illegal outside of a loop or comprehension binding" stx))
+
+;; ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;  streams & sequences
+
+;; structure type for generic sequences:
+(define-values (struct:do-sequence
+                make-do-sequence
+                do-sequence?
+                do-sequence-ref
+                do-sequence-set!)
+  (make-struct-type 'sequence #f 1 0 #f))
+
+;; property for generic streams
+(define stream-ref list-ref) ; xxx
+#;(define-values (prop:stream stream-via-prop? stream-ref)
+  (make-struct-type-property
+   'stream
+   (lambda (v si)
+     (unless (and (vector? v)
+                  (= 3 (vector-length v))
+                  (procedure? (vector-ref v 0))
+                  (procedure-arity-includes? (vector-ref v 0) 1)
+                  (procedure? (vector-ref v 1))
+                  (procedure-arity-includes? (vector-ref v 1) 1)
+                  (procedure? (vector-ref v 2))
+                  (procedure-arity-includes? (vector-ref v 2) 1))
+       (raise-argument-error 'guard-for-prop:stream
+                             (string-append
+                              "(vector/c (procedure-arity-includes/c 1)\n"
+                              "          (procedure-arity-includes/c 1)\n"
+                              "          (procedure-arity-includes/c 1))")
+                             v))
+     (vector->immutable-vector v))))
+
+;; new-style sequence property, where the property value is a procedure
+;; to get the sequence-driving value and procedures;
+;; this property is not currently exported
+#;(define-values (prop:gen-sequence sequence-via-prop? sequence-ref)
+  (make-struct-type-property
+   'sequence
+   (lambda (v si)
+     (unless (and (procedure? v)
+                  (procedure-arity-includes? v 1))
+       (raise-argument-error 'guard-for-prop:sequence
+                             "(procedure-arity-includes/c 1)"
+                             v))
+     v)))
+
+;; exported sequence property, where the property value
+;; is a procedure to get a sequence
+#;(define-values (prop:sequence :sequence? :sequence-ref)
+  (make-struct-type-property
+   'sequence
+   (lambda (v sinfo)
+     (unless (and (procedure? v) (procedure-arity-includes? v 1))
+       (raise-argument-error 'sequence-property-guard "(procedure-arity-includes/c 1)" v))
+     (lambda (self)
+       (let ([s (v self)])
+         (unless (sequence? s)
+           (raise-mismatch-error
+            'sequence-generate
+            "procedure (value of prop:sequence) produced a non-sequence: "
+            s))
+         s)))))
+
+(define-syntax define-sequence-syntax
+  (syntax-rules ()
+    [(_ id expr-transformer-expr clause-transformer-expr)
+     (define-syntax id
+       (create-sequence-transformer expr-transformer-expr
+                                    clause-transformer-expr))]))
+
+(define (stream? v)
+  (or (list? v)
+      #; (stream-via-prop? v)  ; xxx
+      ))
+
+(define (unsafe-stream-not-empty? v)
+  (if (null? v)
+      #f
+      (or (pair? v)
+          (not ((vector-ref (stream-ref v) 0) v)))))
+
+(define (stream-empty? v)
+  (or (null? v)
+      (if (stream? v)
+          (if (pair? v)
+              #f
+              ((vector-ref (stream-ref v) 0) v))
+          (error 'stream-empty?
+                                "stream?"
+                                v))))
+
+(define (unsafe-stream-first v)
+  (cond [(pair? v) (car v)]
+        [else ((vector-ref (stream-ref v) 1) v)]))
+
+(define (stream-first v)
+  (if (and (stream? v)
+           (not (stream-empty? v)))
+      (unsafe-stream-first v)
+      (error 'stream-first
+                            "(and/c stream? (not/c stream-empty?))"
+                            v)))
+
+(define (unsafe-stream-rest v)
+  (cond [(pair? v) (cdr v)]
+        [else (let ([r ((vector-ref (stream-ref v) 2) v)])
+                (unless (stream? r)
+                  (raise-mismatch-error 'stream-rest-guard
+                                        "result is not a stream: "
+                                        r))
+                r)]))
+
+(define (stream-rest v)
+  (if (and (stream? v)
+           (not (stream-empty? v)))
+      (unsafe-stream-rest v)
+      (error 'stream-rest
+                            "(and/c stream? (not/c stream-empty?))"
+                            v)))
+
+(define (sequence? v)
+  (or (exact-nonnegative-integer? v)
+      (do-sequence? v)
+      ; (sequence-via-prop? v)
+      (stream? v)
+      ; (mpair? v)
+      (vector? v)
+      ;(flvector? v)
+      ;(fxvector? v)
+      (string? v)
+      ;(bytes? v)
+      ;(input-port? v)
+      (range? v) ; XXX
+      (hash? v)
+      ; (and (:sequence? v) (not (struct-type? v))
+           ))
+
+(define (make-sequence who v)
+  (cond
+    [(exact-nonnegative-integer? v) (:integer-gen v)]
+    [(do-sequence? v) ((do-sequence-ref v 0))]
+    ; [(mpair? v) (:mlist-gen v)]
+    [(list? v) (:list-gen v)]
+    [(vector? v) (:vector-gen v 0 (vector-length v) 1)]
+    ;[(flvector? v) (:flvector-gen v 0 (flvector-length v) 1)]
+    ;[(fxvector? v) (:fxvector-gen v 0 (fxvector-length v) 1)]
+    [(string? v) (:string-gen v 0 (string-length v) 1)]
+    ;[(bytes? v) (:bytes-gen v 0 (bytes-length v) 1)]
+    ;[(input-port? v) (:input-port-gen v)]
+    ;[(hash? v) (:hash-key+val-gen v)]
+    ;[(sequence-via-prop? v) ((sequence-ref v) v)]
+    ;[(:sequence? v) (make-sequence who ((:sequence-ref v) v))]
+    [(stream? v) (:stream-gen v)]
+    [(range? v)  (:range-gen v)]
+    [else (error 'make-sequence
+                 (format "for: expected a sequence for ~a, got something else: ~v"
+                    (if (= 1 (length who))
+                        (car who)
+                        who)
+                    v))
+          #;(raise
+           (exn:fail:contract
+            (format "for: expected a sequence for ~a, got something else: ~v"
+                    (if (= 1 (length who))
+                        (car who)
+                        who)
+                    v)
+            (current-continuation-marks)))]))
+
+
+; (make-range n add1 #f)
+(struct range (start inc cont?))
+(define make-range range)
+#;(define-values (struct:range
+                make-range
+                range?
+                range-ref
+                range-set!)
+  (make-struct-type 'stream #f 3 0 #f
+                    (list (cons prop:stream
+                                (vector
+                                 (lambda (v)
+                                   (let ([cont? (range-ref v 2)])
+                                     (and cont?
+                                          (not (cont? (range-ref v 0))))))
+                                 (lambda (v) (range-ref v 0))
+                                 (lambda (v) (make-range
+                                              ((range-ref v 1) (range-ref v 0))
+                                              (range-ref v 1)
+                                              (range-ref v 2)))))
+                          (cons prop:gen-sequence
+                                (lambda (v)
+                                  (values
+                                   values
+                                   (range-ref v 1)
+                                   (range-ref v 0)
+                                   (range-ref v 2)
+                                   #f
+                                   #f))))))
+
+(define in-range
+  (case-lambda
+    [(b) (in-range 0 b 1)]
+    [(a b) (in-range a b 1)]
+    [(a b step)
+     (unless (real? a) (error 'in-range "real?" a))
+     (unless (real? b) (error 'in-range "real?" b))
+     (unless (real? step) (error 'in-range "real?" step))
+     (let* ([cont? (if (step . >= . 0)
+                       (lambda (x) (< x b))
+                       (lambda (x) (> x b)))]
+            [inc (lambda (x) (+ x step))])
+       ;(:range-gen a b step)
+       (make-range a inc cont?))]))
+
+(define (:range-gen a b step)
+  (values values add1 a (lambda (i) (i . < . b)) #f #f))
+
+(define (:integer-gen v)
+  (values values add1 0 (lambda (i) (i . < . v)) #f #f))
+
+(define in-naturals
+  (case-lambda
+    [() (in-naturals 0)]
+    [(n)
+     (unless (and (integer? n)
+                  (exact? n)
+                  (n . >= . 0))
+       (error 'in-naturals
+                             "exact-nonnegative-integer?"
+                             n))
+     (make-range n add1 #f)]))
+
+;; [Whalesong] Implement list-stream using standard structs
+(struct list-stream (empty? first rest))
+(define make-list-stream list-stream)
+(define (list-stream-ref ls i)
+  (cond [(= i 0) (list-stream-empty? ls)]
+        [(= i 1) (list-stream-first ls)]
+        [(= i 2) (list-stream-rest ls)]
+        [else (error 'list-stream-ref)]))
+
+#;(define-values (struct:list-stream
+                make-list-stream
+                list-stream?
+                list-stream-ref
+                list-stream-set!)
+  (make-struct-type 'stream #f 1 0 #f
+                    (list (cons prop:stream
+                                (vector
+                                 (lambda (v) (not (pair? (list-stream-ref v 0))))
+                                 (lambda (v) (car (list-stream-ref v 0)))
+                                 (lambda (v) (make-list-stream (cdr (list-stream-ref v 0))))))
+                          (cons prop:gen-sequence
+                                (lambda (v)
+                                  (values
+                                   car
+                                   cdr
+                                   (list-stream-ref v 0)
+                                   pair?
+                                   #f
+                                   #f))))))
+
+
+(define (in-list l)
+  (unless (list? l) (error 'in-list "list?" l))
+  (make-list-stream l))
+
+(define (:list-gen l)
+  (values car cdr l pair? #f #f))
+
+#;(define (in-mlist l)
+  (make-do-sequence (lambda () (:mlist-gen l))))
+
+#;(define (:mlist-gen l)
+  (values mcar mcdr l mpair? #f #f))
+
+#;(define (in-input-port-bytes p)
+  (unless (input-port? p)
+    (raise-argument-error 'in-input-port-bytes "input-port?" p))
+  (make-do-sequence (lambda () (:input-port-gen p))))
+
+#;(define (:input-port-gen p)
+  (values read-byte values p #f
+          (lambda (x) (not (eof-object? x)))
+          #f))
+
+#;(define (in-input-port-chars p)
+  (unless (input-port? p)
+    (raise-argument-error 'in-input-port-chars "input-port?" p))
+  (in-producer (lambda () (read-char p)) eof))
+
+#;(define (check-in-port r p)
+  (unless (and (procedure? r) (procedure-arity-includes? r 1))
+    (raise-argument-error 'in-port "(procedure-arity-includes/c 1)" r))
+  (unless (input-port? p) (raise-argument-error 'in-port "input-port?" p)))
+
+#;(define in-port
+  (case-lambda
+    [()  (in-port read (current-input-port))]
+    [(r) (in-port r (current-input-port))]
+    [(r p)
+     (check-in-port r p)
+     (in-producer (lambda () (r p)) eof)]))
+
+#;(define (check-in-lines p mode)
+  (unless (input-port? p) (raise-argument-error 'in-lines "input-port?" p))
+  (unless (memq mode '(linefeed return return-linefeed any any-one))
+    (raise-argument-error
+     'in-lines
+     "(or/c 'linefeed 'return 'return-linefeed 'any 'any-one)"
+     mode)))
+
+#;(define in-lines
+  (case-lambda
+    [()  (in-lines (current-input-port) 'any)]
+    [(p) (in-lines p 'any)]
+    [(p mode)
+     (check-in-lines p mode)
+     (in-producer (lambda () (read-line p mode)) eof)]))
+
+#;(define (check-in-bytes-lines p mode)
+  (unless (input-port? p) (raise-argument-error 'in-bytes-lines "input-port" p))
+  (unless (memq mode '(linefeed return return-linefeed any any-one))
+    (raise-argument-error
+     'in-bytes-lines
+     "(or/c 'linefeed 'return 'return-linefeed 'any 'any-one)"
+     mode)))
+
+#;(define in-bytes-lines
+  (case-lambda
+    [()  (in-bytes-lines (current-input-port) 'any)]
+    [(p) (in-bytes-lines p 'any)]
+    [(p mode)
+     (check-in-bytes-lines p mode)
+     (in-producer (lambda () (read-bytes-line p mode)) eof)]))
+
+#;(define (in-hash ht)
+  (unless (hash? ht) (error 'in-hash "hash?" ht))
+  (make-do-sequence (lambda () (:hash-key+val-gen ht))))
+
+#;(define (:hash-key+val-gen ht)
+  (:hash-gen ht (lambda (ht pos)
+                  (values (hash-iterate-key ht pos)
+                          (hash-iterate-value ht pos)))))
+
+#;(define (in-hash-keys ht)
+  (unless (hash? ht) (raise-argument-error 'in-hash-keys "hash?" ht))
+  (make-do-sequence (lambda () (:hash-gen ht hash-iterate-key))))
+#;(define (in-hash-values ht)
+  (unless (hash? ht) (raise-argument-error 'in-hash-values "hash?" ht))
+  (make-do-sequence (lambda () (:hash-gen ht hash-iterate-value))))
+#;(define (in-hash-pairs ht)
+  (unless (hash? ht) (raise-argument-error 'in-hash-values "hash?" ht))
+  (make-do-sequence (lambda ()
+                      (:hash-gen ht (lambda (ht pos)
+                                      (cons (hash-iterate-key ht pos)
+                                            (hash-iterate-value ht pos)))))))
+
+#;(define (:hash-gen ht sel)
+  (values (lambda (pos) (sel ht pos))
+          (lambda (pos) (hash-iterate-next ht pos))
+          (hash-iterate-first ht)
+          (lambda (pos) pos) ; #f position means stop
+          #f
+          #f))
+
+(define (in-stream l)
+  (unless (stream? l) (error 'in-stream "stream?" l))
+  (make-do-sequence (lambda () (:stream-gen l))))
+
+(define (:stream-gen l)
+  (values unsafe-stream-first unsafe-stream-rest l unsafe-stream-not-empty? #f #f))
+
+;; Vector-like sequences --------------------------------------------------
+
+;; (: check-ranges (Symbol Natural Integer Integer Natural -> Void))
+;;
+;; As no object can have more slots than can be indexed by
+;; the largest fixnum, after running these checks start,
+;; stop, and step are guaranteed to be fixnums.
+(define raise-range-error error)
+(define raise-argument-error error)
+(define raise-arguments-error error)
+(define (check-ranges who vec start stop step len)
+  (unless (and (exact-nonnegative-integer? start) (<= start len))
+    (raise-range-error who "vector" "starting " start vec 0 len))
+  (unless (and (exact-integer? stop) (<= -1 stop) (<= stop len))
+    (raise-range-error who "vector" "stopping " stop vec -1 len))
+  (unless (and (exact-integer? step) (not (zero? step)))
+    (raise-argument-error who "(and/c exact-integer? (not/c zero?))" step))
+  (when (and (< start stop) (< step 0))
+    (raise-arguments-error who 
+                           "starting index less then stopping index, but given a negative step"
+                           "starting index" start
+                           "stopping index" stop
+                           "step" step))
+  (when (and (< stop start) (> step 0))
+    (raise-arguments-error who 
+                           "starting index more then stopping index, but given a positive step"
+                           "starting index" start
+                           "stopping index" stop
+                           "step" step)))
+
+;; (: normalise-inputs (A) (Symbol String (Any -> Boolean) (A -> Natural) Any Any Any Any -> (values Fixnum Fixnum Fixnum)))
+;;
+;; Checks all inputs are valid for an in-vector sequence,
+;; and if so returns the vector, start, stop, and
+;; step. Start, stop, and step are guaranteed to be Fixnum
+(define (normalise-inputs who type-name vector? vector-length
+                          vec start stop step)
+  (unless (vector? vec)
+    (raise-argument-error who type-name vec))
+  (let* ([len (vector-length vec)]
+         [stop* (if stop stop len)])
+    (check-ranges who vec start stop* step len)
+    (values vec start stop* step)))
+
+(define-syntax define-in-vector-like
+  (syntax-rules ()
+    [(define-in-vector-like in-vector-name
+       type-name-str vector?-id vector-length-id :vector-gen-id)
+     (define in-vector-name
+       (case-lambda
+         [(v) (in-vector-name v 0 #f 1)]
+         [(v start) (in-vector-name v start #f 1)]
+         [(v start stop) (in-vector-name v start stop 1)]
+         [(v start stop step)
+          (let-values (([v start stop step]
+                        (normalise-inputs 'in-vector-name type-name-str vector?-id vector-length-id
+                                          v start stop step)))
+            (make-do-sequence (lambda () (:vector-gen-id v start stop step))))]))]))
+
+(define-syntax define-:vector-like-gen
+  (syntax-rules ()
+    [(define-:vector-like-gen :vector-like-name vector-ref-id)
+     (define (:vector-like-name v start stop step)
+       (values
+        ;; pos->element
+        (lambda (i) (vector-ref-id v i))
+        ;; next-pos
+        ;; Minor optimisation.  I assume add1 is faster than \x.x+1
+        (if (= step 1) add1 (lambda (i) (+ i step)))
+        ;; initial pos
+        start
+        ;; continue?
+        (if (> step 0)
+            (lambda (i) (< i stop))
+            (lambda (i) (> i stop)))
+        #f
+        #f))]))
+
+(define-for-syntax (make-in-vector-like in-vector-name
+                                        type-name-str
+                                        vector?-id
+                                        unsafe-vector-length-id
+                                        in-vector-id
+                                        unsafe-vector-ref-id)
+  (define (in-vector-like stx)
+    (with-syntax ([in-vector-name in-vector-name]
+                  [type-name type-name-str]
+                  [vector? vector?-id]
+                  [in-vector in-vector-id]
+                  [unsafe-vector-length unsafe-vector-length-id]
+                  [unsafe-vector-ref unsafe-vector-ref-id])
+      (syntax-case stx ()
+        ;; Fast case
+        [[(id) (_ vec-expr)]
+         (for-clause-syntax-protect
+          #'[(id)
+             (:do-in
+              ;;outer bindings
+              ([(vec len) (let ([vec vec-expr])
+                            (unless (vector? vec)
+                              (in-vector vec))
+                            (values vec (unsafe-vector-length vec)))])
+              ;; outer check
+              #f
+              ;; loop bindings
+              ([pos 0])
+              ;; pos check
+              (pos . < . len)
+              ;; inner bindings
+              ([(id) (unsafe-vector-ref vec pos)])
+              ;; pre guard
+              #t
+              ;; post guard
+              #t
+              ;; loop args
+              ((+ 1 pos)))])]
+        ;; General case
+        [((id) (_ vec-expr start))
+         (in-vector-like (syntax ((id) (_ vec-expr start #f 1))))]
+        [((id) (_ vec-expr start stop))
+         (in-vector-like (syntax ((id) (_ vec-expr start stop 1))))]
+        [((id) (_ vec-expr start stop step))
+         (let ([all-fx? (memq (syntax-e #'step) '(1 -1))])
+           (for-clause-syntax-protect
+            #`[(id)
+               (:do-in
+                ;; Outer bindings
+                ;; start*, stop*, and step* are guaranteed to be exact integers
+                ([(v* start* stop* step*)
+                  (normalise-inputs (quote in-vector-name) type-name
+                                    ;; reverse-eta triggers JIT inlining of
+                                    ;; primitives, which is good for futures:
+                                    (lambda (x) (vector? x))
+                                    (lambda (x) (unsafe-vector-length x))
+                                    vec-expr start stop step)])
+                ;; Outer check is done by normalise-inputs
+                #t
+                ;; Loop bindings
+                ([idx start*])
+                ;; Pos guard
+                #,(cond
+                    [(not (number? (syntax-e #'step)))
+                     #`(if (step* . >= . 0) (< idx stop*) (> idx stop*))]
+                    [((syntax-e #'step) . >= . 0)
+                     (if all-fx?
+                         #'(< idx stop*)
+                         #'(< idx stop*))]
+                    [else
+                     (if all-fx?
+                         #'(> idx stop*)
+                         #'(> idx stop*))])
+                ;; Inner bindings
+                ([(id) (unsafe-vector-ref v* idx)])
+                ;; Pre guard
+                #t
+                ;; Post guard
+                #t
+                ;; Loop args
+                ((#,(if all-fx? #'+ #'+) idx step)))]))]
+        [_ #f])))
+  in-vector-like)
+
+(define-:vector-like-gen :vector-gen vector-ref)
+
+(define-in-vector-like in-vector
+  "vector" vector? vector-length :vector-gen)
+
+(define-sequence-syntax *in-vector
+  (lambda () #'in-vector)
+  (make-in-vector-like 'in-vector
+                       "vector"
+                       #'vector?
+                       #'vector-length
+                       #'in-vector
+                       #'vector-ref))
+
+(define-:vector-like-gen :string-gen string-ref)
+
+(define-in-vector-like in-string
+  "string" string? string-length :string-gen)
+
+(define-sequence-syntax *in-string
+  (lambda () #'in-string)
+  (make-in-vector-like 'in-string
+                       "string"
+                       #'string?
+                       #'string-length
+                       #'in-string
+                       #'string-ref))
+
+; (define-:vector-like-gen :bytes-gen bytes-ref)
+
+#;(define-in-vector-like in-bytes
+  "bytes" bytes? bytes-length :bytes-gen)
+
+#;(define-sequence-syntax *in-bytes
+  (lambda () #'in-bytes)
+  (make-in-vector-like 'in-bytes
+                       "bytes"
+                       #'bytes?
+                       #'bytes-length
+                       #'in-bytes
+                       #'bytes-ref))
+
+;(define-:vector-like-gen :flvector-gen unsafe-flvector-ref)
+;; in-flvector is defined in racket/flonum
+;(define-:vector-like-gen :fxvector-gen unsafe-fxvector-ref)
+;; in-fxvector is defined in racket/fixnum
+
+;; ------------------------------------------------------------------------
+
+(define (stop-before g pred)
+  (unless (sequence? g) (raise-argument-error 'stop-before "sequence?" g))
+  (unless (and (procedure? pred)
+               (procedure-arity-includes? pred 1))
+    (raise-argument-error 'stop-before "(procedure-arity-includes/c 1)" pred))
+  (make-do-sequence (lambda ()
+                      (let-values ([(pos->val pos-next init pos-cont? pre-cont? post-cont?)
+                                    (make-sequence #f g)])
+                        (values pos->val
+                                pos-next
+                                init
+                                pos-cont?
+                                (case-lambda
+                                  [(val) (and (if pre-cont? (pre-cont? val) #t)
+                                              (not (pred val)))]
+                                  [vals (and (if pre-cont? (apply pre-cont? vals) #t)
+                                             (not (apply pred vals)))])
+                                post-cont?)))))
+
+(define (stop-after g pred)
+  (unless (sequence? g) (raise-argument-error 'stop-after "sequence?" g))
+  (unless (and (procedure? pred)
+               (procedure-arity-includes? pred 1))
+    (raise-argument-error 'stop-after "(procedure-arity-includes/c 1)" pred))
+  (make-do-sequence (lambda ()
+                      (let-values ([(pos->val pos-next init pos-cont? pre-cont? post-cont?)
+                                    (make-sequence #f g)])
+                        (values pos->val
+                                pos-next
+                                init
+                                pos-cont?
+                                pre-cont?
+                                (case-lambda
+                                  [(pos val) (and (if post-cont? (post-cont? pos val) #t)
+                                                  (not (pred val)))]
+                                  [(pos . vals) (and (if post-cont? (apply post-cont? pos vals) #t)
+                                                     (not (apply pred vals)))]))))))
+
+(define (in-indexed g)
+  (unless (sequence? g) (raise-argument-error 'in-indexed "sequence?" g))
+  (make-do-sequence (lambda ()
+                      (let-values ([(pos->val pos-next init pos-cont? pre-cont? post-cont?)
+                                    (make-sequence #f g)])
+                        (values (lambda (pos) (values (pos->val (car pos)) (cdr pos)))
+                                (lambda (pos) (cons (pos-next (car pos)) (add1 (cdr pos))))
+                                (cons init 0)
+                                (and pos-cont?
+                                     (lambda (pos) (pos-cont? (car pos))))
+                                (and pre-cont?
+                                     (lambda (val idx) (pre-cont? val)))
+                                (and post-cont?
+                                     (lambda (pos val idx) (post-cont? pos val))))))))
+
+(define (in-value v)
+  (make-do-sequence (lambda ()
+                      (values (lambda (pos) v)
+                              (lambda (pos) #f)
+                              #t
+                              (lambda (pos) pos)
+                              void
+                              void))))
+
+(define (in-values-sequence g)
+  (unless (sequence? g) (raise-argument-error 'in-values-sequence "sequence?" g))
+  (make-do-sequence (lambda ()
+                      (let-values ([(pos->val pos-next init pos-cont? pre-cont? post-cont?)
+                                    (make-sequence #f g)])
+                        (values (lambda (pos) (call-with-values (lambda () (pos->val pos))
+                                                                list))
+                                pos-next
+                                init
+                                pos-cont?
+                                (and pre-cont?
+                                     (lambda (vals) (apply pre-cont? vals)))
+                                (and post-cont?
+                                     (lambda (pos vals) (apply post-cont? pos vals))))))))
+
+(define (in-values*-sequence g)
+  (unless (sequence? g) (raise-argument-error 'in-values-sequence "sequence?" g))
+  (make-do-sequence (lambda ()
+                      (let-values ([(pos->val pos-next init pos-cont? pre-cont? post-cont?)
+                                    (make-sequence #f g)])
+                        (values (lambda (pos) (call-with-values (lambda () (pos->val pos))
+                                                                (case-lambda
+                                                                  [(v) (if (list? v) (list v) v)]
+                                                                  [vs vs])))
+                                pos-next
+                                init
+                                pos-cont?
+                                (and pre-cont?
+                                     (lambda (vals)
+                                       (if (list? vals)
+                                           (apply pre-cont? vals)
+                                           (pre-cont? vals))))
+                                (and post-cont?
+                                     (lambda (pos vals)
+                                       (if (list? vals)
+                                           (apply post-cont? pos vals)
+                                           (post-cont? pos vals)))))))))
+
+;; ----------------------------------------
+
+(define (append-sequences sequences cyclic?)
+  (define (seqs->m+g+r seqs)
+    (if (pair? seqs)
+        (let-values ([(more? get) (sequence-generate (car seqs))]
+                     [(seqs) (cdr seqs)])
+          (if (more?) (list* more? get seqs) (seqs->m+g+r seqs)))
+        (and cyclic? (seqs->m+g+r sequences))))
+  (make-do-sequence
+   (lambda ()
+     ;; place is (cur-more? cur-get rest-seqs ...) or #f
+     (values (lambda (m+g+r) ((cadr m+g+r)))
+             (lambda (m+g+r)
+               (if (and (pair? m+g+r) (not ((car m+g+r))))
+                   (seqs->m+g+r (cddr m+g+r))
+                   m+g+r))
+             (seqs->m+g+r sequences)
+             values
+             void
+             void))))
+
+(define (check-sequences who sequences)
+  (for-each (lambda (g)
+              (unless (sequence? g) (raise-argument-error who "sequence?" g)))
+            sequences))
+
+(define (in-sequences . sequences)
+  (check-sequences 'in-sequences sequences)
+  (if (and (pair? sequences) (null? (cdr sequences)))
+      (car sequences)
+      (append-sequences sequences #f)))
+(define (in-cycle . sequences)
+  (check-sequences 'in-cycle sequences)
+  (append-sequences sequences #t))
+
+(define (in-parallel . sequences)
+  (check-sequences 'in-parallel sequences)
+  (if (= 1 (length sequences))
+      (car sequences)
+      (make-do-sequence
+       (lambda ()
+         (let-values ([(pos->vals pos-nexts inits pos-cont?s pre-cont?s post-cont?s)
+                       (for/lists (p->v p-s i ps? pr? po?) ([g sequences])
+                         (make-sequence #f g))])
+           (values
+            (lambda (poses) (apply values (map (lambda (pos->val pos) (pos->val pos))
+                                               pos->vals
+                                               poses)))
+            (lambda (poses) (map (lambda (pos-next pos) (pos-next pos))
+                                 pos-nexts
+                                 poses))
+            inits
+            (and (ormap values pos-cont?s)
+                 (lambda (poses) (andmap (lambda (pos-cont? pos)
+                                           (if pos-cont? (pos-cont? pos) #t))
+                                         pos-cont?s
+                                         poses)))
+            (and (ormap values pre-cont?s)
+                 (lambda vals (andmap (lambda (pre-cont? val)
+                                        (if pre-cont? (pre-cont? val) #t))
+                                      pre-cont?s
+                                      vals)))
+            (and (ormap values post-cont?s)
+                 (lambda (poses . vals) (andmap (lambda (post-cont? pos val)
+                                                  (if post-cont? (post-cont? pos val) #t))
+                                                post-cont?s
+                                                poses
+                                                vals)))))))))
+
+(define in-producer
+  (case-lambda
+    [(producer)
+     ;; simple stop-less version
+     (make-do-sequence (lambda () (values (λ _ (producer)) void (void) #f #f #f)))]
+    [(producer stop . more)
+     (define produce!
+       (if (null? more)
+           (lambda (_) (producer))
+           (lambda (_) (apply producer more))))
+     (define stop?
+       (cond [(not (procedure? stop))
+              (lambda (x) (not (eq? x stop)))]
+             [(equal? 1 (procedure-arity stop))
+              (lambda (x) (not (stop x)))]
+             [else
+              (lambda xs (not (apply stop xs)))]))
+     (make-do-sequence
+      (lambda ()
+        (values produce! void (void) #f stop? #f)))]))
+
+;; ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;  running sequences outside of a loop:
+
+#;(define-values (struct:do-stream
+                make-do-stream
+                do-stream?
+                do-stream-ref
+                do-stream-set!)
+  (make-struct-type 'stream #f 3 0 #f
+                    (list (cons prop:stream
+                                (vector
+                                 (lambda (v) ((do-stream-ref v 0)))
+                                 (lambda (v) ((do-stream-ref v 1)))
+                                 (lambda (v) ((do-stream-ref v 2))))))))
+
+;(define empty-stream (make-do-stream (lambda () #t) void void))
+
+#;(define (sequence->stream s)
+  (unless (sequence? s)
+    (raise-argument-error 'sequence-generate "sequence?" s))
+  (cond
+    [(stream? s) s]
+    [else
+     (let-values ([(pos->val pos-next init pos-cont? pre-cont? post-cont?)
+                   (make-sequence #f s)])
+       (define (gen-stream pos)
+         (let ([done? #f]
+               [vals #f]
+               [empty? #f]
+               [next #f])
+           (define (force!)
+             (unless done?
+               (if (if pos-cont? (pos-cont? pos) #t)
+                   (begin
+                     (set! vals (call-with-values (lambda () (pos->val pos)) list))
+                     (unless (if pre-cont? (apply pre-cont? vals) #t)
+                       (set! vals #f)
+                       (set! empty? #t)))
+                   (set! empty? #t))
+               (set! done? #t)))
+           (make-do-stream (lambda () (force!) empty?)
+                           (lambda () (force!) (apply values vals))
+                           (lambda ()
+                             (force!)
+                             (if next
+                                 next
+                                 (begin
+                                   (if (if post-cont? (apply post-cont? pos vals) #t)
+                                       (set! next (gen-stream (pos-next pos)))
+                                       (set! next empty-stream))
+                                   next))))))
+       (gen-stream init))]))
+
+(define (no-more)
+  (error "sequence has no more values")
+  #;(raise (exn:fail:contract "sequence has no more values"
+                            (current-continuation-marks))))
+
+(define (sequence-generate g)
+  (unless (sequence? g)
+    (raise-argument-error 'sequence-generate "sequence?" g))
+  (let-values ([(pos->val pos-next init pos-cont? pre-cont? post-cont?)
+                (make-sequence #f g)])
+    (let ([pos init])
+      (letrec ([more? #f]
+               [prep-val! #f]
+               [next #f])
+        (letrec ([init-more?
+                  (lambda () (prep-val!) (more?))]
+                 [init-next
+                  (lambda () (prep-val!) (next))]
+                 [init-prep-val!
+                  (lambda ()
+                    (if (if pos-cont? (pos-cont? pos) #t)
+                        (call-with-values
+                         (lambda () (pos->val pos))
+                         (lambda vals
+                           (if (if pre-cont? (apply pre-cont? vals) #t)
+                               (begin
+                                 (set! more? (lambda () #t))
+                                 (set! next
+                                       (lambda ()
+                                         (let ([v vals])
+                                           (set! prep-val!
+                                                 (lambda ()
+                                                   (if (if post-cont?
+                                                           (apply post-cont? pos vals)
+                                                           #t)
+                                                       (begin
+                                                         (set! pos (pos-next pos))
+                                                         (set! prep-val! init-prep-val!)
+                                                         (prep-val!))
+                                                       (begin
+                                                         (set! more? (lambda () #f))
+                                                         (set! next no-more)))))
+                                           (set! more? init-more?)
+                                           (set! next init-next)
+                                           (apply values v))))
+                                 (set! prep-val! void)
+                                 (apply values vals))
+                               (begin
+                                 (set! more? (lambda () #f))
+                                 (set! next no-more)))))
+                        (begin
+                          (set! more? (lambda () #f))
+                          (set! next no-more))))])
+          (set! more? init-more?)
+          (set! prep-val! init-prep-val!)
+          (set! next init-next)
+          (let ([sequence-more? (lambda () (more?))]
+                [sequence-next (lambda () (next))])
+            (values sequence-more?
+                    sequence-next)))))))
+
+(define (sequence-generate* g)
+  (unless (sequence? g)
+    (raise-argument-error 'sequence-generate* "sequence?" g))
+  (let-values ([(pos->val pos-next init pos-cont? pre-cont? post-cont?)
+                (make-sequence #f g)])
+    (letrec ([next!
+              (lambda (pos)
+                (if (if pos-cont? (pos-cont? pos) #t)
+                    (call-with-values
+                     (lambda () (pos->val pos))
+                     (lambda vals
+                       (if (if pre-cont? (apply pre-cont? vals) #t)
+                           (values vals
+                                   (lambda ()
+                                     (if (if post-cont?
+                                             (apply post-cont? pos vals)
+                                             #t)
+                                         (next! (pos-next pos))
+                                         (values #f no-more))))
+                           (values #f no-more))))
+                    (values #f no-more)))])
+      (next! init))))
+
+;; ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;  core `for/fold' syntax
+
+(define-syntax values*
+  (syntax-rules ()
+    [(_ x) x]
+    [(_ x ...) (values x ...)]))
+
+(define-syntax (for/foldX/derived stx)
+  (syntax-case stx ()
+    ;; Done case (no more clauses, and no generated clauses to emit):
+    [(_ [orig-stx nested? emit? ()] ([fold-var fold-init] ...) ()
+        expr1 expr ...)
+     #`(let ([fold-var fold-init] ...) (let () expr1 expr ...))]
+    ;; Switch-to-emit case (no more clauses to generate):
+    [(_ [orig-stx nested? #f binds] ([fold-var fold-init] ...) () . body)
+     #`(for/foldX/derived [orig-stx nested? #t binds]
+                          ([fold-var fold-init] ...) () . body)]
+    ;; Emit case:
+    [(_ [orig-stx nested? #t binds] ([fold-var fold-init] ...) rest expr1 . body)
+     (with-syntax ([(([outer-binding ...]
+                      outer-check
+                      [loop-binding ...]
+                      pos-guard
+                      [inner-binding ...]
+                      pre-guard
+                      post-guard
+                      [loop-arg ...]) ...) (reverse (syntax->list #'binds))])
+       (quasisyntax/loc #'orig-stx
+         (let-values (outer-binding ... ...)
+           outer-check ...
+           #,(syntax/loc #'orig-stx
+               (let for-loop ([fold-var fold-init] ...
+                              loop-binding ... ...)
+                 (if (and pos-guard ...)
+                     (let-values (inner-binding ... ...)
+                       (if (and pre-guard ...)
+                           (let-values ([(fold-var ...)
+                                         (for/foldX/derived [orig-stx nested? #f ()]
+                                                            ([fold-var fold-var] ...)
+                                                            rest expr1 . body)])
+                             (if (and post-guard ...)
+                                 (for-loop fold-var ... loop-arg ... ...)
+                                 (values* fold-var ...)))
+                           (values* fold-var ...)))
+                     (values* fold-var ...)))))))]
+    ;; Bad body cases:
+    [(_ [orig-stx . _] fold-bind ())
+     (raise-syntax-error
+      #f "missing body expression after sequence bindings" #'orig-stx)]
+    [(_ [orig-stx . _] fold-bind () . rest)
+     (raise-syntax-error
+      #f "bad syntax (illegal use of `.') after sequence bindings" #'orig-stx)]
+    ;; Guard case, no pending emits:
+    [(_ [orig-stx nested? #f ()] ([fold-var fold-init] ...) (#:when expr . rest) . body)
+     #'(let ([fold-var fold-init] ...)
+         (if expr
+             (for/foldX/derived [orig-stx nested? #f ()]
+                                ([fold-var fold-var] ...) rest . body)
+             (values* fold-var ...)))]
+    ;; Guard case, pending emits need to be flushed first
+    [(frm [orig-stx nested? #f binds] ([fold-var fold-init] ...)
+          (#:when expr . rest) . body)
+     #'(frm [orig-stx nested? #t binds] ([fold-var fold-init] ...)
+            (#:when expr . rest) . body)]
+    ;; Negative guard case, no pending emits:
+    [(_ [orig-stx nested? #f ()] ([fold-var fold-init] ...) (#:unless expr . rest) . body)
+     #'(let ([fold-var fold-init] ...)
+         (if expr
+             (values* fold-var ...)
+             (for/foldX/derived [orig-stx nested? #f ()]
+                                ([fold-var fold-var] ...) rest . body)))]
+    ;; Negative guard case, pending emits need to be flushed first
+    [(frm [orig-stx nested? #f binds] ([fold-var fold-init] ...)
+          (#:unless expr . rest) . body)
+     #'(frm [orig-stx nested? #t binds] ([fold-var fold-init] ...)
+            (#:unless expr . rest) . body)]
+    ;; Convert single-value form to multi-value form:
+    [(_ [orig-stx nested? #f binds] fold-bind ([id rhs] . rest) . body)
+     (identifier? #'id)
+     #'(for/foldX/derived [orig-stx nested? #f binds] fold-bind
+                          ([(id) rhs] . rest) . body)]
+    ;; If we get here in single-value mode, then it's a bad clause:
+    [(_ [orig-stx #f #f nested? #f binds] fold-bind (clause . rest) . body)
+     (raise-syntax-error
+      #f "bad sequence binding clause" #'orig-stx #'clause)]
+    ;; Expand one multi-value clause, and push it into the results to emit:
+    [(frm [orig-stx nested? #f binds] ([fold-var fold-init] ...)
+          (clause . rest) . body)
+     (with-syntax ([bind (expand-clause #'orig-stx #'clause)])
+       (let ([r #`(frm [orig-stx nested? nested? (bind . binds)]
+                       ([fold-var fold-init] ...) rest . body)]
+             [d (syntax-property #'bind 'disappeared-use)])
+         (if d
+             (syntax-property r 'disappeared-use d)
+             r)))]
+    [(_ [orig-stx . _] . _)
+     (raise-syntax-error #f "bad syntax" #'orig-stx)]))
+
+(define-syntax (for/foldX/derived/break stx)
+  (syntax-case stx ()
+    [(_ [orig-stx nested? emit? ()] ([id init] ...) (clause ...) body ...)
+     (ormap (lambda (form)
+              (or (eq? (syntax-e form) '#:break)
+                  (eq? (syntax-e form) '#:final)))
+            (syntax->list #'(clause ... body ...)))
+     ;; Add an accumulator for short-circuiting
+     (with-syntax ([body
+                    (let loop ([bodys (syntax->list #'(body ...))] [accum null])
+                      (cond
+                        [(null? bodys)
+                         (if (null? accum)
+                             (raise-syntax-error #f "missing final body expression" #'orig-stx)
+                             #`(let-values ([(id ...) (let () #,@(reverse accum))])
+                                 (values stop-after? id ...)))]
+                        [(or (eq? '#:break (syntax-e (car bodys)))
+                             (eq? '#:final (syntax-e (car bodys))))
+                         (let ([break? (eq? '#:break (syntax-e (car bodys)))])
+                           (if (null? (cdr bodys))
+                               (raise-syntax-error #f 
+                                                   (format "missing expression after ~a" (syntax-e (car bodys)))
+                                                   #'orig-stx (car bodys))
+                               #`(let ()
+                                   #,@(reverse accum)
+                                   #,(if break?
+                                         #`(if #,(cadr bodys)
+                                               (values #t id ...)
+                                               (let () #,(loop (cddr bodys) null)))
+                                         #`(let ([stop-after? (or #,(cadr bodys) stop-after?)])
+                                             #,(loop (cddr bodys) null))))))]
+                        [else (loop (cdr bodys) (cons (car bodys) accum))]))]
+                   [(limited-for-clause ...)
+                    ;; If nested, wrap all binding clauses. Otherwise, wrap
+                    ;; only the first and the first after each keyword clause:
+                    (let loop ([fcs (syntax->list #'(clause ...))] [wrap? #t])
+                      (cond
+                        [(null? fcs) null]
+                        [(eq? '#:break (syntax-e (car fcs)))
+                         (when (null? (cdr fcs))
+                           (raise-syntax-error #f "no expression after #:break" #'orig-stx (car fcs)))
+                         (list* #'#:when #'#t
+                                #`[stop? (*in-value #,(cadr fcs))]
+                                #'#:when #'#t
+                                #`[stop-after? (*in-value (or stop-after? stop?))]
+                                #'#:unless #'stop?
+                                (loop (cddr fcs) #t))]
+                        [(eq? '#:final (syntax-e (car fcs)))
+                         (when (null? (cdr fcs))
+                           (raise-syntax-error #f "no expression after #:break" #'orig-stx (car fcs)))
+                         (list* #'#:when #'#t
+                                #`[stop-after? (*in-value (or #,(cadr fcs) stop-after?))]
+                                #'#:when #'#t
+                                (loop (cddr fcs) #t))]
+                        [(keyword? (syntax-e (car fcs)))
+                         (if (null? (cdr fcs))
+                             fcs
+                             (list* (car fcs) (cadr fcs) (loop (cddr fcs) #t)))]
+                        [(not wrap?)
+                         (cons (car fcs) (loop (cdr fcs) #f))]
+                        [else
+                         (define fc (car fcs))
+                         (define wrapped-fc
+                           (syntax-case fc ()
+                             [[ids rhs]
+                              (or (identifier? #'ids)
+                                  (let ([l (syntax->list #'ids)])
+                                    (and l (andmap identifier? l))))
+                              (syntax/loc fc [ids (stop-after
+                                                   rhs
+                                                   (lambda x stop-after?))])]
+                             [_ fc]))
+                         (cons wrapped-fc
+                               (loop (cdr fcs) (syntax-e #'nested?)))]))])
+       #'(let-values ([(stop? id ...) 
+                       (for/foldX/derived [orig-stx nested? emit? ()] ([stop-after? #f] [id init] ...) 
+                                          (limited-for-clause ...) 
+                                          body)])
+           (values id ...)))]
+    [(_ . rest)
+     #'(for/foldX/derived . rest)]))
+
+(define-syntax for/fold/derived
+  (syntax-rules ()
+    [(_ orig-stx . rest)
+     (for/foldX/derived/break [orig-stx #f #f ()] . rest)]))
+
+(define-syntax for*/fold/derived
+  (syntax-rules ()
+    [(_ orig-stx . rest)
+     (for/foldX/derived/break [orig-stx #t #f ()] . rest)]))
+
+;; ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;  derived `for' syntax
+
+(define-for-syntax (split-for-body stx body-stx)
+  (let ([lst (syntax->list body-stx)])
+    (if lst
+        (let loop ([exprs lst] [pre-kw null] [post-kw null])
+          (cond
+            [(null? exprs)
+             (if (null? post-kw)
+                 (raise-syntax-error #f
+                                     (format "missing body form after ~a clause" (syntax-e (cadr pre-kw)))
+                                     stx
+                                     (cadr pre-kw))
+                 (list (reverse pre-kw) (reverse post-kw)))]
+            [(memq (syntax-e (car exprs)) '(#:break #:final))
+             (if (pair? (cdr exprs))
+                 (loop (cddr exprs) 
+                       (append (list* (cadr exprs) (car exprs) post-kw)
+                               pre-kw)
+                       null)
+                 (raise-syntax-error #f
+                                     (format "missing expression after ~a" (syntax-e (car exprs)))
+                                     stx
+                                     (car exprs)))]
+            [else
+             (loop (cdr exprs) pre-kw (cons (car exprs) post-kw))]))
+        (raise-syntax-error #f "bad syntax" stx))))
+
+(define-for-syntax (for-variant-stx stx derived-id-stx fold-bind-stx wrap rhs-wrap combine)
+  (with-syntax ([derived-id derived-id-stx]
+                [fold-bind fold-bind-stx])
+    (syntax-case stx ()
+      ;; When there's a bindings clause...
+      [(_ (bind ...) expr1 expr ...)
+       (with-syntax ([(bind ...)
+                      (let loop ([bs (syntax->list #'(bind ...))])
+                        (if (null? bs)
+                            null
+                            (syntax-case (car bs) ()
+                              [[ids rhs]
+                               (or (identifier? #'ids)
+                                   (andmap identifier? (or (syntax->list #'ids) '(#f))))
+                               (cons #`[ids #,(rhs-wrap #'rhs)]
+                                     (loop (cdr bs)))]
+                              [kw
+                               (memq (syntax-e #'kw) '(#:when #:unless #:break #:final))
+                               (cons (car bs)
+                                     (if (null? (cdr bs))
+                                         null
+                                         (cons (cadr bs) (loop (cddr bs)))))]
+                              [_
+                               ;; a syntax error; let the /derived form
+                               ;; handle it, and no need to wrap any more:
+                               bs])))]
+                     [((middle-expr ...) (end-expr ...))
+                      (split-for-body stx #'(expr1 expr ...))])
+         (quasisyntax/loc stx
+           #,(wrap (quasisyntax/loc stx
+                     (derived-id #,stx fold-bind (bind ...)
+                                 middle-expr ...
+                                 #,(combine (syntax/loc stx (let () end-expr ...))))))))]
+      ;; Let `derived-id' complain about the missing bindings and body expression:
+      [(_ . rest)
+       #`(derived-id #,stx fold-bind . rest)])))
+
+(define-syntax define-syntax-via-derived
+  (syntax-rules ()
+    [(_ id derived-id fold-bind wrap rhs-wrap combine)
+     (define-syntax (id stx)
+       (for-variant-stx stx #'derived-id #'fold-bind wrap rhs-wrap combine))]))
+
+(define-syntax define-for-variants
+  (syntax-rules ()
+    [(_ (for for*) fold-bind wrap rhs-wrap combine)
+     (begin
+       (define-syntax-via-derived for for/fold/derived fold-bind wrap rhs-wrap combine)
+       (define-syntax-via-derived for* for*/fold/derived fold-bind wrap rhs-wrap combine))]))
+
+(define-syntax (for/fold stx)
+  (syntax-case stx ()
+    [(_ . rest) (quasisyntax/loc stx (for/fold/derived #,stx . rest))]))
+(define-syntax (for*/fold stx)
+  (syntax-case stx ()
+    [(_ . rest) (quasisyntax/loc stx (for*/fold/derived #,stx . rest))]))
+
+(define-for-variants (for for*)
+  ([fold-var (void)])
+  (lambda (x) x)
+  (lambda (x) x)
+  (lambda (x) `(,#'begin ,x ,#'(void))))
+
+(define-for-variants (for/list for*/list)
+  ([fold-var null])
+  (lambda (x) `(,#'reverse ,x))
+  (lambda (x) x)
+  (lambda (x) `(,#'cons ,x ,#'fold-var)))
+
+(define (vector-copy! dest dest-start src src-start [src-end (vector-length src)])
+  (let loop ([s src-start] [d dest-start])
+    (when (< s src-end)
+      (vector-set! dest d (vector-ref src s))
+      (loop (+ s 1) (+ d 1)))))
+
+(define (grow-vector vec)
+  (define n (vector-length vec))
+  (define new-vec (make-vector (* 2 n)))
+  (vector-copy! new-vec 0 vec 0 n)
+  new-vec)
+
+(define (shrink-vector vec i)
+  (define new-vec (make-vector i))
+  (vector-copy! new-vec 0 vec 0 i)
+  new-vec)
+
+(define-for-syntax (for_/vector stx orig-stx for_/vector-stx for_/fold/derived-stx wrap-all?)
+  (syntax-case stx ()
+    [(_ (for-clause ...) body ...)
+     (with-syntax ([orig-stx orig-stx]
+                   [for_/fold/derived for_/fold/derived-stx]
+                   [((middle-body ...) (last-body ...)) (split-for-body stx #'(body ...))])
+       (syntax/loc stx
+         (let-values ([(vec i)
+                       (for_/fold/derived
+                        orig-stx
+                        ([vec (make-vector 16)]
+                         [i 0])
+                        (for-clause ...) 
+                        middle-body ...
+                        (let ([new-vec (if (eq? i (vector-length vec))
+                                           (grow-vector vec)
+                                           vec)])
+                          (vector-set! new-vec i (let () last-body ...))
+                          (values new-vec (+ i 1))))])
+           (shrink-vector vec i))))]
+    [(_ #:length length-expr #:fill fill-expr (for-clause ...) body ...)
+     (with-syntax ([orig-stx orig-stx]
+                   [(limited-for-clause ...)
+                    ;; If `wrap-all?', wrap all binding clauses. Otherwise, wrap
+                    ;; only the first and the first after each keyword clause:
+                    (let loop ([fcs (syntax->list #'(for-clause ...))] [wrap? #t])
+                      (cond
+                        [(null? fcs) null]
+                        [(keyword? (syntax-e (car fcs)))
+                         (if (null? (cdr fcs))
+                             fcs
+                             (list* (car fcs) (cadr fcs) (loop (cddr fcs) #t)))]
+                        [(not wrap?)
+                         (cons (car fcs) (loop (cdr fcs) #f))]
+                        [else
+                         (define fc (car fcs))
+                         (define wrapped-fc
+                           (syntax-case fc ()
+                             [[ids rhs]
+                              (or (identifier? #'ids)
+                                  (let ([l (syntax->list #'ids)])
+                                    (and l (andmap identifier? l))))
+                              (syntax/loc fc [ids (stop-after
+                                                   rhs
+                                                   (lambda x
+                                                     (= i len)))])]
+                             [_ fc]))
+                         (cons wrapped-fc
+                               (loop (cdr fcs) wrap-all?))]))]
+                   [((middle-body ...) (last-body ...)) (split-for-body stx #'(body ...))]
+                   [for_/vector for_/vector-stx]
+                   [for_/fold/derived for_/fold/derived-stx])
+       (syntax/loc stx
+         (let ([len length-expr])
+           (unless (exact-nonnegative-integer? len)
+             (raise-argument-error 'for_/vector "exact-nonnegative-integer?" len))
+           (let ([v (make-vector len fill-expr)])
+             (unless (zero? len)
+               (for_/fold/derived
+                orig-stx 
+                ([i 0])
+                (limited-for-clause ...)
+                middle-body ...
+                (unsafe-vector*-set! v i (let () last-body ...))
+                (+ 1 i)))
+             v))))]
+    [(_ #:length length-expr (for-clause ...) body ...)
+     (for_/vector #'(fv #:length length-expr #:fill 0 (for-clause ...) body ...) 
+                  orig-stx for_/vector-stx for_/fold/derived-stx wrap-all?)]))
+
+(define-syntax (for/vector stx)
+  (for_/vector stx stx #'for/vector #'for/fold/derived #f))
+
+(define-syntax (for*/vector stx)
+  (for_/vector stx stx #'for*/vector #'for*/fold/derived #t))
+
+
+(define-for-syntax (do-for/lists for/fold-id stx)
+  (syntax-case stx ()
+    [(_ (id ...) bindings expr1 expr ...)
+     (let ([ids (syntax->list #'(id ...))])
+       (for-each (lambda (id)
+                   (unless (identifier? id)
+                     (raise-syntax-error #f
+                                         "not an identifier"
+                                         stx
+                                         id)))
+                 ids)
+       (with-syntax ([(id2 ...) (generate-temporaries ids)]
+                     [for/fold for/fold-id]
+                     [orig-stx stx])
+         #'(let-values ([(id ...)
+                         (for/fold orig-stx ([id null] ...) bindings
+                           (let-values ([(id2 ...) (let ()
+                                                     expr1
+                                                     expr ...)])
+                             (values* (cons id2 id) ...)))])
+             (values* (reverse id) ...))))]))
+
+(define-syntax (for/lists stx) (do-for/lists #'for/fold/derived stx))
+(define-syntax (for*/lists stx) (do-for/lists #'for*/fold/derived stx))
+
+(define-for-variants (for/and for*/and)
+  ([result #t])
+  (lambda (x) x)
+  (lambda (rhs) #`(stop-after #,rhs (lambda x (not result))))
+  (lambda (x) x))
+
+(define-for-variants (for/or for*/or)
+  ([result #f])
+  (lambda (x) x)
+  (lambda (rhs) #`(stop-after #,rhs (lambda x result)))
+  (lambda (x) x))
+
+(define-for-variants (for/first for*/first)
+  ([val #f] [stop? #f])
+  (lambda (x) #`(let-values ([(val _) #,x]) val))
+  (lambda (rhs) #`(stop-after #,rhs (lambda x stop?)))
+  (lambda (x) #`(values #,x #t)))
+
+(define-for-variants (for/last for*/last)
+  ([result #f])
+  (lambda (x) x)
+  (lambda (rhs) rhs)
+  (lambda (x) x))
+
+(define-for-variants (for/sum for*/sum)
+  ([result 0])
+  (lambda (x) x)
+  (lambda (rhs) rhs)
+  (lambda (x) #`(+ result #,x)))
+
+(define-for-variants (for/product for*/product)
+  ([result 1])
+  (lambda (x) x)
+  (lambda (rhs) rhs)
+  (lambda (x) #`(* result #,x)))
+
+(define-for-variants (for/hash for*/hash)
+  ([table #hash()])
+  (lambda (x) x)
+  (lambda (rhs) rhs)
+  (lambda (x)
+    #`(let-values ([(key val) #,x])
+        (hash-set table key val))))
+
+(define-for-variants (for/hasheq for*/hasheq)
+  ([table #hasheq()])
+  (lambda (x) x)
+  (lambda (rhs) rhs)
+  (lambda (x)
+    #`(let-values ([(key val) #,x])
+        (hash-set table key val))))
+
+(define-for-variants (for/hasheqv for*/hasheqv)
+  ([table #hasheqv()])
+  (lambda (x) x)
+  (lambda (rhs) rhs)
+  (lambda (x)
+    #`(let-values ([(key val) #,x])
+        (hash-set table key val))))
+
+;; ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;  specific sequences
+
+(define-sequence-syntax *in-range
+  (lambda () #'in-range)
+  (lambda (stx)
+    (let loop ([stx stx])
+      (syntax-case stx ()
+        [[(id) (_ a b step)]
+         (let ([all-fx? (and (fixnum? (syntax-e #'a))
+                             (fixnum? (syntax-e #'b))
+                             (memq (syntax-e #'step) '(1 -1)))])
+           (for-clause-syntax-protect
+            #`[(id)
+               (:do-in
+                ;; outer bindings:
+                ([(start) a] [(end) b] [(inc) step])
+                ;; outer check:
+                (unless (and (real? start) (real? end) (real? inc))
+                  ;; let `in-range' report the error:
+                  (in-range start end inc))
+                ;; loop bindings:
+                ([pos start])
+                ;; pos check
+                #,(cond [all-fx?
+                         ;; Special case, can use unsafe ops:
+                         (if ((syntax-e #'step) . >= . 0)
+                             #'(< pos end)
+                             #'(> pos end))]
+                        ;; General cases:
+                        [(not (number? (syntax-e #'step)))
+                         #`(if (step . >= . 0) (< pos end) (> pos end))]
+                        [((syntax-e #'step) . >= . 0)
+                         #'(< pos end)]
+                        [else
+                         #'(> pos end)])
+                ;; inner bindings
+                ([(id) pos])
+                ;; pre guard
+                #t
+                ;; post guard
+                #t
+                ;; loop args
+                ((#,(if all-fx? #'+ #'+) pos inc)))]))]
+        [[(id) (_ a b)] (loop #'[(id) (_ a b 1)])]
+        [[(id) (_ b)] (loop #'[(id) (_ 0 b 1)])]
+        [_ #f]))))
+
+(define-sequence-syntax *in-naturals
+  (lambda () #'in-naturals)
+  (lambda (stx)
+    (let loop ([stx stx])
+      (syntax-case stx ()
+        [[(id) (_ start-expr)]
+         (for-clause-syntax-protect
+          #`[(id)
+             (:do-in
+              ;; outer bindings:
+              ([(start) start-expr])
+              ;; outer check:
+              (unless (exact-nonnegative-integer? start)
+                ;; let `in-naturals' report the error:
+                (in-naturals start))
+              ;; loop bindings:
+              ([pos start])
+              ;; pos check
+              #t
+              ;; inner bindings
+              ([(id) pos])
+              ;; pre guard
+              #t
+              ;; post guard
+              #t
+              ;; loop args
+              ((+ pos 1)))])]
+        [[(id) (_)]
+         (loop #'[(id) (_ 0)])]
+        [_ #f]))))
+
+(define-sequence-syntax *in-list
+  (lambda () #'in-list)
+  (lambda (stx)
+    (syntax-case stx (list)
+      [[(id) (_ (list expr))] #'[(id) (:do-in ([(id) expr]) #t () #t () #t #f ())]]
+      [[(id) (_ lst-expr)]
+       (for-clause-syntax-protect
+        #'[(id)
+           (:do-in
+            ;;outer bindings
+            ([(lst) lst-expr])
+            ;; outer check
+            (unless (list? lst) (in-list lst))
+            ;; loop bindings
+            ([lst lst])
+            ;; pos check
+            (pair? lst)
+            ;; inner bindings
+            ([(id) (car lst)])
+            ;; pre guard
+            #t
+            ;; post guard
+            #t
+            ;; loop args
+            ((cdr lst)))])]
+      [_ #f])))
+
+(define-sequence-syntax *in-mlist
+  (lambda () #'in-mlist)
+  (lambda (stx)
+    (syntax-case stx (mlist)
+      [[(id) (_ (mlist expr))] #'[(id) (:do-in ([(id) expr]) #t () #t () #t #f ())]]
+      [[(id) (_ lst-expr)]
+       (for-clause-syntax-protect
+        #'[(id)
+           (:do-in
+            ;;outer bindings
+            ([(lst) lst-expr])
+            ;; outer check
+            (void) ; (unless (list? lst) (in-list lst))
+            ;; loop bindings
+            ([lst lst])
+            ;; pos check
+            (not (null? lst))
+            ;; inner bindings
+            ([(id) (mcar lst)])
+            ;; pre guard
+            #t
+            ;; post guard
+            #t
+            ;; loop args
+            ((mcdr lst)))])]
+      [_ #f])))
+
+(define-sequence-syntax *in-stream
+  (lambda () #'in-stream)
+  (lambda (stx)
+    (syntax-case stx ()
+      [[(id) (_ lst-expr)]
+       (for-clause-syntax-protect
+        #'[(id)
+           (:do-in
+            ;;outer bindings
+            ([(lst) lst-expr])
+            ;; outer check
+            (unless (stream? lst) (in-stream lst))
+            ;; loop bindings
+            ([lst lst])
+            ;; pos check
+            (unsafe-stream-not-empty? lst)
+            ;; inner bindings
+            ([(id) (unsafe-stream-first lst)])
+            ;; pre guard
+            #t
+            ;; post guard
+            #t
+            ;; loop args
+            ((unsafe-stream-rest lst)))])]
+      [_ #f])))
+
+(define-sequence-syntax *in-indexed
+  (lambda () #'in-indexed)
+  (lambda (stx)
+    (syntax-case stx ()
+      [[(id1 id2) (_ gen-expr)]
+       #'[(id1 id2) (in-parallel gen-expr (*in-naturals))]])))
+
+(define-sequence-syntax *in-value
+  (lambda () #'in-value)
+  (lambda (stx)
+    (syntax-case stx ()
+      [[(id) (_ expr)]
+       #'[(id) (:do-in ([(id) expr]) #t () #t () #t #f ())]])))
+
+(define-sequence-syntax *in-producer
+  (lambda () #'in-producer)
+  (lambda (stx)
+    (syntax-case stx ()
+      ;; cheap & simple stop-less and arg-less version
+      [[(id ...) (_ producer)]
+       #'[(id ...)
+          (:do-in ([(producer*) producer]) #t () #t ([(id ...) (producer*)])
+                  #t #t ())]]
+      ;; full version
+      [[(id ...) (_ producer stop more ...)]
+       (with-syntax ([(more* ...) (generate-temporaries #'(more ...))]
+                     [single? (= 1 (length (syntax->list #'(id ...))))])
+         #'[(id ...)
+            (:do-in
+             ;; outer bindings
+             ([(producer*) producer]
+              [(more*) more] ...
+              [(stop?)
+               (let ([s stop])
+                 (cond [(procedure? s) s]
+                       ['single? (lambda (x) (eq? x s))]
+                       [else (error 'in-producer
+                                    "stop condition for ~a, got: ~e"
+                                    "multiple values must be a predicate" s)]))])
+             ;; outer check
+             #t
+             ;; loop bindings
+             ()
+             ;; pos check
+             #t
+             ;; inner bindings
+             ([(id ...) (producer* more* ...)])
+             ;; pre guard
+             (not (stop? id ...))
+             ;; post guard
+             #t
+             ;; loop args
+             ())])])))
+
+;; Some iterators that are implemented using `*in-producer' (note: do not use
+;; `in-producer', since in this module it is the procedure version).
+
+(define-sequence-syntax *in-port
+  (lambda () #'in-port)
+  (lambda (stx)
+    (syntax-case stx ()
+      [[(id) (_)]   #'[(id) (*in-port read (current-input-port))]]
+      [[(id) (_ r)] #'[(id) (*in-port r (current-input-port))]]
+      [[(id) (_ r p)]
+       #'[(id) (*in-producer
+                (let ([r* r] [p* p])
+                  (check-in-port r* p*)
+                  (lambda () (r* p*)))
+                eof)]])))
+
+(define-sequence-syntax *in-lines
+  (lambda () #'in-lines)
+  (lambda (stx)
+    (syntax-case stx ()
+      [[(id) (_)]   #'[(id) (*in-lines (current-input-port) 'any)]]
+      [[(id) (_ p)] #'[(id) (*in-lines p 'any)]]
+      [[(id) (_ p mode)]
+       #'[(id) (*in-producer
+                (let ([p* p] [mode* mode])
+                  (check-in-lines p* mode*)
+                  (lambda () (read-line p* mode*)))
+                eof)]])))
+
+(define-sequence-syntax *in-bytes-lines
+  (lambda () #'in-bytes-lines)
+  (lambda (stx)
+    (syntax-case stx ()
+      [[(id) (_)]   #'[(id) (*in-bytes-lines (current-input-port) 'any)]]
+      [[(id) (_ p)] #'[(id) (*in-bytes-lines p 'any)]]
+      [[(id) (_ p mode)]
+       #'[(id) (*in-producer
+                (let ([p* p] [mode* mode])
+                  (check-in-bytes-lines p* mode*)
+                  (lambda () (read-bytes-line p* mode*)))
+                eof)]])))
+
+(define-sequence-syntax *in-input-port-bytes
+  (lambda () #'in-input-port-bytes)
+  (lambda (stx)
+    (syntax-case stx ()
+      [[(id) (_ p)]
+       #'[(id) (*in-producer
+                (let ([p* p])
+                  (unless (input-port? p*) (in-input-port-bytes p*))
+                  (lambda () (read-byte p*)))
+                eof)]])))
+
+(define-sequence-syntax *in-input-port-chars
+  (lambda () #'in-input-port-chars)
+  (lambda (stx)
+    (syntax-case stx ()
+      [[(id) (_ p)]
+       #'[(id) (*in-producer
+                (let ([p* p])
+                  (unless (input-port? p*) (in-input-port-chars p*))
+                  (lambda () (read-char p*)))
+                eof)]])))
+
+#;(define (dir-list full-d d acc)
+  (for/fold ([acc acc]) ([f (in-list (reverse (directory-list full-d)))])
+    (cons (build-path d f) acc)))
+
+#;(define (next-body l d init-dir use-dir?)
+  (let ([full-d (path->complete-path d init-dir)])
+    (if (and (directory-exists? full-d)
+             (use-dir? full-d))
+        (dir-list full-d d (cdr l))
+        (cdr l))))
+
+#;(define (initial-state orig-dir init-dir)
+  (if orig-dir
+      (dir-list (path->complete-path orig-dir init-dir)
+                orig-dir null)
+      (directory-list init-dir)))
+
+#;(define *in-directory
+  (case-lambda 
+    [() (*in-directory #f (lambda (d) #t))]
+    [(orig-dir) (*in-directory orig-dir (lambda (d) #t))]
+    [(orig-dir use-dir?)
+     (define init-dir (current-directory))
+     ;; current state of the sequence is a list of paths to produce; when
+     ;; incrementing past a directory, add the directory's immediate
+     ;; content to the front of the list:
+     (define (next l)
+       (define d (car l))
+       (next-body l d init-dir use-dir?))
+     (make-do-sequence
+      (lambda ()
+        (values
+         car
+         next
+         (initial-state orig-dir init-dir)
+         pair?
+         #f
+         #f)))]))
+
+(define-sequence-syntax in-directory
+  (λ () #'*in-directory)
+  (λ (stx)
+    (syntax-case stx ()
+      [((d) (_)) #'[(d) (*in-directory #f)]]
+      [((d) (_ dir)) #'[(d) (*in-directory dir (lambda (d) #t))]]
+      [((d) (_ dir use-dir?-expr))
+       #'[(d) 
+          (:do-in
+           ([(orig-dir) (or dir #f)]
+            [(init-dir) (current-directory)]
+            [(use-dir?) use-dir?-expr])
+           #true
+           ([l (initial-state orig-dir init-dir)])
+           (pair? l)
+           ([(d) (car l)])
+           #true
+           #true
+           [(next-body l d init-dir use-dir?)])]])))

--- a/whalesong/lang/kernel.rkt
+++ b/whalesong/lang/kernel.rkt
@@ -40,12 +40,13 @@
 ;; Custom letrec and letrec-values in order to avoid running
 ;; into the (in Racket) newly introduced undefined value.
 
-(provide letrec letrec-values)  
+(provide letrec letrec-values)
+(define unique-undefined-value (list '<undefined>))
 (define-syntax (letrec stx)
   (syntax-case stx ()
     [(_ ([id expr] ...) body ...)
      (syntax/loc stx
-       (let ([id '**undefined**] ...)
+       (let ([id unique-undefined-value] ...)
          (set! id expr) ...
          (let () body ...)))]))
 
@@ -53,7 +54,7 @@
   (syntax-case stx ()
     [(_ ([(id ...) expr] ...) body ...)
      (syntax/loc stx
-       (let ([id '**undefined**] ... ...)
+       (let ([id unique-undefined-value] ... ...)
          (set!-values (id ...) expr) ...
          (let () body ...)))]))
 

--- a/whalesong/lang/kernel.rkt
+++ b/whalesong/lang/kernel.rkt
@@ -3,8 +3,8 @@
                                      sgn conjugate))
          (prefix-in racket: racket/base)
          racket/provide
-	 racket/local
-	 (for-syntax racket/base)
+         racket/local
+         (for-syntax racket/base)
          racket/stxparam
          
          (only-in '#%paramz
@@ -35,6 +35,27 @@
     [(v) (set! my-current-print-mode v)]))
 
 (provide current-print-mode)
+
+
+;; Custom letrec and letrec-values in order to avoid running
+;; into the (in Racket) newly introduced undefined value.
+
+(provide letrec letrec-values)  
+(define-syntax (letrec stx)
+  (syntax-case stx ()
+    [(_ ([id expr] ...) body ...)
+     (syntax/loc stx
+       (let ([id '**undefined**] ...)
+         (set! id expr) ...
+         (let () body ...)))]))
+
+(define-syntax (letrec-values stx)
+  (syntax-case stx ()
+    [(_ ([(id ...) expr] ...) body ...)
+     (syntax/loc stx
+       (let ([id '**undefined**] ... ...)
+         (set!-values (id ...) expr) ...
+         (let () body ...)))]))
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -83,74 +104,74 @@
          null
          eof
          #%plain-module-begin
-	 #%module-begin
-	 #%datum
-	 #%app
+         #%module-begin
+         #%datum
+         #%app
          #%plain-app
-	 #%top-interaction
-	 #%top
+         #%top-interaction
+         #%top
          module
          define
-	 define-values
+         define-values
          let-syntax
-	 let-values
-	 let*-values
-	 define-struct
+         let-values
+         let*-values
+         define-struct
          struct
          if
-	 cond
-	 else
+         cond
+         else
          =>
-	 case
-	 quote
-	 unquote
-	 unquote-splicing
-	 lambda
-	 case-lambda
-	 let
-	 let*
-	 letrec
-	 letrec-values
-	 local
-	 begin
-	 begin0
-	 set!
-	 and
-	 or
-	 when
-	 unless
+         case
+         quote
+         unquote
+         unquote-splicing
+         lambda
+         case-lambda
+         let
+         let*
+         letrec
+         letrec-values
+         local
+         begin
+         begin0
+         set!
+         and
+         or
+         when
+         unless
          do
          require
-	 for-syntax
+         for-syntax
          for-template
-	 define-for-syntax
-	 begin-for-syntax
-	 prefix-in
-	 only-in
+         define-for-syntax
+         begin-for-syntax
+         prefix-in
+         only-in
          rename-in
          except-in
-	 provide
-	 planet
-	 all-defined-out
-	 all-from-out
+         provide
+         planet
+         all-defined-out
+         all-from-out
          prefix-out
-	 except-out
-	 rename-out
-	 struct-out
+         except-out
+         rename-out
+         struct-out
          filtered-out
          combine-in
          protect-out
          combine-out
-
+         
          
          define-syntax-rule
-	 define-syntax
-	 define-syntaxes
-
-
+         define-syntax
+         define-syntaxes
+         
+         
          let/cc
-	 with-continuation-mark
-
+         with-continuation-mark
+         
          hash?
          hash-equal?
          hash-eq?
@@ -172,20 +193,20 @@
          hash-remove
          equal-hash-code
          hash-count
-
-
+         
+         
          ;; Kernel inlinable
          *
-	 -
-	 +
-	 =
-	 /
-	 sub1
-	 add1
-	 <
-	 >
-	 <=
-	 >=
+         -
+         +
+         =
+         /
+         sub1
+         add1
+         <
+         >
+         <=
+         >=
          cons
          car
          cdr
@@ -196,15 +217,15 @@
          not
          eq?
          values
-
+         
          ;; The version of apply in racket/base is doing some stuff that
          ;; we are not handling yet.  So we expose the raw apply here instead.
          (rename-out [kernel:apply apply])
          call-with-values
-
+         
          gensym
-
-
+         
+         
          srcloc
          make-srcloc
          srcloc?
@@ -213,25 +234,25 @@
          srcloc-column
          srcloc-position
          srcloc-span
-
-
+         
+         
          make-struct-type
          make-struct-field-accessor
          make-struct-field-mutator
          struct-type?
-
+         
          exn:fail
          struct:exn:fail
          prop:exn:srclocs
-
-
+         
+         
          current-inexact-milliseconds
          current-seconds
          
          continuation-prompt-available?
          abort-current-continuation
          call-with-continuation-prompt
-
+         
          ;; needed for cs019-local
          #%stratified-body
          )
@@ -248,293 +269,293 @@
 ;; Many of these should be pushed upward rather than stubbed, so that
 ;; Racket's compiler can optimize these.
 (provide-stub-function
-
+ 
  current-output-port
  current-print 
-
-
-
+ 
+ 
+ 
  write
  write-byte
  display
  newline
  displayln
-
+ 
  
  current-continuation-marks
  continuation-mark-set->list
  
-;;  continuation-mark-set?
-;;  continuation-mark-set->list
-
-;;  struct-constructor-procedure?
-;;  struct-predicate-procedure?
-;;  struct-accessor-procedure?
-;;  struct-mutator-procedure?
-
-;;  make-arity-at-least
-;;  arity-at-least?
-;;  arity-at-least-value
-
-
-;;  compose
-;;  current-inexact-milliseconds
-;;  current-seconds
-  void
-  random
-;;  sleep
-;;  (identity -identity)
-
-  raise  
-  error
-  raise-type-error
-  raise-mismatch-error
-
-  make-exn
-  make-exn:fail
-  make-exn:fail:contract
-  make-exn:fail:contract:arity
-  make-exn:fail:contract:variable
-  make-exn:fail:contract:divide-by-zero
-
-;;  exn?
-;;  exn:fail:contract:arity?
-;;  exn:fail:contract:variable?
-;;  exn:fail:contract:divide-by-zero?
-  exn:fail?
-  exn:fail:contract?
-  exn:fail:contract:arity?
-
-  exn-message
-  exn-continuation-marks
-
-  abs
-  quotient
-  remainder
-  modulo
-  max
-  min
-  gcd
-  lcm
-  floor
-  ceiling
-  round
-  truncate
-  numerator
-  denominator
-  expt
-  exp
-  log
-  sin
-  sinh
-  cos
-  cosh
-  tan
-  asin
-  acos
-  atan
-  sqr
-  sqrt
-  integer-sqrt
-  sgn
-  make-rectangular
-  make-polar
-  real-part
-  imag-part
-  angle
-  magnitude
-  conjugate
-  inexact->exact
-  exact->inexact
-  number->string
-  string->number
-  procedure?
-  procedure-arity
-  procedure-arity-includes?
-  procedure-rename
-  ;;  (undefined? -undefined?)
-;;  immutable?
-void?
-symbol?
-string?
-char?
-boolean?
-vector?
-struct?
-;;  bytes?
-byte?
-number?
-complex?
-real?
-rational?
-integer?
-exact-integer?
-exact?
-exact-nonnegative-integer?
-inexact?
-odd?
-even?
-zero?
-positive?
-negative?
-box?
-;;  hash?
-
-  equal?
-  eqv?
-  
-  caar
-  cdar
-  cadr
-  cddr
-  caaar
-  cdaar
-  cadar
-  cddar
-  caadr
-  cdadr
-  caddr
-  cdddr
-  caaaar
-  cdaaar
-  cadaar
-  cddaar
-  caadar
-  cdadar
-  caddar
-  cdddar
-  caaadr
-  cdaadr
-  cadadr
-  cddadr
-  caaddr
-  cdaddr
-  cadddr
-  cddddr
-  
-  length
-  list*
-  list-ref
-;;  list-tail
-  append
-  reverse
-  for-each
-  map
-  andmap
-  ormap
-  memq
-  memv
-  member
-  memf
-  assq
-  assv
-  assoc
-;;  sort
-  box
-;;  box-immutable
-  unbox
-  set-box!
-;;  make-hash
-;;  make-hasheq
-;;  hash-set!
-;;  hash-ref
-;;  hash-remove!
-;;  hash-map
-;;  hash-for-each
-  make-string
-  string
-  string-length
-  string-ref
-  string=?
-  string<?
-  string>?
-  string<=?
-  string>=?
-  string-ci=?
-  string-ci<?
-  string-ci>?
-  string-ci<=?
-  string-ci>=?
-
-  string-copy
-  substring
-  string-append
-  string->list
-  list->string
-  string->symbol
-  symbol->string
-  
-  format
-  printf
-  fprintf
-;;  string->immutable-string
-  string-set!
-;;  string-fill!
-;;  make-bytes
-;;  bytes
-;;  bytes->immutable-bytes
-;;  bytes-length
-;;  bytes-ref
-;;  bytes-set!
-;;  subbytes
-;;  bytes-copy
-;;  bytes-fill!
-;;  bytes-append
-;;  bytes->list
-;;  list->bytes
-;;  bytes=?
-;;  bytes<?
-;;  bytes>?
-  make-vector
-  vector
-  vector-length
-  vector-ref
-  vector-set!
-  vector->list
-  list->vector
-  char=?
-  char<?
-  char>?
-  char<=?
-  char>=?
-  char-ci=?
-  char-ci<?
-  char-ci>?
-  char-ci<=?
-  char-ci>=?
-  char-alphabetic?
-  char-numeric?
-  char-whitespace?
-  char-upper-case?
-  char-lower-case?
-  char->integer
-  integer->char
-  char-upcase
-  char-downcase
-
-  
-  ;; these are defined in bootstrapped-primitives in Whalesong's compiler package
-  call-with-current-continuation
-  call/cc
-
-  ;;  call-with-continuation-prompt
-  ;;  abort-current-continuation
-  default-continuation-prompt-tag
-  make-continuation-prompt-tag
-  continuation-prompt-tag?
-
-  make-reader-graph
-  make-placeholder
-  placeholder-set!
-
-  eof-object?
-  read-byte
-
-
-  hash-has-key?
-  hash-keys
-  hash-values
-  )
+ ;;  continuation-mark-set?
+ ;;  continuation-mark-set->list
+ 
+ ;;  struct-constructor-procedure?
+ ;;  struct-predicate-procedure?
+ ;;  struct-accessor-procedure?
+ ;;  struct-mutator-procedure?
+ 
+ ;;  make-arity-at-least
+ ;;  arity-at-least?
+ ;;  arity-at-least-value
+ 
+ 
+ ;;  compose
+ ;;  current-inexact-milliseconds
+ ;;  current-seconds
+ void
+ random
+ ;;  sleep
+ ;;  (identity -identity)
+ 
+ raise  
+ error
+ raise-type-error
+ raise-mismatch-error
+ 
+ make-exn
+ make-exn:fail
+ make-exn:fail:contract
+ make-exn:fail:contract:arity
+ make-exn:fail:contract:variable
+ make-exn:fail:contract:divide-by-zero
+ 
+ ;;  exn?
+ ;;  exn:fail:contract:arity?
+ ;;  exn:fail:contract:variable?
+ ;;  exn:fail:contract:divide-by-zero?
+ exn:fail?
+ exn:fail:contract?
+ exn:fail:contract:arity?
+ 
+ exn-message
+ exn-continuation-marks
+ 
+ abs
+ quotient
+ remainder
+ modulo
+ max
+ min
+ gcd
+ lcm
+ floor
+ ceiling
+ round
+ truncate
+ numerator
+ denominator
+ expt
+ exp
+ log
+ sin
+ sinh
+ cos
+ cosh
+ tan
+ asin
+ acos
+ atan
+ sqr
+ sqrt
+ integer-sqrt
+ sgn
+ make-rectangular
+ make-polar
+ real-part
+ imag-part
+ angle
+ magnitude
+ conjugate
+ inexact->exact
+ exact->inexact
+ number->string
+ string->number
+ procedure?
+ procedure-arity
+ procedure-arity-includes?
+ procedure-rename
+ ;;  (undefined? -undefined?)
+ ;;  immutable?
+ void?
+ symbol?
+ string?
+ char?
+ boolean?
+ vector?
+ struct?
+ ;;  bytes?
+ byte?
+ number?
+ complex?
+ real?
+ rational?
+ integer?
+ exact-integer?
+ exact?
+ exact-nonnegative-integer?
+ inexact?
+ odd?
+ even?
+ zero?
+ positive?
+ negative?
+ box?
+ ;;  hash?
+ 
+ equal?
+ eqv?
+ 
+ caar
+ cdar
+ cadr
+ cddr
+ caaar
+ cdaar
+ cadar
+ cddar
+ caadr
+ cdadr
+ caddr
+ cdddr
+ caaaar
+ cdaaar
+ cadaar
+ cddaar
+ caadar
+ cdadar
+ caddar
+ cdddar
+ caaadr
+ cdaadr
+ cadadr
+ cddadr
+ caaddr
+ cdaddr
+ cadddr
+ cddddr
+ 
+ length
+ list*
+ list-ref
+ ;;  list-tail
+ append
+ reverse
+ for-each
+ map
+ andmap
+ ormap
+ memq
+ memv
+ member
+ memf
+ assq
+ assv
+ assoc
+ ;;  sort
+ box
+ ;;  box-immutable
+ unbox
+ set-box!
+ ;;  make-hash
+ ;;  make-hasheq
+ ;;  hash-set!
+ ;;  hash-ref
+ ;;  hash-remove!
+ ;;  hash-map
+ ;;  hash-for-each
+ make-string
+ string
+ string-length
+ string-ref
+ string=?
+ string<?
+ string>?
+ string<=?
+ string>=?
+ string-ci=?
+ string-ci<?
+ string-ci>?
+ string-ci<=?
+ string-ci>=?
+ 
+ string-copy
+ substring
+ string-append
+ string->list
+ list->string
+ string->symbol
+ symbol->string
+ 
+ format
+ printf
+ fprintf
+ ;;  string->immutable-string
+ string-set!
+ ;;  string-fill!
+ ;;  make-bytes
+ ;;  bytes
+ ;;  bytes->immutable-bytes
+ ;;  bytes-length
+ ;;  bytes-ref
+ ;;  bytes-set!
+ ;;  subbytes
+ ;;  bytes-copy
+ ;;  bytes-fill!
+ ;;  bytes-append
+ ;;  bytes->list
+ ;;  list->bytes
+ ;;  bytes=?
+ ;;  bytes<?
+ ;;  bytes>?
+ make-vector
+ vector
+ vector-length
+ vector-ref
+ vector-set!
+ vector->list
+ list->vector
+ char=?
+ char<?
+ char>?
+ char<=?
+ char>=?
+ char-ci=?
+ char-ci<?
+ char-ci>?
+ char-ci<=?
+ char-ci>=?
+ char-alphabetic?
+ char-numeric?
+ char-whitespace?
+ char-upper-case?
+ char-lower-case?
+ char->integer
+ integer->char
+ char-upcase
+ char-downcase
+ 
+ 
+ ;; these are defined in bootstrapped-primitives in Whalesong's compiler package
+ call-with-current-continuation
+ call/cc
+ 
+ ;;  call-with-continuation-prompt
+ ;;  abort-current-continuation
+ default-continuation-prompt-tag
+ make-continuation-prompt-tag
+ continuation-prompt-tag?
+ 
+ make-reader-graph
+ make-placeholder
+ placeholder-set!
+ 
+ eof-object?
+ read-byte
+ 
+ 
+ hash-has-key?
+ hash-keys
+ hash-values
+ )
 
 
 

--- a/whalesong/lang/match.rkt
+++ b/whalesong/lang/match.rkt
@@ -1,0 +1,27 @@
+#lang whalesong
+(require "private/match/match.rkt" "private/match/runtime.rkt"
+         (for-syntax racket/base))
+
+(provide (except-out (all-from-out "private/match/match.rkt")
+                     define-match-expander)
+         failure-cont
+         (rename-out [define-match-expander* define-match-expander]))
+
+
+(define-for-syntax (no-old-match-form stx)
+  (raise-syntax-error
+   #f
+   "works only for constructor-based `match' form"
+   stx))
+
+(define-syntax-rule (failure-cont) (fail))
+
+
+(define-syntax define-match-expander*
+  (syntax-rules ()
+    [(_ id expr) (define-match-expander id expr)]
+    [(_ id expr expr2) (define-match-expander id
+                         expr
+                         no-old-match-form
+                         (#%expression expr2))]))
+

--- a/whalesong/lang/parameters.rkt
+++ b/whalesong/lang/parameters.rkt
@@ -1,0 +1,84 @@
+#lang whalesong
+(provide make-parameter parameterize)
+
+;;;
+;;; PARAMETERS
+;;;
+
+; This is an implementation of "parameters".
+; Consider this a first approximation.
+
+; Parameters in Racket implement a kind of dynamic binding that
+; works nicely with threads and continuations.
+
+; Since Whalesong currently is single-threaded there is
+; nothing to worry about regarding threads.
+
+; In standard Racket (parameterize bindings body) the bindings
+; will be in effect while evaluating body. If control
+; leaves body due to exceptions, escapes or similar, the
+; bindings are reverted to their previous values. On re-entry
+; to body (e.g. from a captured continuation) the bindings
+; are supposed to be reinstated.
+
+; Given dynamic-wind this behaviour is straight-forward to implement.
+; Alas Whalesong does not support dynamic-wind yet, so in this
+; implementation nothing happens, when control leaves body.
+
+; In short: For programs that don't use call/cc and friends
+; this implementation of parameters ought to work as expected.
+
+(require (for-syntax racket/base))
+(require (for-syntax syntax/parse))
+
+; Parameterization can be nested, so we represent the parameter cell
+; as a stack of values. 
+(struct parameter (values) #:mutable)
+
+; Each parameter will get an unique id.
+(define *parameters* '())   ; Assocation list from ids to parameter cells.
+
+; syntax : (push! id-expr)
+;  push a new parameter cell to *parameters*
+(define-syntax (push! stx)
+  (syntax-case stx ()
+    [(_ val)
+     #'(set! *parameters* (cons val *parameters*))]))
+
+; find-parameter : id -> parameter
+;   return parameter associated with id
+(define (find-parameter id)
+  (cond
+    [(assq id *parameters*) => cdr]
+    [else (error 'find-parameter "parameter not found, got id: ~a" id)]))
+
+; make-parameter : value -> parameter-procecure
+;   Make new parameter and return its parameter procedure.
+;   The parameter procedure also acts as id for the parameter.
+(define (make-parameter val)
+  (define p (parameter (list val)))
+  (define proc (case-lambda
+                 [()  (first (parameter-values (find-parameter proc)))]
+                 [(v) (define p (find-parameter proc))
+                      (define vs (cons v (parameter-values p)))
+                      (set-parameter-values! p vs)]))
+  (push! (cons proc p))
+  proc)
+
+; syntax : (parameterize bindings body ...)
+;   Evaluate body where the parameters in bindings
+;   are bound to the values given in bindings.
+;   Restore bindings afterwards.
+(define-syntax (parameterize stx)
+  (syntax-case stx ()
+    [(_ ([param-expr val-expr]) body ...)
+     #'(let ()
+         (define proc param-expr)
+         (define p (find-parameter proc))
+         (define v  val-expr)
+         (define old (parameter-values p))
+         (define vs (cons v old))
+         (set-parameter-values! p vs)
+         (begin0
+           body ...
+           (set-parameter-values! p old)))]))

--- a/whalesong/lang/private/match/compiler.rkt
+++ b/whalesong/lang/private/match/compiler.rkt
@@ -1,0 +1,481 @@
+#lang racket/base
+
+(require (for-template whalesong/lang/whalesong
+                       ; racket/base 
+                       "runtime.rkt"
+                       racket/stxparam
+                       ; racket/unsafe/ops
+                       )
+         syntax/boundmap
+         syntax/stx
+         "patterns.rkt"
+         "split-rows.rkt"
+         "reorder.rkt"
+         racket/stxparam
+         racket/syntax)
+
+(provide compile*)
+
+;; for non-linear patterns
+(define vars-seen (make-parameter null))
+
+(define (hash-on f elems #:equal? [eql #t])
+  (define ht (if eql (make-hash) (make-hasheq)))
+  ;; put all the elements e in the ht, indexed by (f e)
+  (for ([r
+         ;; they need to be in the original order when they come out
+         (reverse elems)])
+    (define k (f r))
+    (hash-set! ht k (cons r (hash-ref ht k (lambda () null)))))
+  ht)
+
+;; generate a clause of kind k
+;; for rows rows, with matched variable x and rest variable xs
+;; escaping to esc
+(define (gen-clause k rows x xs esc)
+  (define-syntax-rule (constant-pat predicate-stx)
+    (with-syntax ([rhs (compile* (cons x xs)
+                                 (map (lambda (row)
+                                        (define-values (p ps)
+                                          (Row-split-pats row))
+                                        (define p* (Atom-p p))
+                                        (make-Row (cons p* ps)
+                                                  (Row-rhs row)
+                                                  (Row-unmatch row)
+                                                  (Row-vars-seen row)))
+                                      rows)
+                                 esc)])
+      #`[(#,predicate-stx #,x) rhs]))
+  (define (compile-con-pat accs pred pat-acc)
+    (with-syntax* ([(tmps ...) (generate-temporaries accs)]
+                   [(accs ...) accs]
+                   [pred pred]
+                   [body (compile*
+                          (append (syntax->list #'(tmps ...)) xs)
+                          (map (lambda (row)
+                                 (define-values (p1 ps) (Row-split-pats row))
+                                 (make-Row (append (pat-acc p1) ps)
+                                           (Row-rhs row)
+                                           (Row-unmatch row)
+                                           (Row-vars-seen row)))
+                               rows)
+                          esc)])
+      #`[(pred #,x) (let ([tmps (accs #,x)] ...) body)]))
+  (cond
+    [(eq? 'box k)
+     (compile-con-pat (list #'unbox) #'box? (compose list Box-p))]
+    [(eq? 'pair k)
+     (compile-con-pat (list #'car #'cdr) #'pair?
+                      (lambda (p) (list (Pair-a p) (Pair-d p))))]
+    [(eq? 'mpair k)
+     ; XXX These should be unsafe-mcar* when mpairs have chaperones
+     (compile-con-pat (list #'mcar #'mcdr) #'mpair?
+                      (lambda (p) (list (MPair-a p) (MPair-d p))))]
+    [(eq? 'string k)  (constant-pat #'string?)]
+    [(eq? 'number k)  (constant-pat #'number?)]
+    [(eq? 'symbol k)  (constant-pat #'symbol?)]
+    [(eq? 'keyword k) (constant-pat #'keyword?)]
+    [(eq? 'char k)    (constant-pat #'char?)]
+    [(eq? 'bytes k)   (constant-pat #'bytes?)]
+    [(eq? 'regexp k)  (constant-pat #'regexp?)]
+    [(eq? 'boolean k) (constant-pat #'boolean?)]
+    [(eq? 'null k)    (constant-pat #'null?)]
+    ;; vectors are handled specially
+    ;; because each arity is like a different constructor
+    [(eq? 'vector k)
+     (let ([ht (hash-on (lambda (r) 
+                          (length (Vector-ps (Row-first-pat r)))) rows)])
+       (with-syntax ([(clauses ...)
+                      (hash-map
+                       ht
+                       (lambda (arity rows)
+                         (define ns (build-list arity values))
+                         (with-syntax ([(tmps ...) (generate-temporaries ns)])
+                           (with-syntax ([body
+                                          (compile*
+                                           (append (syntax->list #'(tmps ...)) xs)
+                                           (map (lambda (row)
+                                                  (define-values (p1 ps)
+                                                    (Row-split-pats row))
+                                                  (make-Row (append (Vector-ps p1) ps)
+                                                            (Row-rhs row)
+                                                            (Row-unmatch row)
+                                                            (Row-vars-seen row)))
+                                                rows)
+                                           esc)]
+                                         [(n ...) ns])
+                             #`[(#,arity)
+                                (let ([tmps (vector-ref #,x n)] ...)
+                                  body)]))))])
+         #`[(vector? #,x)
+            (case (vector-length #,x) ; [Whalesong] unsafe-
+              clauses ...
+              [else (#,esc)])]))]
+    ;; it's a structure
+    [(box? k)
+     ;; all the rows are structures with the same predicate
+     (let* ([s (Row-first-pat (car rows))]
+            [accs (Struct-accessors s)]
+            [accs (if (Struct-complete? s)
+                      (build-list (length accs) 
+                                  (λ (i) (with-syntax ([a (list-ref accs i)])
+                                           #`(λ (x) (a x))))) ; [Whalesong]
+                      accs)]
+            [pred (Struct-pred s)])
+       (compile-con-pat accs pred Struct-ps))]
+    [else (error 'match-compile "bad key: ~a" k)]))
+
+
+;; produces the syntax for a let clause
+(define (compile-one vars block esc)
+  (define-values (first rest-pats) (Row-split-pats (car block)))
+  (define x (car vars))
+  (define xs (cdr vars))
+  (cond
+    ;; the Exact rule
+    [(Exact? first)
+     (let ([ht (hash-on (compose Exact-v Row-first-pat) block #:equal? #t)])
+       (with-syntax ([(clauses ...)
+                      (hash-map
+                       ht
+                       (lambda (k v)
+                         #`[(equal? #,x '#,k)
+                            #,(compile* xs
+                                        (map (lambda (row)
+                                               (make-Row (cdr (Row-pats row))
+                                                         (Row-rhs row)
+                                                         (Row-unmatch row)
+                                                         (Row-vars-seen row)))
+                                             v)
+                                        esc)]))])
+         #`(cond clauses ... [else (#,esc)])))]
+    ;; the Var rule
+    [(Var? first)
+     (let ([transform
+            (lambda (row)
+              (define-values (p ps) (Row-split-pats row))
+              (define v (Var-v p))
+              (define seen (Row-vars-seen row))              
+              ;; a new row with the rest of the patterns
+              (cond
+                ;; if this was a wild-card variable, don't bind
+                [(Dummy? p) (make-Row ps
+                                      (Row-rhs row)
+                                      (Row-unmatch row)
+                                      (Row-vars-seen row))]
+                ;; if we've seen this variable before, check that it's equal to
+                ;; the one we saw
+                [(for/or ([e seen])
+                   (let ([v* (car e)] [id (cdr e)])
+                     (and (bound-identifier=? v v*) id)))                 
+                 =>
+                 (lambda (id)
+                   (make-Row ps
+                             #`(if ((match-equality-test) #,x #,id)
+                                   #,(Row-rhs row)
+                                   (fail))
+                             (Row-unmatch row)
+                             seen))]
+                ;; otherwise, bind the matched variable to x, and add it to the
+                ;; list of vars we've seen
+                [else (let ([v* (free-identifier-mapping-get
+                                 (current-renaming) v (lambda () v))])
+                        (make-Row ps
+                                  #`(let ([#,v* #,x]) #,(Row-rhs row))
+                                  (Row-unmatch row)
+                                  (cons (cons v x) (Row-vars-seen row))))]))])
+       ;; compile the transformed block
+       (compile* xs (map transform block) esc))]
+    ;; the Constructor rule
+    [(CPat? first)
+     (let ;; put all the rows in the hash, indexed by their constructor
+         ([ht (hash-on (lambda (r) (pat-key (Row-first-pat r))) block)])
+       (with-syntax ([(clauses ...)
+                      (hash-map
+                       ht (lambda (k v) (gen-clause k v x xs esc)))])
+         #`(cond clauses ... [else (#,esc)])))]
+    ;; the Or rule
+    [(Or? first)
+     ;; we only handle 1-row Ors atm - this is all the mixture rule should give
+     ;; us
+     (unless (null? (cdr block))
+       (error 'compile-one "Or block with multiple rows: ~a" block))
+     (let* ([row (car block)]
+            [pats (Row-pats row)]
+            [seen (Row-vars-seen row)]
+            ;; all the pattern alternatives
+            [qs (Or-ps (car pats))]
+            ;; the variables bound by this pattern - they're the same for the
+            ;; whole list
+            [vars 
+             (for/list ([bv (bound-vars (car qs))]
+                        #:when (for/and ([seen-var seen])
+                                 (not (free-identifier=? bv (car seen-var)))))
+               bv)])
+       (with-syntax ([(esc* success? var ...) (append (generate-temporaries '(esc* success?)) vars)])
+         ;; do the or matching, and bind the results to the appropriate
+         ;; variables
+         #`(let ([esc* (lambda () (values #f #,@(for/list ([v vars]) #'#f)))])
+             (let-values ([(success? var ...)
+                           #,(compile* (list x)
+                                       (map (lambda (q)
+                                              (make-Row (list q)
+                                                        #'(values #t var ...)
+                                                        #f
+                                                        seen))
+                                            qs)
+                                       #'esc*)])
+               ;; then compile the rest of the row
+               (if success?
+                   #,(compile* xs
+                               (list (make-Row (cdr pats)
+                                               (Row-rhs row)
+                                               (Row-unmatch row)
+                                               (append (map cons vars vars) seen)))
+                               esc)
+                   (#,esc))))))]
+    ;; the App rule
+    [(App? first)
+     ;; we only handle 1-row Apps atm - this is all the mixture rule should
+     ;; give us
+     (unless (null? (cdr block))
+       (error 'compile-one "App block with multiple rows: ~a" block))
+     (let* ([row (car block)]
+            [pats (Row-pats row)]
+            [app-pats (App-ps first)])
+       (with-syntax ([(t ...) (generate-temporaries app-pats)])
+         #`(let-values ([(t ...) (#,(App-expr first) #,x)])
+             #,(compile* (append (syntax->list #'(t ...)) xs)
+                         (list (make-Row (append app-pats (cdr pats))
+                                         (Row-rhs row)
+                                         (Row-unmatch row)
+                                         (Row-vars-seen row)))
+                         esc))))]
+    ;; the And rule
+    [(And? first)
+     ;; we only handle 1-row Ands 
+     ;; this is all the mixture rule should give us
+     (unless (null? (cdr block))
+       (error 'compile-one "And block with multiple rows: ~a" block))
+     (define row (car block))
+     (define pats (Row-pats row))
+     ;; all the patterns
+     (define qs (And-ps (car pats)))
+     (compile* (append (map (lambda _ x) qs) xs)
+               (list (make-Row (append qs (cdr pats))
+                               (Row-rhs row)
+                               (Row-unmatch row)
+                               (Row-vars-seen row)))
+               esc
+               ;; don't re-order OrderedAnd patterns
+               (not (OrderedAnd? first)))]
+    ;; the Not rule
+    [(Not? first)
+     ;; we only handle 1-row Nots atm - this is all the mixture rule should
+     ;; give us
+     (unless (null? (cdr block))
+       (error 'compile-one "Not block with multiple rows: ~a" block))
+     (let* ([row (car block)]
+            [pats (Row-pats row)]
+            ;; the single pattern
+            [q (Not-p (car pats))])
+       (with-syntax ([(f) (generate-temporaries #'(f))])
+         #`(let ;; if q fails, we jump to here
+               ([f (lambda ()
+                     #,(compile* xs
+                                 (list (make-Row (cdr pats)
+                                                 (Row-rhs row)
+                                                 (Row-unmatch row)
+                                                 (Row-vars-seen row)))
+                                 esc))])
+             #,(compile* (list x)
+                         ;; if q doesn't fail, we jump to esc and fail the not
+                         ;; pattern
+                         (list (make-Row (list q)
+                                         #`(#,esc)
+                                         (Row-unmatch row)
+                                         (Row-vars-seen row)))
+                         #'f))))]
+    [(Pred? first)
+     ;; multiple preds iff they have the identical predicate
+     (with-syntax ([pred? (Pred-pred first)]
+                   [body (compile* xs
+                                   (map (lambda (row)
+                                          (define-values (_1 ps)
+                                            (Row-split-pats row))
+                                          (make-Row ps
+                                                    (Row-rhs row)
+                                                    (Row-unmatch row)
+                                                    (Row-vars-seen row)))
+                                        block)
+                                   esc)])
+       #`(cond [(pred? #,x) body] [else (#,esc)]))]
+    ;; Generalized sequences... slightly tested
+    [(GSeq? first)
+     (let* ([headss (GSeq-headss first)]
+            [mins (GSeq-mins first)]
+            [maxs (GSeq-maxs first)]
+            [onces? (GSeq-onces? first)]
+            [tail (GSeq-tail first)]
+            [mutable? (GSeq-mutable? first)]
+            [make-Pair (if mutable? make-MPair make-Pair)]
+            [k (Row-rhs (car block))]
+            [xvar (car (generate-temporaries (list #'x)))]
+            [complete-heads-pattern
+             (lambda (ps)
+               (define (loop ps pat)
+                 (if (pair? ps)
+                     (make-Pair (car ps) (loop (cdr ps) pat))
+                     pat))
+               (loop ps (make-Var xvar)))]
+            [heads
+             (for/list ([ps headss])
+               (complete-heads-pattern ps))]
+            [head-idss
+             (for/list ([heads headss])
+               (apply append (map bound-vars heads)))]
+            [hid-argss (map generate-temporaries head-idss)]
+            [head-idss* (map generate-temporaries head-idss)]
+            [hid-args (apply append hid-argss)]
+            [reps (generate-temporaries (for/list ([head heads]) 'rep))])
+       (with-syntax ([x xvar]
+                     [var0 (car vars)]
+                     [((hid ...) ...) head-idss]
+                     [((hid* ...) ...) head-idss*]
+                     [((hid-arg ...) ...) hid-argss]
+                     [(rep ...) reps]
+                     [(maxrepconstraint ...)
+                      ;; FIXME: move to side condition to appropriate pattern
+                      (for/list ([repvar reps] [maxrep maxs])
+                        (if maxrep #`(< #,repvar #,maxrep) #`#t))]
+                     [(minrepclause ...)
+                      (for/list ([repvar reps] [minrep mins] #:when minrep)
+                        #`[(< #,repvar #,minrep) (fail)])]
+                     [((hid-rhs ...) ...)
+                      (for/list ([hid-args hid-argss] [once? onces?])
+                        (for/list ([hid-arg hid-args])
+                          (if once?
+                              #`(car (reverse #,hid-arg))
+                              #`(reverse #,hid-arg))))]
+                     [(parse-loop failkv fail-tail)
+                      (generate-temporaries #'(parse-loop failkv fail-tail))])
+         (with-syntax ([(rhs ...)
+                        #`[(let ([hid-arg (cons hid* hid-arg)] ...)
+                             (if maxrepconstraint
+                                 (let ([rep (add1 rep)])
+                                   (parse-loop x #,@hid-args #,@reps fail))
+                                 (begin (fail))))
+                           ...]]
+                       [tail-rhs
+                        #`(cond minrepclause ...
+                                [else
+                                 (let ([hid hid-rhs] ... ...
+                                                     [fail-tail fail])
+                                   #,(compile*
+                                      (cdr vars)
+                                      (list (make-Row rest-pats k
+                                                      (Row-unmatch (car block))
+                                                      (Row-vars-seen
+                                                       (car block))))
+                                      #'fail-tail))])])
+           (parameterize ([current-renaming
+                           (for/fold ([ht (copy-mapping (current-renaming))])
+                             ([id (apply append head-idss)]
+                              [id* (apply append head-idss*)])
+                             (free-identifier-mapping-put! ht id id*)
+                             (free-identifier-mapping-for-each
+                              ht
+                              (lambda (k v)
+                                (when (free-identifier=? v id)
+                                  (free-identifier-mapping-put! ht k id*))))
+                             ht)])
+             #`(let parse-loop ([x var0]
+                                [hid-arg null] ... ...
+                                [rep 0] ...
+                                [failkv #,esc])
+                 #,(compile* (list #'x)
+                             (append
+                              (map (lambda (pats rhs)
+                                     (make-Row pats
+                                               rhs
+                                               (Row-unmatch (car block))
+                                               (Row-vars-seen
+                                                (car block))))
+                                   (map list heads)
+                                   (syntax->list #'(rhs ...)))
+                              (list (make-Row (list tail)
+                                              #`tail-rhs
+                                              (Row-unmatch (car block))
+                                              (Row-vars-seen
+                                               (car block)))))
+                             #'failkv))))))]
+    [else (error 'compile "unsupported pattern: ~a\n" first)]))
+
+(define (compile* vars rows esc [reorder? #t])
+  (define (let/wrap clauses body)
+    (if (stx-null? clauses)
+        body
+        (quasisyntax (let* #,clauses #,body))))
+  (cond 
+    ;; if there are no rows, then just call the esc continuation
+    [(null? rows) #`(#,esc)]
+    ;; if we have no variables, there are no more patterns to match
+    ;; so we just pick the first RHS
+    [(null? vars)
+     (let ([fns
+            (let loop ([blocks (reverse rows)] [esc esc] [acc null])
+              (if (null? blocks)
+                  ;; if we're done, return the blocks
+                  (reverse acc)
+                  (with-syntax
+                      (;; f is the name this block will have
+                       [(f) (generate-temporaries #'(f))]
+                       ;; compile the block, with jumps to the previous esc
+                       [c (with-syntax ([rhs #`(syntax-parameterize
+                                                ([fail (make-rename-transformer
+                                                        (quote-syntax #,esc))])
+                                                #,(Row-rhs (car blocks)))])
+                            (define unmatch (Row-unmatch (car blocks)))
+                            (if unmatch
+                                (quasisyntax/loc unmatch
+                                  (call-with-continuation-prompt
+                                   (lambda () (let ([#,unmatch
+                                                     (lambda ()
+                                                       (abort-current-continuation match-prompt-tag))])
+                                                rhs))
+                                   match-prompt-tag
+                                   (lambda () (#,esc))))
+                                #'rhs))])
+                    ;; then compile the rest, with our name as the esc
+                    (loop (cdr blocks) #'f (cons #'[f (lambda () c)] acc)))))])
+       (with-syntax ([(fns ... [_ (lambda () body)]) fns])
+         (let/wrap #'(fns ...) #'body)))]
+    ;; otherwise, we split the matrix into blocks
+    ;; and compile each block with a reference to its continuation
+    [else
+     (let*-values
+         ([(rows vars) (if reorder?
+                           (reorder-columns rows vars)
+                           (values rows vars))]
+          [(fns)
+           (let loop ([blocks (reverse (split-rows rows))] [esc esc] [acc null])
+             (if (null? blocks)
+                 ;; if we're done, return the blocks
+                 (reverse acc)
+                 (with-syntax (;; f is the name this block will have
+                               [(f) (generate-temporaries #'(f))]
+                               ;; compile the block, with jumps to the previous
+                               ;; esc
+                               [c (compile-one vars (car blocks) esc)])
+                   ;; then compile the rest, with our name as the esc
+                   (loop (cdr blocks) 
+                         #'f 
+                         (cons #`[f #,(syntax-property
+                                       #'(lambda () c)
+                                       'typechecker:called-in-tail-position #t)]
+                               acc)))))])
+       (with-syntax ([(fns ... [_ (lambda () body)]) fns])
+         (let/wrap #'(fns ...) #'body)))]))
+
+;; (require mzlib/trace)
+;; (trace compile* compile-one)

--- a/whalesong/lang/private/match/define-forms.rkt
+++ b/whalesong/lang/private/match/define-forms.rkt
@@ -1,0 +1,183 @@
+#lang whalesong
+
+(require (for-syntax racket/base
+                     racket/syntax
+                     (only-in racket/list append* remove-duplicates)
+                     unstable/sequence
+                     syntax/parse
+                     syntax/parse/experimental/template
+                     racket/lazy-require))
+
+(require (for-syntax "patterns.rkt" "gen-match.rkt")) ; [Whalesong]
+#;(begin-for-syntax
+ (lazy-require ["patterns.rkt" (bound-vars)]
+               ["gen-match.rkt" (go parse-id go/one)]))
+
+(provide define-forms)
+
+;; syntax classes for `define/match`
+(begin-for-syntax
+  (define-syntax-class function-header
+    (pattern ((~or header:function-header name:id) . args:args)
+             #:attr params
+             (template ((?@ . (?? header.params ()))
+                        . args.params))))
+
+  (define-syntax-class args
+    (pattern (arg:arg ...)
+             #:attr params #'(arg.name ...))
+    (pattern (arg:arg ... . rest:id)
+             #:attr params #'(arg.name ... rest)))
+
+  (define-splicing-syntax-class arg
+    #:attributes (name)
+    (pattern name:id)
+    (pattern [name:id default])
+    (pattern (~seq kw:keyword name:id))
+    (pattern (~seq kw:keyword [name:id default]))))
+
+(define-syntax-rule (define-forms parse-id
+                      match match* match-lambda match-lambda*
+		      match-lambda** match-let match-let*
+                      match-let-values match-let*-values
+		      match-define match-define-values match-letrec
+		      match/values match/derived match*/derived
+                      define/match)
+  (...
+   (begin
+     (provide match match* match-lambda match-lambda* match-lambda**
+	      match-let match-let* match-let-values match-let*-values
+              match-define match-define-values match-letrec
+	      match/values match/derived match*/derived match-define-values
+              define/match)
+     (define-syntax (match* stx)
+       (syntax-parse stx
+         [(_ es . clauses)
+          (go parse-id stx #'es #'clauses)]))
+
+     (define-syntax (match*/derived stx)
+       (syntax-parse stx
+         [(_ es orig-stx . clauses)
+          (go parse-id #'orig-stx #'es #'clauses)]))
+
+     (define-syntax (match stx)
+       (syntax-parse stx
+         [(_ arg:expr clauses ...)
+          (go/one parse-id stx #'arg #'(clauses ...))]))
+
+     (define-syntax (match/derived stx)
+       (syntax-parse stx
+         [(_ arg:expr orig-stx clauses ...)
+          (go/one parse-id #'orig-stx #'arg #'(clauses ...))]))
+
+     (define-syntax (match/values stx)
+       (syntax-parse stx
+         [(_ arg:expr (~and cl0 [(pats ...) rhs ...]) clauses ...)
+          (with-syntax ([(ids ...) (generate-temporaries #'(pats ...))])
+            #`(let-values ([(ids ...) arg])
+                (match*/derived (ids ...) #,stx cl0 clauses ...)))]))
+
+     (define-syntax (match-lambda stx)
+       (syntax-parse stx
+         [(_ . clauses)
+          (with-syntax* ([arg (generate-temporary)]
+                         [body #`(match/derived arg #,stx . clauses)])
+            (syntax/loc stx (lambda (arg) body)))]))
+
+     (define-syntax (match-lambda* stx)
+       (syntax-parse stx
+         [(_ . clauses)
+          (with-syntax* ([arg (generate-temporary)]
+                         [body #`(match/derived arg #,stx . clauses)])
+            (syntax/loc stx (lambda arg body)))]))
+
+     (define-syntax (match-lambda** stx)
+       (syntax-parse stx
+         [(_ (~and clauses [(pats ...) . rhs]) ...)
+          (with-syntax* ([vars (generate-temporaries (car (syntax-e #'((pats ...) ...))))]
+                         [body #`(match*/derived vars #,stx clauses ...)])
+            (syntax/loc stx (lambda vars body)))]))
+
+
+     (define-syntax (match-let-values stx)
+       (syntax-parse stx
+         [(_ (~and clauses ([(patss ...) rhss:expr] ...)) body1 body ...)
+          (define-values (idss let-clauses)
+            (for/lists (idss let-clauses)
+                ([pats (syntax->list #'((patss ...) ...))]
+                 [rhs (syntax->list #'(rhss ...))])
+              (define ids (generate-temporaries pats))
+              (values ids #`[#,ids #,rhs])))
+          #`(let-values #,let-clauses
+              (match*/derived #,(append* idss) #,stx
+                [(patss ... ...) (let () body1 body ...)]))]))
+
+     (define-syntax (match-let*-values stx)
+       (syntax-parse stx
+         [(_ () body1 body ...)
+          #'(let () body1 body ...)]
+         [(_ ([(pats ...) rhs] rest-pats ...) body1 body ...)
+          (with-syntax ([(ids ...) (generate-temporaries #'(pats ...))])
+            #`(let-values ([(ids ...) rhs])
+                (match*/derived (ids ...) #,stx
+                  [(pats ...) #,(syntax/loc stx (match-let*-values (rest-pats ...)
+                                                  body1 body ...))])))]))
+
+     ;; there's lots of duplication here to handle named let
+     ;; some factoring out would do a lot of good
+     (define-syntax (match-let stx)
+       (syntax-parse stx
+         [(_ nm:id (~and clauses ([pat init-exp:expr] ...)) body1 body ...)
+          (with-syntax*
+           ([vars (generate-temporaries #'(pat ...))]
+            [loop-body #`(match*/derived vars #,stx
+                           [(pat ...) (let () body1 body ...)])])
+           #'(letrec ([nm (lambda vars loop-body)])
+               (nm init-exp ...)))]
+         [(_ ([pat init-exp:expr] ...) body1 body ...)
+          #`(match-let-values ([(pat) init-exp] ...) body1 body ...)]))
+
+     (define-syntax-rule (match-let* ([pat exp] ...) body1 body ...)
+       (match-let*-values ([(pat) exp] ...) body1 body ...))
+
+     (define-syntax (match-letrec stx)
+       (syntax-parse stx
+         [(_ ((~and cl [pat exp]) ...) body1 body ...)
+          (quasisyntax/loc stx
+			   (let ()
+                            #,@(for/list ([c (in-syntax #'(cl ...))]
+                                          [p (in-syntax #'(pat ...))]
+                                          [e (in-syntax #'(exp ...))])
+                                 (quasisyntax/loc c (match-define #,p #,e)))
+                            body1 body ...))]))
+
+     (define-syntax (match-define stx)
+       (syntax-parse stx
+         [(_ pat rhs:expr)
+          (let ([p (parse-id #'pat)])
+            (with-syntax ([vars (bound-vars p)])
+              (quasisyntax/loc stx
+                (define-values vars (match*/derived (rhs) #,stx
+				      [(pat) (values . vars)])))))]))
+
+     (define-syntax (match-define-values stx)
+       (syntax-parse stx
+         [(_ (pats ...) rhs:expr)
+          (define bound-vars-list (remove-duplicates
+                                   (foldr (λ (pat vars)
+                                             (append (bound-vars (parse-id pat)) vars))
+                                          '() (syntax->list #'(pats ...)))
+                                   bound-identifier=?))
+          (with-syntax ([(ids ...) (generate-temporaries #'(pats ...))])
+            (quasisyntax/loc stx
+              (define-values #,bound-vars-list
+                (match/values rhs
+                  [(pats ...) (values . #,bound-vars-list)]))))]))
+
+     (define-syntax (define/match stx)
+       (syntax-parse stx
+         [(_ ?header:function-header ?clause ...)
+          (template
+           (define ?header
+             (match* (?? ?header.params)
+               ?clause ...)))])))))

--- a/whalesong/lang/private/match/define-forms.rkt
+++ b/whalesong/lang/private/match/define-forms.rkt
@@ -3,7 +3,7 @@
 (require (for-syntax racket/base
                      racket/syntax
                      (only-in racket/list append* remove-duplicates)
-                     unstable/sequence
+                     syntax/stx
                      syntax/parse
                      syntax/parse/experimental/template
                      racket/lazy-require))
@@ -145,9 +145,9 @@
          [(_ ((~and cl [pat exp]) ...) body1 body ...)
           (quasisyntax/loc stx
 			   (let ()
-                            #,@(for/list ([c (in-syntax #'(cl ...))]
-                                          [p (in-syntax #'(pat ...))]
-                                          [e (in-syntax #'(exp ...))])
+                            #,@(for/list ([c (in-list (stx->list #'(cl ...)))]
+                                          [p (in-list (stx->list #'(pat ...)))]
+                                          [e (in-list (stx->list #'(exp ...)))])
                                  (quasisyntax/loc c (match-define #,p #,e)))
                             body1 body ...))]))
 

--- a/whalesong/lang/private/match/gen-match.rkt
+++ b/whalesong/lang/private/match/gen-match.rkt
@@ -1,0 +1,88 @@
+#lang racket/base
+
+(require "patterns.rkt" "compiler.rkt"
+         syntax/stx syntax/parse racket/syntax
+         (for-template racket/base (only-in "runtime.rkt" match:error fail)))
+
+(provide go go/one)
+
+;; this transforms `match'-style clauses into ones acceptable to `go'
+;; go : syntax syntax syntax -> syntax
+(define (go/one parse stx expr clauses)
+  (define-syntax-class cl
+    #:description "a clause with a pattern and a result"
+    (pattern [p . rhs]
+             #:with res (syntax/loc this-syntax [(p) . rhs])))
+  (syntax-parse clauses
+    [(c:cl ...)
+     (go parse stx (quasisyntax/loc expr (#,expr))
+         #'(c.res ...))]))
+
+;; this parses the clauses using parse, then compiles them
+;; go : syntax syntax syntax -> syntax
+(define (go parse stx es clauses)
+  (syntax-parse clauses
+    [([pats . rhs] ...)
+     (parameterize ([orig-stx stx])
+       (unless (syntax->list es)
+         (raise-syntax-error 'match* "expected a sequence of expressions to match" es)))
+     (define/with-syntax form-name
+       (syntax-case stx ()
+         [(fname . _)
+          (identifier? #'fname)
+          (syntax-e #'fname)]
+         [_ 'match]))
+     (define len (length (syntax->list es)))
+     (define srcloc-list (list #`(quote #,(syntax-source stx))
+                               #`(quote #,(syntax-line stx))
+                               #`(quote #,(syntax-column stx))
+                               #`(quote #,(syntax-position stx))
+                               #`(quote #,(syntax-span stx))))
+     (define/with-syntax (xs ...) (generate-temporaries es))
+     (define/with-syntax (exprs ...) es)
+     (define/with-syntax outer-fail (generate-temporary #'fail))
+     (define/with-syntax orig-expr (if (= 1 len) (stx-car #'(xs ...)) #'(list xs ...)))
+     (define/with-syntax raise-error
+       (quasisyntax/loc stx (match:error orig-expr (list (srcloc #,@srcloc-list)) 'form-name)))
+     (define parsed-clauses
+       (for/list ([clause (syntax->list clauses)]
+                  [pats (syntax->list #'(pats ...))]
+                  [rhs (syntax->list #'(rhs ...))])
+         (unless (syntax->list pats)
+           (raise-syntax-error 'match* "expected a sequence of patterns" pats))
+         (define lp (length (syntax->list pats)))
+         (unless (= len lp)
+           (raise-syntax-error 
+            'match (format "wrong number of match clauses, expected ~a and got ~a" len lp) pats))
+         (define (mk unm rhs)
+           (make-Row (for/list ([p (syntax->list pats)]) (parse p))
+                     (syntax-property
+                      (quasisyntax/loc stx
+                        (let () . #,rhs))
+                      'feature-profile:pattern-matching 'antimark)
+                     unm null))
+         (syntax-parse rhs
+           [()
+            (raise-syntax-error 
+             'match
+             "expected at least one expression on the right-hand side"
+             clause)]
+           [(#:when e)
+            (raise-syntax-error 
+             'match
+             "expected at least one expression on the right-hand side after #:when clause"
+             clause)]
+           [(#:when e rest ...) (mk #f #'((if e (let () rest ...) (fail))))]
+           [(((~datum =>) unm) . rhs) (mk #'unm #'rhs)]
+           [_ (mk #f rhs)])))
+     (define/with-syntax body 
+       (compile* (syntax->list #'(xs ...)) parsed-clauses #'outer-fail))
+     (define/with-syntax (exprs* ...)
+       (for/list ([e (in-list (syntax->list #'(exprs ...)))])
+         (syntax-property e 'feature-profile:pattern-matching 'antimark)))
+    (syntax-property
+     (quasisyntax/loc stx
+      (let ([xs exprs*] ...)
+        (define (outer-fail) raise-error)
+        body))
+     'feature-profile:pattern-matching #t)]))

--- a/whalesong/lang/private/match/legacy-match.rkt
+++ b/whalesong/lang/private/match/legacy-match.rkt
@@ -1,0 +1,21 @@
+#lang racket/base
+
+(require (only-in "runtime.rkt"
+                  match-equality-test
+                  exn:misc:match?)
+         (only-in "match-expander.rkt"
+                  define-match-expander)
+         "define-forms.rkt"
+         (for-syntax "parse-legacy.rkt"
+                     (only-in "patterns.rkt" match-...-nesting)))
+
+(provide (for-syntax match-...-nesting)
+         match-equality-test
+         define-match-expander
+         exn:misc:match?)
+
+(define-forms parse/legacy
+  match match* match-lambda match-lambda* match-lambda** match-let match-let*
+  match-let-values match-let*-values
+  match-define match-define-values match-letrec match/values match/derived match*/derived
+  define/match)

--- a/whalesong/lang/private/match/match-expander.rkt
+++ b/whalesong/lang/private/match/match-expander.rkt
@@ -1,0 +1,84 @@
+#lang whalesong
+
+(require (for-syntax racket/base "stxtime.rkt"))
+
+(provide define-match-expander)
+
+(begin-for-syntax
+  (define make-match-expander
+    (let ()
+      (define-struct match-expander (match-xform legacy-xform macro-xform)
+        #:property prop:set!-transformer 
+        (λ (me stx)
+          (define xf (match-expander-macro-xform me))
+          (if (set!-transformer? xf)
+              ((set!-transformer-procedure xf) stx)
+              (syntax-case stx (set!)
+                [(set! . _)
+                 (raise-syntax-error #f "cannot mutate syntax identifier" stx)]
+                [_ (xf stx)])))
+        #:property prop:match-expander (struct-field-index match-xform)
+        #:property prop:legacy-match-expander (struct-field-index legacy-xform))
+      (values make-match-expander))))
+
+(define-syntax (define-match-expander stx)
+  (define (lookup v alist)
+    (cond [(assoc v alist) => cadr]
+          [else #f]))
+  (define (parse args)
+    (let loop ([args args]
+               [alist '()])
+      (if (null? args)
+        alist
+        (let* ([stx-v (car args)]
+               [v (syntax-e stx-v)])
+          (cond
+            [(not (keyword? v))
+             (raise-syntax-error #f "argument must be a keyword" stx stx-v)]
+            [(not (memq v '(#:expression #:plt-match #:match)))
+             (raise-syntax-error
+              #f (format "keyword argument ~a is not a correct keyword" v)
+              stx stx-v)]
+            [else
+             (loop (cddr args) (cons (list v (cadr args)) alist))])))))
+  (syntax-case stx ()
+    [(_ id kw . rest)
+     (keyword? (syntax-e #'kw))
+     (let* ([args (syntax->list #'(kw . rest))]
+            [parsed-args (parse args)])
+       (with-syntax
+           ([legacy-xform (lookup '#:match parsed-args)]
+            [match-xform (lookup '#:plt-match parsed-args)]
+            [macro-xform
+             (or (lookup '#:expression parsed-args)
+                 #'(lambda (stx)
+                     (raise-syntax-error
+                      #f "this match expander must be used inside match"
+                      stx)))])
+         (if (identifier? #'macro-xform)
+           (syntax/loc stx
+             (define-syntax id
+               (make-match-expander
+                match-xform
+                legacy-xform
+                (lambda (stx)
+                  (syntax-case stx (set!)
+                    [(nm . args) #'(macro-xform . args)]
+                    [nm (identifier? #'nm) #'macro-xform]
+                    [(set! . _)
+                     (raise-syntax-error #f "match expander cannot be target of a set!" stx)])))))
+           (syntax/loc stx
+             (define-syntax id
+               (make-match-expander match-xform legacy-xform macro-xform))))))]
+    ;; implement legacy syntax
+    [(_ id plt-match-xform match-xform std-xform)
+     #'(define-match-expander id #:plt-match plt-match-xform
+                                 #:match match-xform
+                                 #:expression std-xform)]
+    [(_ id plt-match-xform std-xform)
+     #'(define-match-expander id #:plt-match plt-match-xform
+                                 #:expression std-xform)]
+    [(_ id plt-match-xform)
+     #'(define-match-expander id #:plt-match plt-match-xform)]
+    ;; error checking
+    [_ (raise-syntax-error #f "invalid use of define-match-expander" stx)]))

--- a/whalesong/lang/private/match/match.rkt
+++ b/whalesong/lang/private/match/match.rkt
@@ -1,0 +1,34 @@
+#lang whalesong
+
+(require (only-in "runtime.rkt"
+                  match-equality-test
+                  exn:misc:match?)
+         (only-in "match-expander.rkt"
+                  define-match-expander)
+         "define-forms.rkt"
+         "struct.rkt"
+         (for-syntax racket/lazy-require
+                     (only-in "stxtime.rkt"
+                              match-...-nesting
+                              match-expander?
+                              legacy-match-expander?
+                              prop:match-expander
+                              prop:legacy-match-expander)))
+
+(require (for-syntax "parse.rkt")) ; [Whalesong]
+#;(begin-for-syntax
+    (lazy-require ["parse.rkt" (parse)]))
+
+(provide (for-syntax match-...-nesting match-expander? legacy-match-expander?
+                     prop:match-expander prop:legacy-match-expander)
+         match-equality-test
+         define-match-expander
+         struct* ==          
+         exn:misc:match?)
+
+(define-forms parse
+  match match* match-lambda match-lambda* match-lambda** match-let match-let*
+  match-let-values match-let*-values
+  match-define match-define-values match-letrec match/values
+  match/derived match*/derived
+  define/match)

--- a/whalesong/lang/private/match/parameters.rkt
+++ b/whalesong/lang/private/match/parameters.rkt
@@ -1,0 +1,74 @@
+#lang whalesong
+; This module contains a poor man's parameters.
+(provide make-parameter parameterize)
+
+(require (for-syntax syntax/parse
+                     (only-in racket/base ... 
+                              with-syntax
+                              syntax
+                              generate-temporaries
+                              #%app)))
+
+; Assumptions:
+;   i) single thread
+;  ii) no continuation marks available
+; The return value of make-parameter is not the parameter structure,
+; but the getter/setter. When Whalesong gets support for applicable
+; structures, the structure should be returned instead.
+
+(struct param ([value #:mutable] getter guard)
+  ; #:property prop:procedure (struct-field-index getter)
+  ; Nope - whalesong does not support applicable structures
+  )
+
+(define (make-parameter v [guard #f]) ; -> parameter?
+  ; return new parameter procedure
+  ; the value is initialized to v (in all threads)
+  ; setting a new value will pass the value to a guard,
+  ; the value returned by the guard will be used as the new value
+  ; (the guard can raise an exception)
+  ; the guard is not called for the initial value
+  (letrec ([getter (λ xs 
+                     (if (null? xs)
+                         (param-value p)
+                         (set-param-value! p (car xs))))]
+           [p (param v getter (and guard (λ(x) x)))])
+    getter))
+
+(define-syntax (parameterize stx)
+  (syntax-parse stx
+    [(_ ([param-expr:expr val-expr:expr] ...) body0 body ...)
+     (with-syntax ([(param ...)     (generate-temporaries #'(param-expr ...))]
+                   [(old-value ...) (generate-temporaries #'(param-expr ...))])
+       #'(let ([param param-expr] ...)
+           (let ([old-value (param)] ...)
+             (param val-expr) ...
+             (begin0
+               (let () body0 body ...)
+               (param old-value) ...))))]))
+
+;;; Tests
+#;(begin
+    (define foo (make-parameter 11))
+    (list (list (foo) (foo 12) (foo))
+          (list 11 (void) 12))
+    
+    (define bar (make-parameter 21))
+    
+    (list (list (bar) (bar 22) (bar))
+          (list 21    (void)   22))
+    
+    (list (parameterize ([foo 13] [bar 23])
+            (list (foo) (bar)))
+          (list 13 23))
+    
+    (list (list (foo) (bar))
+          (list 12 22))
+    
+    (list (parameterize ([foo 13] [bar 23])
+            (list (parameterize ([foo 14] [bar 24])
+                    (list (foo) (bar)))
+                  (foo) (bar)))
+          (list (list 14 24) 13 23)))
+
+

--- a/whalesong/lang/private/match/parse-helper.rkt
+++ b/whalesong/lang/private/match/parse-helper.rkt
@@ -1,0 +1,224 @@
+#lang racket/base
+
+(require (for-template racket/base)
+         syntax/boundmap
+         racket/struct-info
+         ;macro-debugger/emit
+         "patterns.rkt")
+
+(provide ddk? parse-literal all-vars pattern-var? match:syntax-err
+         match-expander-transform trans-match parse-struct
+         dd-parse parse-quote parse-id in-splicing?)
+
+(define in-splicing? (make-parameter #f))
+
+;; parse x as a match variable
+;; x : identifier
+(define (parse-id x)
+  (cond [(eq? '_ (syntax-e x))
+         (make-Dummy x)]
+        [(ddk? x) (raise-syntax-error 'match "incorrect use of ... in pattern"
+                                      x)]
+        [else (make-Var x)]))
+
+;; stx : syntax of pattern, starting with quote
+;; parse : the parse function
+(define (parse-quote stx parse)
+  (syntax-case stx (quote)
+    [(quote ())
+     (make-Null (make-Dummy stx))]
+    [(quote (a . b))
+     (make-Pair (parse (syntax/loc stx (quote a)))
+                (parse (syntax/loc stx (quote b))))]
+    [(quote vec)
+     (vector? (syntax-e #'vec))
+     (make-Vector (for/list ([e (syntax-e #'vec)])
+                    (parse (quasisyntax/loc stx (quote #,e)))))]
+    [(quote bx)
+     (box? (syntax-e #'bx))
+     (make-Box (parse (quasisyntax/loc 
+                       stx 
+                       (quote #,(unbox (syntax-e #'bx))))))]
+    [(quote v)
+     (or (parse-literal (syntax-e #'v))
+         (raise-syntax-error 'match "non-literal in quote pattern" stx #'v))]
+    [_ (raise-syntax-error 'match "syntax error in quote pattern" stx)]))
+
+;; parse : the parse fn
+;; p : the repeated pattern
+;; dd : the ... stx
+;; rest : the syntax for the rest
+;; pred? : recognizer for the parsed data structure (such as list?)
+;; to-list: function to convert the value to a list
+(define (dd-parse parse p dd rest pred? #:to-list [to-list #'values] #:mutable [mutable? #f])
+  (define count (ddk? dd))
+  (define min (and (number? count) count))
+  (define pat (parameterize ([match-...-nesting (add1 (match-...-nesting))])
+                (parse p)))
+  (define rest-pat (parse rest))
+  (cond [(and (not (in-splicing?)) ;; when we're inside splicing, rest-pat isn't the rest
+              (not min) ;; if we have a count, better generate general code
+              (Null? rest-pat)
+              (or (Var? pat) (Dummy? pat)))
+         (make-And (list (make-Pred pred?) (make-App to-list (list pat))))]
+        [else (make-GSeq (list (list pat))
+                         (list min)
+                         ;; no upper bound
+                         (list #f)
+                         ;; patterns in p get bound to lists
+                         (list #f)
+                         rest-pat
+                         mutable?)]))
+
+;; stx : the syntax object for the whole pattern
+;; parse : the pattern parser
+;; struct-name : identifier
+;; pats : syntax representing the member patterns
+;; returns a pattern
+(define (parse-struct stx parse struct-name pats)
+  (let* ([fail (lambda ()
+                 (raise-syntax-error
+                  'match (format "~a does not refer to a structure definition"
+                                 (syntax->datum struct-name))
+                  stx struct-name))]
+         [v (syntax-local-value struct-name fail)])
+    (unless (struct-info? v) (fail))
+    (let-values ([(id _1 pred acc _2 super)
+                  (apply values (extract-struct-info v))])
+      ;; this produces a list of all the super-types of this struct
+      ;; ending when it reaches the top of the hierarchy, or a struct that we
+      ;; can't access
+      (define (get-lineage struct-name)
+        (let ([super (list-ref (extract-struct-info (syntax-local-value
+                                                     struct-name))
+                               5)])
+          (cond [(equal? super #t) (values #t '())] ;; no super type exists
+                [(equal? super #f) (values #f '())] ;; super type is unknown
+                [else 
+                 (let-values ([(complete? lineage) (get-lineage super)])
+                   (values complete?
+                           (cons super lineage)))])))
+      (unless pred
+        (raise-syntax-error 'match (format "structure ~a does not have an associated predicate"
+                                           (syntax->datum struct-name))
+                            stx struct-name))
+      (let-values ([(complete? lineage) (get-lineage struct-name)])
+        (let* (;; the accessors come in reverse order
+               [acc (reverse acc)]
+               ;; remove the first element, if it's #f
+               [acc (cond [(null? acc) acc]
+                          [(not (car acc)) (cdr acc)]
+                          [else acc])])
+          (make-Struct pred
+                       (syntax-property 
+                        pred 
+                        'disappeared-use (list struct-name))
+                       lineage (and (checked-struct-info? v) complete?)
+                       acc
+                       (cond [(eq? '_ (syntax-e pats))                            
+                              (map make-Dummy acc)]
+                             [(syntax->list pats)
+                              =>
+                              (lambda (ps)
+                                (unless (= (length ps) (length acc))
+                                  (raise-syntax-error
+                                   'match
+                                   (format "~a structure ~a: expected ~a but got ~a"
+                                           "wrong number for fields for"
+                                           (syntax->datum struct-name) (length acc)
+                                           (length ps))
+                                   stx pats))
+                                (map parse ps))]
+                             [else (raise-syntax-error
+                                    'match
+                                    "improper syntax for struct pattern"
+                                    stx pats)])))))))
+
+(define (trans-match pred transformer pat)
+  (make-And (list (make-Pred pred) (make-App transformer (list pat)))))
+
+;; transform a match-expander application
+;; parse : stx -> pattern
+;; expander : identifier
+;; stx : the syntax of the match-expander application (armed)
+;; accessor : match-expander -> syntax transformer/#f
+;; error-msg : string
+;; produces a parsed pattern
+(define (match-expander-transform parse expander stx accessor
+                                  error-msg)
+  (let* ([expander* (syntax-local-value expander)]
+         [transformer (accessor expander*)]
+         ;; this transformer might have been defined w/ `syntax-id-rules'
+         [transformer (if (set!-transformer? transformer)
+                          (set!-transformer-procedure transformer)
+                          transformer)])
+    (unless transformer (raise-syntax-error #f error-msg expander*))
+    (let* ([introducer (make-syntax-introducer)]
+           [mstx (introducer (syntax-local-introduce stx))]
+           [mresult (if (procedure-arity-includes? transformer 2) 
+                        (transformer expander* mstx)
+                        (transformer mstx))]
+           [result (syntax-local-introduce (introducer mresult))])
+      ;(emit-local-step stx result #:id expander)
+      (parse result))))
+
+;; raise an error, blaming stx
+(define (match:syntax-err stx msg)
+  (raise-syntax-error #f msg stx))
+
+;; pattern-var? : syntax -> bool
+;; is p an identifier representing a pattern variable?
+(define (pattern-var? p)
+  (and (identifier? p) (not (ddk? p))))
+
+;; ddk? : syntax -> number or boolean
+;; if #f is returned, was not a ddk identifier
+;; if #t is returned, no minimum
+;; if a number is returned, that's the minimum
+(define (ddk? s*)
+  (define (./_ c) (or (equal? c #\.) (equal? c #\_)))
+  (let ([s (syntax->datum s*)])
+    (and (symbol? s)
+         (if (memq s '(... ___))
+           #t
+           (let* ([m (regexp-match #rx"^(?:\\.\\.|__)([0-9]+)$"
+                                   (symbol->string s))]
+                  [n (and m (string->number (cadr m)))])
+             (cond [(not n) #f]
+                   [(zero? n) #t]
+                   [(exact-nonnegative-integer? n) n]
+                   [else (raise-syntax-error
+                          'match "invalid number for ..k pattern"
+                          s*)]))))))
+
+;; parse-literal : racket-val -> pat option
+;; is v is a literal, return a pattern matching it
+;; otherwise, return #f
+(define (parse-literal v)
+  (if (or (number? v) (string? v) (keyword? v) (symbol? v) (bytes? v)
+          (regexp? v) (boolean? v) (char? v))
+    (make-Exact v)
+    #f))
+
+;; (listof pat) syntax -> void
+;; ps is never null
+;; check that all the ps bind the same set of variables
+(define (all-vars ps stx)  
+  (let* ([first-vars (bound-vars (car ps))]
+         [l (length ps)]
+         [ht (make-free-identifier-mapping)])
+    (for ([v first-vars]) (free-identifier-mapping-put! ht v 1))
+    (for* ([p (cdr ps)]
+           [v (bound-vars p)])
+      (cond [(free-identifier-mapping-get ht v (lambda () #f))
+             => (lambda (n)
+                  (free-identifier-mapping-put! ht v (add1 n)))]
+            [else (raise-syntax-error 'match
+                                      "variable not bound in all or patterns"
+                                      stx v)]))
+    (free-identifier-mapping-for-each
+     ht
+     (lambda (v n)
+       (unless (= n l)
+         (raise-syntax-error 'match "variable not bound in all or patterns"
+                             stx v))))))

--- a/whalesong/lang/private/match/parse-legacy.rkt
+++ b/whalesong/lang/private/match/parse-legacy.rkt
@@ -1,0 +1,75 @@
+#lang racket/base
+
+(require (for-template racket/base)
+         "patterns.rkt"
+         "parse-helper.rkt"
+         "parse-quasi.rkt")
+
+(provide parse/legacy)
+
+(define orig-insp (variable-reference->module-declaration-inspector
+                   (#%variable-reference)))
+
+(define (parse/legacy stx)
+  (define (rearm new-stx) (syntax-rearm new-stx stx))
+  (define (parse stx) (parse/legacy (rearm stx)))
+  (define disarmed-stx (syntax-disarm stx orig-insp))
+  (syntax-case* disarmed-stx (not $ ? and or = quasiquote quote)
+                (lambda (x y) (eq? (syntax-e x) (syntax-e y)))
+    [(expander args ...)
+     (and (identifier? #'expander)
+          (legacy-match-expander?
+           (syntax-local-value #'expander (λ () #f))))
+     (match-expander-transform
+      parse #'expander disarmed-stx legacy-match-expander-proc
+      "This expander only works with the standard match syntax")]
+    [(and p ...)
+     (make-And (map parse (syntax->list #'(p ...))))]
+    [(or)
+     (make-Not (make-Dummy stx))]
+    [(or p ps ...)
+     (let ([ps (map parse (syntax->list #'(p ps ...)))])
+       (all-vars ps stx)
+       (make-Or ps))]
+    [(not p ...)
+     ;; nots are conjunctions of negations
+     (let ([ps (map (compose make-Not parse) (syntax->list #'(p ...)))])
+       (make-And ps))]
+    [bx
+     (box? (syntax-e #'bx))
+     (make-Box (parse (unbox (syntax-e #'bx))))]
+    [#(es ...)
+     (ormap ddk? (syntax->list #'(es ...)))
+     (make-And (list (make-Pred #'vector?)
+                     (make-App #'vector->list
+                               (list (parse (syntax/loc stx (es ...)))))))]
+    [#(es ...)
+     (make-Vector (map parse (syntax->list #'(es ...))))]
+    [($ s . pats)
+     (parse-struct disarmed-stx parse #'s #'pats)]
+    [(? p q1 qs ...)
+     (make-And (cons (make-Pred #'p)
+                     (map parse (syntax->list #'(q1 qs ...)))))]
+    [(? p)
+     (make-Pred (rearm #'p))]
+    [(= f p)
+     (make-App #'f (list (parse #'p)))]
+    [(quasiquote p)
+     (parse-quasi #'p parse)]
+    [(quote . rest)
+     (parse-quote disarmed-stx parse)]
+    [() (make-Null (make-Dummy #f))]
+    [(..)
+     (ddk? #'..)
+     (raise-syntax-error 'match "incorrect use of ... in pattern" stx #'..)]
+    [(p .. . rest)
+     (ddk? #'..)
+     (dd-parse parse #'p #'.. #'rest #'list?)]
+    [(e . es)
+     (make-Pair (parse #'e) (parse (syntax/loc stx es)))]
+    [x
+     (identifier? #'x)
+     (parse-id #'x)]
+    [v
+     (or (parse-literal (syntax-e #'v))
+         (raise-syntax-error 'match "syntax error in pattern" stx))]))

--- a/whalesong/lang/private/match/parse-quasi.rkt
+++ b/whalesong/lang/private/match/parse-quasi.rkt
@@ -1,0 +1,87 @@
+#lang racket/base
+
+(require (for-template racket/base)
+         "patterns.rkt"
+         "parse-helper.rkt")
+
+(provide parse-quasi)
+
+;; is pat a pattern representing a list?
+(define (null-terminated? pat)
+  (cond [(Pair? pat) (null-terminated? (Pair-d pat))]
+        [(GSeq? pat) (null-terminated? (GSeq-tail pat))]
+        [(Null? pat) #t]
+        [else #f]))
+
+;; combine a null-terminated pattern with another pattern to match afterwards
+(define (append-pats p1 p2)
+  (cond [(Pair? p1) (make-Pair (Pair-a p1) (append-pats (Pair-d p1) p2))]
+        [(GSeq? p1) (make-GSeq (GSeq-headss p1)
+                               (GSeq-mins p1)
+                               (GSeq-maxs p1)
+                               (GSeq-onces? p1)
+                               (append-pats (GSeq-tail p1) p2)
+                               (GSeq-mutable? p1))]
+        [(Null? p1) p2]
+        [else (error 'match "illegal input to append-pats")]))
+
+;; parse stx as a quasi-pattern
+;; parse parses unquote
+(define (parse-quasi stx parse)
+  (define (pq s) (parse-quasi s parse))
+  (syntax-case stx (quasiquote unquote quote unquote-splicing)
+    [(unquote p) (parse #'p)]
+    [((unquote-splicing p) . rest)
+     (let ([pat (parameterize ([in-splicing? #t]) (parse #'p))]
+           [rpat (pq #'rest)])
+       (if (null-terminated? pat)
+           (append-pats pat rpat)
+           (raise-syntax-error 'match "non-list pattern inside unquote-splicing"
+                               stx #'p)))]
+    [(p dd . rest)
+     (ddk? #'dd)
+     ;; FIXME: parameterize dd-parse so that it can be used here
+     (let* ([count (ddk? #'dd)]
+            [min (and (number? count) count)])
+       (make-GSeq
+        (parameterize ([match-...-nesting (add1 (match-...-nesting))])
+          (list (list (pq #'p))))
+        (list min)
+        ;; no upper bound
+        (list #f)
+        ;; patterns in p get bound to lists
+        (list #f)
+        (pq #'rest)
+        #f))]
+    [(a . b) (make-Pair (pq #'a) (pq #'b))]
+    ;; prefab structs
+    [struct
+     (prefab-struct-key (syntax-e #'struct))
+     (let ([key (prefab-struct-key (syntax-e #'struct))]
+           [pats (cdr (vector->list (struct->vector (syntax-e #'struct))))])
+       (make-And (list (make-Pred #`(struct-type-make-predicate (prefab-key->struct-type '#,key #,(length pats))))
+                       (make-App #'struct->vector
+                                 (list (make-Vector (cons (make-Dummy #f) (map pq pats)))))))
+       #;
+       (make-PrefabStruct key (map pq pats)))]
+    ;; the hard cases
+    [#(p ...)
+     (ormap (lambda (p)
+              (or (ddk? p)
+                  (syntax-case p (unquote-splicing)
+                    [(unquote-splicing . _) #t]
+                    [_ #f])))
+            (syntax->list #'(p ...)))
+     (make-And (list (make-Pred #'vector?)
+                     (make-App #'vector->list
+                               (list (pq (quasisyntax/loc stx (p ...)))))))]
+    [#(p ...)
+     (make-Vector (map pq (syntax->list #'(p ...))))]
+    [bx
+     (box? (syntax-e #'bx))
+     (make-Box (pq (unbox (syntax-e #'bx))))]    
+    [()
+     (make-Null (make-Dummy #f))]
+    [v
+     (or (parse-literal (syntax-e #'v))
+         (raise-syntax-error 'match "syntax error in quasipattern" stx))]))

--- a/whalesong/lang/private/match/parse.rkt
+++ b/whalesong/lang/private/match/parse.rkt
@@ -1,0 +1,184 @@
+#lang racket/base
+
+(require racket/struct-info
+         "patterns.rkt"
+         "parse-helper.rkt"
+         "parse-quasi.rkt"
+         (for-template (only-in "runtime.rkt" matchable? mlist? mlist->list)
+                       racket/base))
+
+(provide parse)
+
+(define (ht-pat-transform p)
+  (syntax-case p ()
+    [(a b) #'(list a b)]
+    [x (identifier? #'x) #'x]))
+
+(define orig-insp (variable-reference->module-declaration-inspector
+                   (#%variable-reference)))
+
+;; parse : syntax -> Pat
+;; compile stx into a pattern, using the new syntax
+(define (parse stx)
+  (define (rearm new-stx) (syntax-rearm new-stx stx))
+  (define (rearm+parse new-stx) (parse (rearm new-stx)))
+  (define disarmed-stx (syntax-disarm stx orig-insp))
+  (syntax-case* disarmed-stx (not var struct box cons list vector ? and or quote app
+                                  regexp pregexp list-rest list-no-order hash-table
+                                  quasiquote mcons list* mlist)
+                (lambda (x y) (eq? (syntax-e x) (syntax-e y)))
+    [(expander args ...)
+     (and (identifier? #'expander)
+          (match-expander? (syntax-local-value #'expander
+                                               (lambda () #f))))
+     (match-expander-transform
+      rearm+parse #'expander disarmed-stx match-expander-proc
+      "This expander only works with the legacy match syntax")]
+    [(var v)
+     (identifier? #'v)
+     (Var (rearm #'v))]
+    [(and p ...)
+     (And (map rearm+parse (syntax->list #'(p ...))))]
+    [(or)
+     (Not (Dummy stx))]
+    [(or p ps ...)
+     (let ([ps (map rearm+parse (syntax->list #'(p ps ...)))])
+       (all-vars ps stx)
+       (Or ps))]
+    [(not p ...)
+     ;; nots are conjunctions of negations
+     (let ([ps (map (compose Not rearm+parse) (syntax->list #'(p ...)))])
+       (And ps))]
+    [(regexp r)
+     (trans-match #'matchable?
+                  (rearm #'(lambda (e) (regexp-match r e)))
+                  (Pred #'values))]
+    [(regexp r p)
+     (trans-match #'matchable? #'(lambda (e) (regexp-match r e)) (parse #'p))]
+    [(pregexp r)
+     (trans-match #'matchable?
+                  (rearm
+                   #'(lambda (e)
+                       (regexp-match (if (pregexp? r) r (pregexp r)) e)))
+                  (Pred #'values))]
+    [(pregexp r p)
+     (trans-match #'matchable?
+                  (rearm 
+                   #'(lambda (e)
+                       (regexp-match (if (pregexp? r) r (pregexp r)) e)))
+                  (rearm+parse #'p))]
+    [(box e) (Box (parse #'e))]
+    [(vector es ...)
+     (ormap ddk? (syntax->list #'(es ...)))
+     (trans-match #'vector?
+                  #'vector->list
+                  (rearm+parse (syntax/loc stx (list es ...))))]
+    [(vector es ...)
+     (Vector (map rearm+parse (syntax->list #'(es ...))))]
+    [(hash-table p ... dd)
+     (ddk? #'dd)
+     (trans-match
+      #'hash?
+      #'(lambda (e) (hash-map e list))
+      (with-syntax ([(elems ...)
+                     (map ht-pat-transform (syntax->list #'(p ...)))])
+        (rearm+parse (syntax/loc stx (list-no-order elems ... dd)))))]
+    [(hash-table p ...)
+     (ormap ddk? (syntax->list #'(p ...)))
+     (raise-syntax-error
+      'match "dot dot k can only appear at the end of hash-table patterns" stx
+      (ormap (lambda (e) (and (ddk? e) e)) (syntax->list #'(p ...))))]
+    [(hash-table p ...)
+     (trans-match #'hash?
+                  #'(lambda (e) (hash-map e list))
+                  (with-syntax ([(elems ...)
+                                 (map ht-pat-transform
+                                      (syntax->list #'(p ...)))])
+                    (rearm+parse (syntax/loc stx (list-no-order elems ...)))))]
+    [(hash-table . _)
+     (raise-syntax-error 'match "syntax error in hash-table pattern" stx)]
+    [(list-no-order p ... lp dd)
+     (ddk? #'dd)
+     (let* ([count (ddk? #'dd)]
+            [min (if (number? count) count #f)]
+            [max (if (number? count) count #f)]
+            [ps (syntax->list #'(p ...))])
+       (GSeq (cons (list (rearm+parse #'lp))
+                        (for/list ([p ps]) (list (parse p))))
+                  (cons min (map (lambda _ 1) ps))
+                  (cons max (map (lambda _ 1) ps))
+                  ;; vars in lp are lists, vars elsewhere are not
+                  (cons #f (map (lambda _ #t) ps))
+                  (Null (Dummy (syntax/loc stx _)))
+                  #f))]
+    [(list-no-order p ...)
+     (ormap ddk? (syntax->list #'(p ...)))
+     (raise-syntax-error
+      'match "dot dot k can only appear at the end of unordered match patterns"
+      stx
+      (ormap (lambda (e) (and (ddk? e) e)) (syntax->list #'(p ...))))]
+    [(list-no-order p ...)
+     (let ([ps (syntax->list #'(p ...))])
+       (GSeq (for/list ([p ps]) (list (rearm+parse p)))
+                  (map (lambda _ 1) ps)
+                  (map (lambda _ 1) ps)
+                  ;; all of these patterns get bound to only one thing
+                  (map (lambda _ #t) ps)
+                  (Null (Dummy (syntax/loc stx _)))
+                  #f))]
+    [(list) (Null (Dummy (syntax/loc stx _)))]
+    [(mlist) (Null (Dummy (syntax/loc stx _)))]
+    [(list ..)
+     (ddk? #'..)
+     (raise-syntax-error 'match "incorrect use of ... in pattern" stx #'..)]
+    [(mlist ..)
+     (ddk? #'..)
+     (raise-syntax-error 'match "incorrect use of ... in pattern" stx #'..)]
+    [(list p .. . rest)
+     (ddk? #'..)
+     (dd-parse rearm+parse #'p #'.. (syntax/loc stx (list . rest)) #'list?)]
+    [(mlist p .. . rest)
+     (ddk? #'..)
+     (dd-parse rearm+parse #'p #'.. (syntax/loc stx (list . rest)) #'mlist? #:to-list #'mlist->list #:mutable #t)]
+    [(list e es ...)
+     (Pair (rearm+parse #'e) (rearm+parse (syntax/loc stx (list es ...))))]
+    [(mlist e es ...)
+     (MPair (rearm+parse #'e) (rearm+parse (syntax/loc stx (mlist es ...))))]
+    [(list* . rest)
+     (rearm+parse (syntax/loc stx (list-rest . rest)))]
+    [(list-rest e)
+     (rearm+parse #'e)]
+    [(list-rest p dd . rest)
+     (ddk? #'dd)
+     (dd-parse rearm+parse #'p #'dd (syntax/loc stx (list-rest . rest)) #'list?)]
+    [(list-rest e . es)
+     (Pair (rearm+parse #'e) (rearm+parse (syntax/loc #'es (list-rest . es))))]
+    [(cons e1 e2) (Pair (rearm+parse #'e1) (rearm+parse #'e2))]
+    [(mcons e1 e2) (MPair (rearm+parse #'e1) (rearm+parse #'e2))]
+    [(struct s pats)
+     (parse-struct disarmed-stx rearm+parse #'s #'pats)]
+    [(s . pats)
+     (and (identifier? #'s) (struct-info? (syntax-local-value #'s (lambda () #f))))
+     (parse-struct disarmed-stx rearm+parse #'s #'pats)]
+    [(? p q1 qs ...)
+     (OrderedAnd 
+      (list (Pred (rearm #'p))
+            (And (map rearm+parse (syntax->list #'(q1 qs ...))))))]
+    [(? p)
+     (Pred (rearm #'p))]
+    [(app f ps ...) ;; only make a list for more than one pattern
+     (App #'f (map rearm+parse (syntax->list #'(ps ...))))]
+    [(quasiquote p)
+     (parse-quasi #'p rearm+parse)]
+    [(quasiquote . _)
+     (raise-syntax-error 'match "illegal use of quasiquote")]
+    [(quote . _)
+     (parse-quote disarmed-stx rearm+parse)]
+    [x
+     (identifier? #'x)
+     (parse-id (rearm #'x))]
+    [v
+     (or (parse-literal (syntax-e #'v))
+         (raise-syntax-error 'match "syntax error in pattern" disarmed-stx))]))
+
+;; (trace parse)

--- a/whalesong/lang/private/match/patterns.rkt
+++ b/whalesong/lang/private/match/patterns.rkt
@@ -1,0 +1,212 @@
+#lang racket/base
+
+(require syntax/boundmap
+         racket/contract
+         "stxtime.rkt"
+         (for-syntax racket/base))
+
+(provide (except-out (combine-out 
+                      (all-defined-out)
+                      (all-from-out "stxtime.rkt"))
+                     struct-key-ht
+                     get-key
+                     (struct-out Row)))
+
+(define orig-stx (make-parameter #f))
+
+(define-struct Pat () #:transparent)
+;; v is an identifier
+(define-struct (Var Pat) (v)
+  #:transparent
+  #:property
+  prop:custom-write (lambda (v p w?)
+                      (fprintf p "(Var ~a)" (syntax-e (Var-v v)))))
+(define-struct (Dummy Var) ()
+  #:transparent
+  #:property
+  prop:custom-write (lambda (v p w?) (fprintf p "_")))
+
+;; constructor patterns
+(define-struct (CPat Pat) () #:transparent)
+
+;; start is what index to start at
+(define-struct (Vector CPat) (ps) #:transparent)
+
+(define-struct (Pair CPat) (a d) #:transparent)
+(define-struct (MPair CPat) (a d) #:transparent)
+
+(define-struct (Box CPat) (p) #:transparent)
+
+;; p is a pattern to match against the literal
+(define-struct (Atom CPat) (p) #:transparent)
+(define-struct (String Atom) () #:transparent)
+(define-struct (Number Atom) () #:transparent)
+(define-struct (Symbol Atom) () #:transparent)
+(define-struct (Keyword Atom) () #:transparent)
+(define-struct (Char Atom) () #:transparent)
+(define-struct (Bytes Atom) () #:transparent)
+(define-struct (Regexp Atom) () #:transparent)
+(define-struct (Boolean Atom) () #:transparent)
+(define-struct (Null Atom) () #:transparent)
+
+;; expr is an expression
+;; ps is a list of patterns
+(define-struct (App Pat) (expr ps) #:transparent)
+
+;; pred is an expression
+(define-struct (Pred Pat) (pred) #:transparent)
+
+;; pred is an identifier
+;; super is an identifier, or #f
+;; complete? is a boolean
+;; accessors is a listof identifiers (NB in reverse order from the struct info)
+;; ps is a listof patterns
+(define-struct (Struct CPat) (id pred super complete? accessors ps) #:transparent)
+
+;; both fields are lists of pats
+(define-struct (HashTable CPat) (key-pats val-pats) #:transparent)
+
+;; ps are patterns
+(define-struct (Or Pat) (ps) #:transparent)
+(define-struct (And Pat) (ps) #:transparent)
+(define-struct (OrderedAnd And) () #:transparent)
+;; p is a pattern
+(define-struct (Not Pat) (p) #:transparent)
+
+;; headss : listof listof pattern
+;; mins : listof option number
+;; maxs : listof option number
+;; onces? : listof boolean -- is this pattern being bound only once (take the
+;;                            car of the variables)
+;; tail : pattern
+;; mutable? : is this for mutable lists?
+(define-struct (GSeq Pat) (headss mins maxs onces? tail mutable?) #:transparent)
+
+;; match with equal?
+;; v is a quotable racket value
+(define-struct (Exact Pat) (v) #:transparent)
+
+;; pats is a Listof Pat
+;; rhs is an expression
+;; unmatch is an identifier
+;; vars-seen is a listof identifiers
+(define-struct Row (pats rhs unmatch vars-seen) #:transparent
+  #:property
+  prop:custom-write
+  (lambda (v p w?) (fprintf p "(Row ~a <expr>)" (Row-pats v))))
+
+(define struct-key-ht (make-free-identifier-mapping))
+(define (get-key id)
+  (free-identifier-mapping-get
+   struct-key-ht id
+   (lambda ()
+     (let ([k (box-immutable (syntax-e id))])
+       (free-identifier-mapping-put! struct-key-ht id k)
+       k))))
+
+;; pat-key returns either an immutable box, or a symbol., or #f
+;; the result is a box iff the argument was a struct pattern
+;; (eq? (pat-key p) (pat-key q)) if p and q match the same constructor
+;; the result is #f if p is not a constructor pattern
+(define (pat-key p)
+  (cond [(Struct? p) (get-key (Struct-id p))]
+        [(Box? p) 'box]
+        [(Vector? p) 'vector]
+        [(Pair? p) 'pair]
+        [(MPair? p) 'mpair]
+        [(String? p) 'string]
+        [(Symbol? p) 'symbol]
+        [(Number? p) 'number]
+        [(Bytes? p) 'bytes]
+        [(Char? p) 'char]
+        [(Regexp? p) 'regexp]
+        [(Keyword? p) 'keyword]
+        [(Boolean? p) 'boolean]
+        [(Null? p) 'null]
+        [else #f]))
+
+;; (require mzlib/trace)
+;; (trace pat-key)
+
+;; Row-first-pat : Row -> Pat
+;; Row must not have empty list of pats
+(define (Row-first-pat r)
+  (car (Row-pats r)))
+
+(define (Row-split-pats r)
+  (define p (Row-pats r))
+  (values (car p) (cdr p)))
+
+;; merge : (liftof (listof id)) -> (listof id)
+;;  merges lists of identifiers, removing module-identifier=? duplicates
+(define (merge l)
+  (cond [(null? l) null]
+        [(null? (cdr l)) (car l)]
+        [else (let ([m (make-module-identifier-mapping)])
+                (for* ([ids l] [id ids])
+                  (module-identifier-mapping-put! m id #t))
+                (module-identifier-mapping-map m (lambda (k v) k)))]))
+;; bound-vars : Pat -> listof identifiers
+(define (bound-vars p)
+  (cond
+    [(Dummy? p) null]
+    [(Pred? p) null]
+    [(Var? p)
+     (let ([v (Var-v p)])
+       (list (free-identifier-mapping-get (current-renaming) v (lambda () v))))]
+    [(Or? p)
+     (bound-vars (car (Or-ps p)))]
+    [(Box? p)
+     (bound-vars (Box-p p))]
+    [(Atom? p) null]
+    [(Pair? p)
+     (merge (list (bound-vars (Pair-a p)) (bound-vars (Pair-d p))))]
+    [(MPair? p)
+     (merge (list (bound-vars (MPair-a p)) (bound-vars (MPair-d p))))]
+    [(GSeq? p)
+     (merge (cons (bound-vars (GSeq-tail p))
+                  (for/list ([pats (GSeq-headss p)])
+                    (merge (for/list ([pat pats])
+                             (bound-vars pat))))))]
+    [(Vector? p)
+     (merge (map bound-vars (Vector-ps p)))]
+    [(Struct? p)
+     (merge (map bound-vars (Struct-ps p)))]
+    [(App? p)
+     (merge (map bound-vars (App-ps p)))]
+    [(Not? p) null]
+    [(And? p)
+     (merge (map bound-vars (And-ps p)))]
+    [(Exact? p) null]
+    [else (error 'match "bad pattern: ~a" p)]))
+
+(define current-renaming (make-parameter (make-free-identifier-mapping)))
+
+(define (copy-mapping ht)
+  (define new-ht (make-free-identifier-mapping))
+  (free-identifier-mapping-for-each
+   ht (lambda (k v) (free-identifier-mapping-put! new-ht k v)))
+  new-ht)
+
+#|
+;; EXAMPLES
+
+(define p-x (make-Var #'x))
+(define p-y (make-Var #'y))
+(define p-d (make-Dummy #'_))
+
+(define p-cons (make-Pair p-x p-y))
+(define p-vec (make-Vector (list p-x p-y p-d)))
+
+(define r1 (make-Row (list p-x) #'#f #f null))
+(define r2 (make-Row (list p-y) #'#f #f null))
+(define r3 (make-Row (list p-cons) #'#f #f null))
+(define r4 (make-Row (list p-vec p-d) #'#f #f null))
+|#
+
+(provide/contract (struct Row ([pats (listof Pat?)]
+                               [rhs syntax?]
+                               [unmatch (or/c identifier? false/c)]
+                               [vars-seen (listof (cons/c identifier?
+                                                          identifier?))])))
+

--- a/whalesong/lang/private/match/reorder.rkt
+++ b/whalesong/lang/private/match/reorder.rkt
@@ -1,0 +1,87 @@
+#lang racket/base
+
+(require "patterns.rkt"
+         (for-syntax racket/base))
+
+(provide reorder-columns)
+
+#|
+(define p-x (make-Var #'x))
+(define p-y (make-Var #'y))
+(define p-d (make-Dummy #'_))
+
+(define p-cons (make-Pair p-x p-y))
+(define p-vec (make-Vector (list p-x p-y p-d)))
+
+(define r1 (make-Row (list p-x) #'#f #f null))
+(define r2 (make-Row (list p-y) #'#f #f null))
+(define r3 (make-Row (list p-cons) #'#f #f null))
+(define r4 (make-Row (list p-vec p-d) #'#f #f null))
+
+(define r5 (make-Row (list p-x p-y p-cons) #'1 #f null))
+(define r6 (make-Row (list p-cons p-y p-vec) #'1 #f null))
+|#
+
+(define-sequence-syntax in-par
+    (lambda () (raise-syntax-error 'in-par "bad"))
+    (lambda (stx)
+      (syntax-case stx ()
+        [((id) (_ lst-exprs))
+         #'[(id)
+            (:do-in
+             ;;outer bindings
+             ([(lst) lst-exprs])
+             ;; outer check
+             (void) ; (unless (list? lst) (in-list lst))
+             ;; loop bindings
+             ([lst lst])
+             ;; pos check
+             (not (ormap null? lst))
+             ;; inner bindings
+             ([(id) (map car lst)])
+             ;; pre guard
+             #t
+             ;; post guard
+             #t
+             ;; loop args
+             ((map cdr lst)))]]
+        [_ (error 'no (syntax->datum stx))])))
+
+(define (or-all? ps l)
+  (ormap (lambda (p) (andmap p l)) ps))
+
+(define (count-while pred l)
+  (for/sum ([e (in-list l)] #:break (not (pred e))) 1))
+
+(define (score col)
+  (define n (length col))
+  (define c (car col))
+  (define preds (list Var? Pair? Null?))
+  (cond [(or-all? preds col) (add1 n)]
+        [(andmap CPat? col) n]
+        [(Var? c)    (count-while Var? col)]
+        [(Pair? c)   (count-while Pair? col)]
+        [(Vector? c) (count-while Vector? col)]
+        [(Box? c)    (count-while Box? col)]
+        [else 0]))
+
+(define (reorder-by ps scores*)
+  (for/fold 
+      ([pats null])
+    ([score-ref scores*])
+    (cons (list-ref ps score-ref) pats)))
+
+
+(define (reorder-columns rows vars)
+  (define scores (for/list ([i (in-naturals)]
+                            [column (in-par (map (compose Row-pats) rows))])
+                   (cons i (score column))))
+  (define scores* (reverse (map car (sort scores > #:key cdr))))
+  (values
+   (for/list ([row rows])
+     (let ([ps (Row-pats row)])
+       (make-Row (reorder-by ps scores*)
+                 (Row-rhs row)
+                 (Row-unmatch row)
+                 (Row-vars-seen row))))
+   (reorder-by vars scores*)))

--- a/whalesong/lang/private/match/runtime.rkt
+++ b/whalesong/lang/private/match/runtime.rkt
@@ -1,0 +1,72 @@
+#lang whalesong
+(require "parameters.rkt") ; whalesong-libs
+
+(require racket/stxparam
+         (for-syntax racket/base))
+
+(provide match-equality-test
+         exn:misc:match?
+         match:error
+         fail
+         matchable?
+         match-prompt-tag
+         mlist? mlist->list)
+
+(define match-prompt-tag (make-continuation-prompt-tag 'match)) 
+
+; (define match-equality-test (make-parameter equal?))
+; This is an parameter that a user of match can set in order
+; to change the the equality operations used to determine
+; if repeated uses of an identifier in a pattern has "equal" values.
+; The default is equal?, so in the Whalesong matcher we just hardcode it.
+(define match-equality-test (λ () equal?))
+
+
+(define-struct (exn:misc:match exn:fail) (value srclocs)
+ #:property prop:exn:srclocs (lambda (ex) (exn:misc:match-srclocs ex)))
+
+
+(define (match:error val srclocs form-name)
+  (raise (make-exn:misc:match (format "~a: no matching clause for ~e" form-name val)
+                              (current-continuation-marks)
+                              val
+                              srclocs)))
+
+(define-syntax-parameter fail
+  (lambda (stx)
+    (raise-syntax-error
+     #f "used out of context: not in match pattern" stx)))
+
+;; can we pass this value to regexp-match?
+(define (matchable? e)
+  (or (string? e) 
+      ; (bytes? e)   ; [Whalesong] no byte strings
+      ))
+
+;; duplicated because we can't depend on `compatibility` here
+(define mpair? pair?)  ; [Whalesong] no mutable pairs
+(define mcdr cdr)      ; [Whalesong]
+(define mcar car)
+(define (mlist? l)
+  (cond
+   [(null? l) #t]
+   [(mpair? l)
+    (let loop ([turtle l][hare (mcdr l)])
+      (cond
+       [(null? hare) #t]
+       [(eq? hare turtle) #f]
+       [(mpair? hare)
+        (let ([hare (mcdr hare)])
+          (cond
+           [(null? hare) #t]
+           [(eq? hare turtle) #f]
+           [(mpair? hare)
+            (loop (mcdr turtle) (mcdr hare))]
+           [else #f]))]
+       [else #f]))]
+   [else #f]))
+
+(define (mlist->list l)
+  (cond
+   [(null? l) null]
+   [else (cons (mcar l) (mlist->list (mcdr l)))]))

--- a/whalesong/lang/private/match/split-rows.rkt
+++ b/whalesong/lang/private/match/split-rows.rkt
@@ -1,0 +1,81 @@
+#lang racket/base
+
+(require "patterns.rkt")
+
+(provide split-rows)
+
+;; split-rows : Listof[Row] -> Listof[Listof[Row]]
+;; takes a matrix, and returns a list of matrices
+;; each returned matrix does not require the mixture rule to do compilation of
+;; the first column.
+(define (split-rows rows [acc null])
+  (define (loop/var matched-rows prev-mats rows)
+    (if (null? rows)
+      (reverse (cons (reverse matched-rows) prev-mats))
+      (let* ([r (car rows)]
+             [p (Row-first-pat r)]
+             [rs (cdr rows)])
+        (cond [(Row-unmatch r)
+               (split-rows rows (cons (reverse matched-rows) prev-mats))]
+              [(Var? p)
+               (loop/var (cons r matched-rows) prev-mats rs)]
+              [else
+               (split-rows rows (cons (reverse matched-rows) prev-mats))]))))
+  (define (loop/con matched-rows prev-mats struct-key rows)
+    (if (null? rows)
+      (reverse (cons (reverse matched-rows) prev-mats))
+      (let* ([r (car rows)]
+             [p (Row-first-pat r)]
+             [rs (cdr rows)])
+        (cond [(Row-unmatch r)
+               (split-rows rows (cons (reverse matched-rows) prev-mats))]
+              [(and (Struct? p) struct-key (eq? (pat-key p) struct-key))
+               ;; (printf "struct-keys were equal: ~a\n" struct-key)
+               (loop/con (cons r matched-rows) prev-mats struct-key rs)]
+              [(and (Struct? p) (not struct-key))
+               ;; (printf "no struct-key so far: ~a\n" struct-key)
+               (loop/con (cons r matched-rows) prev-mats (pat-key p) rs)]
+              [(and (CPat? p) (not (Struct? p)))
+               ;; (printf "wasn't a struct: ~a\n" p)
+               (loop/con (cons r matched-rows) prev-mats struct-key rs)]
+              [else (split-rows rows (cons (reverse matched-rows)
+                                           prev-mats))]))))
+  (define (loop/exact matched-rows prev-mats rows)
+    (if (null? rows)
+      (reverse (cons (reverse matched-rows) prev-mats))
+      (let* ([r (car rows)]
+             [p (Row-first-pat r)]
+             [rs (cdr rows)])
+        (cond
+          [(Row-unmatch r)
+           (split-rows rows (cons (reverse matched-rows) prev-mats))]
+          [(Exact? p)
+           (loop/exact (cons r matched-rows) prev-mats rs)]
+          [else (split-rows rows (cons (reverse matched-rows) prev-mats))]))))
+  (if (null? rows)
+    (reverse acc)
+    (let* ([r (car rows)]
+           [p (Row-first-pat r)]
+           [rs (cdr rows)])
+      (cond [(Row-unmatch r)
+             (split-rows rs (cons (list r) acc))]
+            [(Var? p)
+             (loop/var (list r) acc rs)]
+            [(Exact? p)
+             (loop/exact (list r) acc rs)]
+            [(CPat? p)
+             (if (Struct? p)
+               (begin
+                 ;; (printf "found a struct: ~a\n" (pat-key r))
+                 (loop/con (list r) acc (pat-key p) rs))
+               (loop/con (list r) acc #f rs))]
+            [else (split-rows rs (cons (list r) acc))]))))
+
+;; (require mzlib/trace)
+;; (trace split-rows)
+
+;; EXAMPLES:
+#|
+(define mat1 (list r1 r2 r3))
+(define mat2 (list r1 r3 r2 r1))
+|#

--- a/whalesong/lang/private/match/struct.rkt
+++ b/whalesong/lang/private/match/struct.rkt
@@ -1,0 +1,80 @@
+#lang whalesong
+(require "match-expander.rkt"
+         (for-syntax racket/base
+                     racket/struct-info
+                     syntax/id-table
+                     racket/list))
+
+(define-match-expander
+  struct*
+  (lambda (stx)
+    (syntax-case stx ()
+      [(_ struct-name (field+pat ...))
+       (let* ([fail (lambda ()
+                      (raise-syntax-error
+                       'struct* "not a structure definition"
+                       stx #'struct-name))]
+              [v (if (identifier? #'struct-name)
+                     (syntax-local-value #'struct-name fail)
+                     (fail))]
+              [field-acc->pattern (make-free-id-table)])
+         (unless (struct-info? v) (fail))
+         ; Check each pattern and capture the field-accessor name
+         (for-each (lambda (an)
+                     (syntax-case an ()
+                       [(field pat)
+                        (unless (identifier? #'field)
+                          (raise-syntax-error 
+                           'struct* "not an identifier for field name" 
+                           stx #'field))
+                        (let ([field-acc
+                               (datum->syntax #'field
+                                              (string->symbol
+                                               (format "~a-~a"
+                                                       (syntax-e #'struct-name)
+                                                       (syntax-e #'field)))
+                                              #'field)])
+                          (when (free-id-table-ref field-acc->pattern field-acc #f)
+                            (raise-syntax-error 'struct* "Field name appears twice" stx #'field)) 
+                          (free-id-table-set! field-acc->pattern field-acc #'pat))]
+                       [_
+                        (raise-syntax-error
+                         'struct* "expected a field pattern of the form (<field-id> <pat>)"
+                         stx an)]))
+                   (syntax->list #'(field+pat ...)))
+         (let* (; Get the structure info
+                [acc (fourth (extract-struct-info v))]
+                ;; the accessors come in reverse order
+                [acc (reverse acc)]
+                ;; remove the first element, if it's #f
+                [acc (cond [(empty? acc) acc]
+                           [(not (first acc)) (rest acc)]
+                           [else acc])]
+                ; Order the patterns in the order of the accessors
+                [pats-in-order
+                 (for/list ([field-acc (in-list acc)])
+                   (begin0
+                     (free-id-table-ref
+                      field-acc->pattern field-acc
+                      (syntax/loc stx _))
+                     ; Use up pattern
+                     (free-id-table-remove! field-acc->pattern field-acc)))])
+           ; Check that all patterns were used
+           (free-id-table-for-each
+            field-acc->pattern
+            (lambda (field-acc pat)
+              (when pat
+                (raise-syntax-error 'struct* "field name not associated with given structure type"
+                                    stx field-acc))))
+           (quasisyntax/loc stx
+             (struct struct-name #,pats-in-order))))])))
+
+(provide struct* ==)
+
+(define-match-expander
+  ==
+  (lambda (stx)
+    (syntax-case stx ()
+      [(_ val comp)
+       #'(? (lambda (x) (comp val x)))]
+      [(_ val) #'(? (lambda (x) (equal? val x)))])))

--- a/whalesong/lang/private/match/stxtime.rkt
+++ b/whalesong/lang/private/match/stxtime.rkt
@@ -1,0 +1,28 @@
+#lang racket/base
+(provide (all-defined-out))
+
+(define match-...-nesting (make-parameter 0))
+
+(struct acc-prop (n acc))
+
+(define (make-struct-type-property/accessor name [guard #f] [supers null])
+  (define-values (p pred? acc)
+    (make-struct-type-property name
+     (λ (pval sinfo)
+	(cond [(exact-nonnegative-integer? pval)
+	       (acc-prop pval (cadddr sinfo))]
+	      [else (if (procedure? guard) 
+			(guard pval sinfo)
+			pval)]))
+     supers))
+  (values p pred? (lambda (v)
+		    (define v* (acc v))
+		    (if (acc-prop? v*)
+			((acc-prop-acc v*) v (acc-prop-n v*))
+			v*))))
+
+(define-values (prop:match-expander match-expander? match-expander-proc) 
+  (make-struct-type-property/accessor 'prop:match-expander))
+
+(define-values (prop:legacy-match-expander legacy-match-expander? legacy-match-expander-proc)
+  (make-struct-type-property/accessor 'prop:legacy-match-expander ))

--- a/whalesong/lang/private/match/test-match.js
+++ b/whalesong/lang/private/match/test-match.js
@@ -1,0 +1,16315 @@
+
+// The following contains the Whalesong runtime.
+
+
+(function(window, undefined) {
+    // dyoo: this library has been modified slightly so it checks to see
+    // if window.jQuery has already been installed.  This is to prevent an ugly issue
+    // with regards to a memory leak if one tries to repeatedly load jQuery.
+    // NOTE: this portion of the file (jquery-protect-header.js) is intentionally
+    // unbalanced.  It'll be closed up by jquery-protect-footer.js.
+    if (!window.jQuery) {
+/*! jQuery v1.6.3 http://jquery.com/ | http://jquery.org/license */
+(function(a,b){function cu(a){return f.isWindow(a)?a:a.nodeType===9?a.defaultView||a.parentWindow:!1}function cr(a){if(!cg[a]){var b=c.body,d=f("<"+a+">").appendTo(b),e=d.css("display");d.remove();if(e==="none"||e===""){ch||(ch=c.createElement("iframe"),ch.frameBorder=ch.width=ch.height=0),b.appendChild(ch);if(!ci||!ch.createElement)ci=(ch.contentWindow||ch.contentDocument).document,ci.write((c.compatMode==="CSS1Compat"?"<!doctype html>":"")+"<html><body>"),ci.close();d=ci.createElement(a),ci.body.appendChild(d),e=f.css(d,"display"),b.removeChild(ch)}cg[a]=e}return cg[a]}function cq(a,b){var c={};f.each(cm.concat.apply([],cm.slice(0,b)),function(){c[this]=a});return c}function cp(){cn=b}function co(){setTimeout(cp,0);return cn=f.now()}function cf(){try{return new a.ActiveXObject("Microsoft.XMLHTTP")}catch(b){}}function ce(){try{return new a.XMLHttpRequest}catch(b){}}function b$(a,c){a.dataFilter&&(c=a.dataFilter(c,a.dataType));var d=a.dataTypes,e={},g,h,i=d.length,j,k=d[0],l,m,n,o,p;for(g=1;g<i;g++){if(g===1)for(h in a.converters)typeof h=="string"&&(e[h.toLowerCase()]=a.converters[h]);l=k,k=d[g];if(k==="*")k=l;else if(l!=="*"&&l!==k){m=l+" "+k,n=e[m]||e["* "+k];if(!n){p=b;for(o in e){j=o.split(" ");if(j[0]===l||j[0]==="*"){p=e[j[1]+" "+k];if(p){o=e[o],o===!0?n=p:p===!0&&(n=o);break}}}}!n&&!p&&f.error("No conversion from "+m.replace(" "," to ")),n!==!0&&(c=n?n(c):p(o(c)))}}return c}function bZ(a,c,d){var e=a.contents,f=a.dataTypes,g=a.responseFields,h,i,j,k;for(i in g)i in d&&(c[g[i]]=d[i]);while(f[0]==="*")f.shift(),h===b&&(h=a.mimeType||c.getResponseHeader("content-type"));if(h)for(i in e)if(e[i]&&e[i].test(h)){f.unshift(i);break}if(f[0]in d)j=f[0];else{for(i in d){if(!f[0]||a.converters[i+" "+f[0]]){j=i;break}k||(k=i)}j=j||k}if(j){j!==f[0]&&f.unshift(j);return d[j]}}function bY(a,b,c,d){if(f.isArray(b))f.each(b,function(b,e){c||bA.test(a)?d(a,e):bY(a+"["+(typeof e=="object"||f.isArray(e)?b:"")+"]",e,c,d)});else if(!c&&b!=null&&typeof b=="object")for(var e in b)bY(a+"["+e+"]",b[e],c,d);else d(a,b)}function bX(a,c){var d,e,g=f.ajaxSettings.flatOptions||{};for(d in c)c[d]!==b&&((g[d]?a:e||(e={}))[d]=c[d]);e&&f.extend(!0,a,e)}function bW(a,c,d,e,f,g){f=f||c.dataTypes[0],g=g||{},g[f]=!0;var h=a[f],i=0,j=h?h.length:0,k=a===bP,l;for(;i<j&&(k||!l);i++)l=h[i](c,d,e),typeof l=="string"&&(!k||g[l]?l=b:(c.dataTypes.unshift(l),l=bW(a,c,d,e,l,g)));(k||!l)&&!g["*"]&&(l=bW(a,c,d,e,"*",g));return l}function bV(a){return function(b,c){typeof b!="string"&&(c=b,b="*");if(f.isFunction(c)){var d=b.toLowerCase().split(bL),e=0,g=d.length,h,i,j;for(;e<g;e++)h=d[e],j=/^\+/.test(h),j&&(h=h.substr(1)||"*"),i=a[h]=a[h]||[],i[j?"unshift":"push"](c)}}}function by(a,b,c){var d=b==="width"?a.offsetWidth:a.offsetHeight,e=b==="width"?bt:bu;if(d>0){c!=="border"&&f.each(e,function(){c||(d-=parseFloat(f.css(a,"padding"+this))||0),c==="margin"?d+=parseFloat(f.css(a,c+this))||0:d-=parseFloat(f.css(a,"border"+this+"Width"))||0});return d+"px"}d=bv(a,b,b);if(d<0||d==null)d=a.style[b]||0;d=parseFloat(d)||0,c&&f.each(e,function(){d+=parseFloat(f.css(a,"padding"+this))||0,c!=="padding"&&(d+=parseFloat(f.css(a,"border"+this+"Width"))||0),c==="margin"&&(d+=parseFloat(f.css(a,c+this))||0)});return d+"px"}function bl(a,b){b.src?f.ajax({url:b.src,async:!1,dataType:"script"}):f.globalEval((b.text||b.textContent||b.innerHTML||"").replace(bd,"/*$0*/")),b.parentNode&&b.parentNode.removeChild(b)}function bk(a){f.nodeName(a,"input")?bj(a):"getElementsByTagName"in a&&f.grep(a.getElementsByTagName("input"),bj)}function bj(a){if(a.type==="checkbox"||a.type==="radio")a.defaultChecked=a.checked}function bi(a){return"getElementsByTagName"in a?a.getElementsByTagName("*"):"querySelectorAll"in a?a.querySelectorAll("*"):[]}function bh(a,b){var c;if(b.nodeType===1){b.clearAttributes&&b.clearAttributes(),b.mergeAttributes&&b.mergeAttributes(a),c=b.nodeName.toLowerCase();if(c==="object")b.outerHTML=a.outerHTML;else if(c!=="input"||a.type!=="checkbox"&&a.type!=="radio"){if(c==="option")b.selected=a.defaultSelected;else if(c==="input"||c==="textarea")b.defaultValue=a.defaultValue}else a.checked&&(b.defaultChecked=b.checked=a.checked),b.value!==a.value&&(b.value=a.value);b.removeAttribute(f.expando)}}function bg(a,b){if(b.nodeType===1&&!!f.hasData(a)){var c=f.expando,d=f.data(a),e=f.data(b,d);if(d=d[c]){var g=d.events;e=e[c]=f.extend({},d);if(g){delete e.handle,e.events={};for(var h in g)for(var i=0,j=g[h].length;i<j;i++)f.event.add(b,h+(g[h][i].namespace?".":"")+g[h][i].namespace,g[h][i],g[h][i].data)}}}}function bf(a,b){return f.nodeName(a,"table")?a.getElementsByTagName("tbody")[0]||a.appendChild(a.ownerDocument.createElement("tbody")):a}function V(a,b,c){b=b||0;if(f.isFunction(b))return f.grep(a,function(a,d){var e=!!b.call(a,d,a);return e===c});if(b.nodeType)return f.grep(a,function(a,d){return a===b===c});if(typeof b=="string"){var d=f.grep(a,function(a){return a.nodeType===1});if(Q.test(b))return f.filter(b,d,!c);b=f.filter(b,d)}return f.grep(a,function(a,d){return f.inArray(a,b)>=0===c})}function U(a){return!a||!a.parentNode||a.parentNode.nodeType===11}function M(a,b){return(a&&a!=="*"?a+".":"")+b.replace(y,"`").replace(z,"&")}function L(a){var b,c,d,e,g,h,i,j,k,l,m,n,o,p=[],q=[],r=f._data(this,"events");if(!(a.liveFired===this||!r||!r.live||a.target.disabled||a.button&&a.type==="click")){a.namespace&&(n=new RegExp("(^|\\.)"+a.namespace.split(".").join("\\.(?:.*\\.)?")+"(\\.|$)")),a.liveFired=this;var s=r.live.slice(0);for(i=0;i<s.length;i++)g=s[i],g.origType.replace(w,"")===a.type?q.push(g.selector):s.splice(i--,1);e=f(a.target).closest(q,a.currentTarget);for(j=0,k=e.length;j<k;j++){m=e[j];for(i=0;i<s.length;i++){g=s[i];if(m.selector===g.selector&&(!n||n.test(g.namespace))&&!m.elem.disabled){h=m.elem,d=null;if(g.preType==="mouseenter"||g.preType==="mouseleave")a.type=g.preType,d=f(a.relatedTarget).closest(g.selector)[0],d&&f.contains(h,d)&&(d=h);(!d||d!==h)&&p.push({elem:h,handleObj:g,level:m.level})}}}for(j=0,k=p.length;j<k;j++){e=p[j];if(c&&e.level>c)break;a.currentTarget=e.elem,a.data=e.handleObj.data,a.handleObj=e.handleObj,o=e.handleObj.origHandler.apply(e.elem,arguments);if(o===!1||a.isPropagationStopped()){c=e.level,o===!1&&(b=!1);if(a.isImmediatePropagationStopped())break}}return b}}function J(a,c,d){var e=f.extend({},d[0]);e.type=a,e.originalEvent={},e.liveFired=b,f.event.handle.call(c,e),e.isDefaultPrevented()&&d[0].preventDefault()}function D(){return!0}function C(){return!1}function m(a,c,d){var e=c+"defer",g=c+"queue",h=c+"mark",i=f.data(a,e,b,!0);i&&(d==="queue"||!f.data(a,g,b,!0))&&(d==="mark"||!f.data(a,h,b,!0))&&setTimeout(function(){!f.data(a,g,b,!0)&&!f.data(a,h,b,!0)&&(f.removeData(a,e,!0),i.resolve())},0)}function l(a){for(var b in a)if(b!=="toJSON")return!1;return!0}function k(a,c,d){if(d===b&&a.nodeType===1){var e="data-"+c.replace(j,"$1-$2").toLowerCase();d=a.getAttribute(e);if(typeof d=="string"){try{d=d==="true"?!0:d==="false"?!1:d==="null"?null:f.isNaN(d)?i.test(d)?f.parseJSON(d):d:parseFloat(d)}catch(g){}f.data(a,c,d)}else d=b}return d}var c=a.document,d=a.navigator,e=a.location,f=function(){function K(){if(!e.isReady){try{c.documentElement.doScroll("left")}catch(a){setTimeout(K,1);return}e.ready()}}var e=function(a,b){return new e.fn.init(a,b,h)},f=a.jQuery,g=a.$,h,i=/^(?:[^#<]*(<[\w\W]+>)[^>]*$|#([\w\-]*)$)/,j=/\S/,k=/^\s+/,l=/\s+$/,m=/\d/,n=/^<(\w+)\s*\/?>(?:<\/\1>)?$/,o=/^[\],:{}\s]*$/,p=/\\(?:["\\\/bfnrt]|u[0-9a-fA-F]{4})/g,q=/"[^"\\\n\r]*"|true|false|null|-?\d+(?:\.\d*)?(?:[eE][+\-]?\d+)?/g,r=/(?:^|:|,)(?:\s*\[)+/g,s=/(webkit)[ \/]([\w.]+)/,t=/(opera)(?:.*version)?[ \/]([\w.]+)/,u=/(msie) ([\w.]+)/,v=/(mozilla)(?:.*? rv:([\w.]+))?/,w=/-([a-z]|[0-9])/ig,x=/^-ms-/,y=function(a,b){return(b+"").toUpperCase()},z=d.userAgent,A,B,C,D=Object.prototype.toString,E=Object.prototype.hasOwnProperty,F=Array.prototype.push,G=Array.prototype.slice,H=String.prototype.trim,I=Array.prototype.indexOf,J={};e.fn=e.prototype={constructor:e,init:function(a,d,f){var g,h,j,k;if(!a)return this;if(a.nodeType){this.context=this[0]=a,this.length=1;return this}if(a==="body"&&!d&&c.body){this.context=c,this[0]=c.body,this.selector=a,this.length=1;return this}if(typeof a=="string"){a.charAt(0)!=="<"||a.charAt(a.length-1)!==">"||a.length<3?g=i.exec(a):g=[null,a,null];if(g&&(g[1]||!d)){if(g[1]){d=d instanceof e?d[0]:d,k=d?d.ownerDocument||d:c,j=n.exec(a),j?e.isPlainObject(d)?(a=[c.createElement(j[1])],e.fn.attr.call(a,d,!0)):a=[k.createElement(j[1])]:(j=e.buildFragment([g[1]],[k]),a=(j.cacheable?e.clone(j.fragment):j.fragment).childNodes);return e.merge(this,a)}h=c.getElementById(g[2]);if(h&&h.parentNode){if(h.id!==g[2])return f.find(a);this.length=1,this[0]=h}this.context=c,this.selector=a;return this}return!d||d.jquery?(d||f).find(a):this.constructor(d).find(a)}if(e.isFunction(a))return f.ready(a);a.selector!==b&&(this.selector=a.selector,this.context=a.context);return e.makeArray(a,this)},selector:"",jquery:"1.6.3",length:0,size:function(){return this.length},toArray:function(){return G.call(this,0)},get:function(a){return a==null?this.toArray():a<0?this[this.length+a]:this[a]},pushStack:function(a,b,c){var d=this.constructor();e.isArray(a)?F.apply(d,a):e.merge(d,a),d.prevObject=this,d.context=this.context,b==="find"?d.selector=this.selector+(this.selector?" ":"")+c:b&&(d.selector=this.selector+"."+b+"("+c+")");return d},each:function(a,b){return e.each(this,a,b)},ready:function(a){e.bindReady(),B.done(a);return this},eq:function(a){return a===-1?this.slice(a):this.slice(a,+a+1)},first:function(){return this.eq(0)},last:function(){return this.eq(-1)},slice:function(){return this.pushStack(G.apply(this,arguments),"slice",G.call(arguments).join(","))},map:function(a){return this.pushStack(e.map(this,function(b,c){return a.call(b,c,b)}))},end:function(){return this.prevObject||this.constructor(null)},push:F,sort:[].sort,splice:[].splice},e.fn.init.prototype=e.fn,e.extend=e.fn.extend=function(){var a,c,d,f,g,h,i=arguments[0]||{},j=1,k=arguments.length,l=!1;typeof i=="boolean"&&(l=i,i=arguments[1]||{},j=2),typeof i!="object"&&!e.isFunction(i)&&(i={}),k===j&&(i=this,--j);for(;j<k;j++)if((a=arguments[j])!=null)for(c in a){d=i[c],f=a[c];if(i===f)continue;l&&f&&(e.isPlainObject(f)||(g=e.isArray(f)))?(g?(g=!1,h=d&&e.isArray(d)?d:[]):h=d&&e.isPlainObject(d)?d:{},i[c]=e.extend(l,h,f)):f!==b&&(i[c]=f)}return i},e.extend({noConflict:function(b){a.$===e&&(a.$=g),b&&a.jQuery===e&&(a.jQuery=f);return e},isReady:!1,readyWait:1,holdReady:function(a){a?e.readyWait++:e.ready(!0)},ready:function(a){if(a===!0&&!--e.readyWait||a!==!0&&!e.isReady){if(!c.body)return setTimeout(e.ready,1);e.isReady=!0;if(a!==!0&&--e.readyWait>0)return;B.resolveWith(c,[e]),e.fn.trigger&&e(c).trigger("ready").unbind("ready")}},bindReady:function(){if(!B){B=e._Deferred();if(c.readyState==="complete")return setTimeout(e.ready,1);if(c.addEventListener)c.addEventListener("DOMContentLoaded",C,!1),a.addEventListener("load",e.ready,!1);else if(c.attachEvent){c.attachEvent("onreadystatechange",C),a.attachEvent("onload",e.ready);var b=!1;try{b=a.frameElement==null}catch(d){}c.documentElement.doScroll&&b&&K()}}},isFunction:function(a){return e.type(a)==="function"},isArray:Array.isArray||function(a){return e.type(a)==="array"},isWindow:function(a){return a&&typeof a=="object"&&"setInterval"in a},isNaN:function(a){return a==null||!m.test(a)||isNaN(a)},type:function(a){return a==null?String(a):J[D.call(a)]||"object"},isPlainObject:function(a){if(!a||e.type(a)!=="object"||a.nodeType||e.isWindow(a))return!1;try{if(a.constructor&&!E.call(a,"constructor")&&!E.call(a.constructor.prototype,"isPrototypeOf"))return!1}catch(c){return!1}var d;for(d in a);return d===b||E.call(a,d)},isEmptyObject:function(a){for(var b in a)return!1;return!0},error:function(a){throw a},parseJSON:function(b){if(typeof b!="string"||!b)return null;b=e.trim(b);if(a.JSON&&a.JSON.parse)return a.JSON.parse(b);if(o.test(b.replace(p,"@").replace(q,"]").replace(r,"")))return(new Function("return "+b))();e.error("Invalid JSON: "+b)},parseXML:function(c){var d,f;try{a.DOMParser?(f=new DOMParser,d=f.parseFromString(c,"text/xml")):(d=new ActiveXObject("Microsoft.XMLDOM"),d.async="false",d.loadXML(c))}catch(g){d=b}(!d||!d.documentElement||d.getElementsByTagName("parsererror").length)&&e.error("Invalid XML: "+c);return d},noop:function(){},globalEval:function(b){b&&j.test(b)&&(a.execScript||function(b){a.eval.call(a,b)})(b)},camelCase:function(a){return a.replace(x,"ms-").replace(w,y)},nodeName:function(a,b){return a.nodeName&&a.nodeName.toUpperCase()===b.toUpperCase()},each:function(a,c,d){var f,g=0,h=a.length,i=h===b||e.isFunction(a);if(d){if(i){for(f in a)if(c.apply(a[f],d)===!1)break}else for(;g<h;)if(c.apply(a[g++],d)===!1)break}else if(i){for(f in a)if(c.call(a[f],f,a[f])===!1)break}else for(;g<h;)if(c.call(a[g],g,a[g++])===!1)break;return a},trim:H?function(a){return a==null?"":H.call(a)}:function(a){return a==null?"":(a+"").replace(k,"").replace(l,"")},makeArray:function(a,b){var c=b||[];if(a!=null){var d=e.type(a);a.length==null||d==="string"||d==="function"||d==="regexp"||e.isWindow(a)?F.call(c,a):e.merge(c,a)}return c},inArray:function(a,b){if(!b)return-1;if(I)return I.call(b,a);for(var c=0,d=b.length;c<d;c++)if(b[c]===a)return c;return-1},merge:function(a,c){var d=a.length,e=0;if(typeof c.length=="number")for(var f=c.length;e<f;e++)a[d++]=c[e];else while(c[e]!==b)a[d++]=c[e++];a.length=d;return a},grep:function(a,b,c){var d=[],e;c=!!c;for(var f=0,g=a.length;f<g;f++)e=!!b(a[f],f),c!==e&&d.push(a[f]);return d},map:function(a,c,d){var f,g,h=[],i=0,j=a.length,k=a instanceof e||j!==b&&typeof j=="number"&&(j>0&&a[0]&&a[j-1]||j===0||e.isArray(a));if(k)for(;i<j;i++)f=c(a[i],i,d),f!=null&&(h[h.length]=f);else for(g in a)f=c(a[g],g,d),f!=null&&(h[h.length]=f);return h.concat.apply([],h)},guid:1,proxy:function(a,c){if(typeof c=="string"){var d=a[c];c=a,a=d}if(!e.isFunction(a))return b;var f=G.call(arguments,2),g=function(){return a.apply(c,f.concat(G.call(arguments)))};g.guid=a.guid=a.guid||g.guid||e.guid++;return g},access:function(a,c,d,f,g,h){var i=a.length;if(typeof c=="object"){for(var j in c)e.access(a,j,c[j],f,g,d);return a}if(d!==b){f=!h&&f&&e.isFunction(d);for(var k=0;k<i;k++)g(a[k],c,f?d.call(a[k],k,g(a[k],c)):d,h);return a}return i?g(a[0],c):b},now:function(){return(new Date).getTime()},uaMatch:function(a){a=a.toLowerCase();var b=s.exec(a)||t.exec(a)||u.exec(a)||a.indexOf("compatible")<0&&v.exec(a)||[];return{browser:b[1]||"",version:b[2]||"0"}},sub:function(){function a(b,c){return new a.fn.init(b,c)}e.extend(!0,a,this),a.superclass=this,a.fn=a.prototype=this(),a.fn.constructor=a,a.sub=this.sub,a.fn.init=function(d,f){f&&f instanceof e&&!(f instanceof a)&&(f=a(f));return e.fn.init.call(this,d,f,b)},a.fn.init.prototype=a.fn;var b=a(c);return a},browser:{}}),e.each("Boolean Number String Function Array Date RegExp Object".split(" "),function(a,b){J["[object "+b+"]"]=b.toLowerCase()}),A=e.uaMatch(z),A.browser&&(e.browser[A.browser]=!0,e.browser.version=A.version),e.browser.webkit&&(e.browser.safari=!0),j.test(" ")&&(k=/^[\s\xA0]+/,l=/[\s\xA0]+$/),h=e(c),c.addEventListener?C=function(){c.removeEventListener("DOMContentLoaded",C,!1),e.ready()}:c.attachEvent&&(C=function(){c.readyState==="complete"&&(c.detachEvent("onreadystatechange",C),e.ready())});return e}(),g="done fail isResolved isRejected promise then always pipe".split(" "),h=[].slice;f.extend({_Deferred:function(){var a=[],b,c,d,e={done:function(){if(!d){var c=arguments,g,h,i,j,k;b&&(k=b,b=0);for(g=0,h=c.length;g<h;g++)i=c[g],j=f.type(i),j==="array"?e.done.apply(e,i):j==="function"&&a.push(i);k&&e.resolveWith(k[0],k[1])}return this},resolveWith:function(e,f){if(!d&&!b&&!c){f=f||[],c=1;try{while(a[0])a.shift().apply(e,f)}finally{b=[e,f],c=0}}return this},resolve:function(){e.resolveWith(this,arguments);return this},isResolved:function(){return!!c||!!b},cancel:function(){d=1,a=[];return this}};return e},Deferred:function(a){var b=f._Deferred(),c=f._Deferred(),d;f.extend(b,{then:function(a,c){b.done(a).fail(c);return this},always:function(){return b.done.apply(b,arguments).fail.apply(this,arguments)},fail:c.done,rejectWith:c.resolveWith,reject:c.resolve,isRejected:c.isResolved,pipe:function(a,c){return f.Deferred(function(d){f.each({done:[a,"resolve"],fail:[c,"reject"]},function(a,c){var e=c[0],g=c[1],h;f.isFunction(e)?b[a](function(){h=e.apply(this,arguments),h&&f.isFunction(h.promise)?h.promise().then(d.resolve,d.reject):d[g+"With"](this===b?d:this,[h])}):b[a](d[g])})}).promise()},promise:function(a){if(a==null){if(d)return d;d=a={}}var c=g.length;while(c--)a[g[c]]=b[g[c]];return a}}),b.done(c.cancel).fail(b.cancel),delete b.cancel,a&&a.call(b,b);return b},when:function(a){function i(a){return function(c){b[a]=arguments.length>1?h.call(arguments,0):c,--e||g.resolveWith(g,h.call(b,0))}}var b=arguments,c=0,d=b.length,e=d,g=d<=1&&a&&f.isFunction(a.promise)?a:f.Deferred();if(d>1){for(;c<d;c++)b[c]&&f.isFunction(b[c].promise)?b[c].promise().then(i(c),g.reject):--e;e||g.resolveWith(g,b)}else g!==a&&g.resolveWith(g,d?[a]:[]);return g.promise()}}),f.support=function(){var a=c.createElement("div"),b=c.documentElement,d,e,g,h,i,j,k,l,m,n,o,p,q,r,s,t,u;a.setAttribute("className","t"),a.innerHTML="   <link><table></table><a href='/a' style='top:1px;float:left;opacity:.55;'>a</a><input type=checkbox>",d=a.getElementsByTagName("*"),e=a.getElementsByTagName("a")[0];if(!d||!d.length||!e)return{};g=c.createElement("select"),h=g.appendChild(c.createElement("option")),i=a.getElementsByTagName("input")[0],k={leadingWhitespace:a.firstChild.nodeType===3,tbody:!a.getElementsByTagName("tbody").length,htmlSerialize:!!a.getElementsByTagName("link").length,style:/top/.test(e.getAttribute("style")),hrefNormalized:e.getAttribute("href")==="/a",opacity:/^0.55$/.test(e.style.opacity),cssFloat:!!e.style.cssFloat,checkOn:i.value==="on",optSelected:h.selected,getSetAttribute:a.className!=="t",submitBubbles:!0,changeBubbles:!0,focusinBubbles:!1,deleteExpando:!0,noCloneEvent:!0,inlineBlockNeedsLayout:!1,shrinkWrapBlocks:!1,reliableMarginRight:!0},i.checked=!0,k.noCloneChecked=i.cloneNode(!0).checked,g.disabled=!0,k.optDisabled=!h.disabled;try{delete a.test}catch(v){k.deleteExpando=!1}!a.addEventListener&&a.attachEvent&&a.fireEvent&&(a.attachEvent("onclick",function(){k.noCloneEvent=!1}),a.cloneNode(!0).fireEvent("onclick")),i=c.createElement("input"),i.value="t",i.setAttribute("type","radio"),k.radioValue=i.value==="t",i.setAttribute("checked","checked"),a.appendChild(i),l=c.createDocumentFragment(),l.appendChild(a.firstChild),k.checkClone=l.cloneNode(!0).cloneNode(!0).lastChild.checked,a.innerHTML="",a.style.width=a.style.paddingLeft="1px",m=c.getElementsByTagName("body")[0],o=c.createElement(m?"div":"body"),p={visibility:"hidden",width:0,height:0,border:0,margin:0,background:"none"},m&&f.extend(p,{position:"absolute",left:"-1000px",top:"-1000px"});for(t in p)o.style[t]=p[t];o.appendChild(a),n=m||b,n.insertBefore(o,n.firstChild),k.appendChecked=i.checked,k.boxModel=a.offsetWidth===2,"zoom"in a.style&&(a.style.display="inline",a.style.zoom=1,k.inlineBlockNeedsLayout=a.offsetWidth===2,a.style.display="",a.innerHTML="<div style='width:4px;'></div>",k.shrinkWrapBlocks=a.offsetWidth!==2),a.innerHTML="<table><tr><td style='padding:0;border:0;display:none'></td><td>t</td></tr></table>",q=a.getElementsByTagName("td"),u=q[0].offsetHeight===0,q[0].style.display="",q[1].style.display="none",k.reliableHiddenOffsets=u&&q[0].offsetHeight===0,a.innerHTML="",c.defaultView&&c.defaultView.getComputedStyle&&(j=c.createElement("div"),j.style.width="0",j.style.marginRight="0",a.appendChild(j),k.reliableMarginRight=(parseInt((c.defaultView.getComputedStyle(j,null)||{marginRight:0}).marginRight,10)||0)===0),o.innerHTML="",n.removeChild(o);if(a.attachEvent)for(t in{submit:1,change:1,focusin:1})s="on"+t,u=s in a,u||(a.setAttribute(s,"return;"),u=typeof a[s]=="function"),k[t+"Bubbles"]=u;o=l=g=h=m=j=a=i=null;return k}(),f.boxModel=f.support.boxModel;var i=/^(?:\{.*\}|\[.*\])$/,j=/([a-z])([A-Z])/g;f.extend({cache:{},uuid:0,expando:"jQuery"+(f.fn.jquery+Math.random()).replace(/\D/g,""),noData:{embed:!0,object:"clsid:D27CDB6E-AE6D-11cf-96B8-444553540000",applet:!0},hasData:function(a){a=a.nodeType?f.cache[a[f.expando]]:a[f.expando];return!!a&&!l(a)},data:function(a,c,d,e){if(!!f.acceptData(a)){var g,h,i=f.expando,j=typeof c=="string",k=a.nodeType,l=k?f.cache:a,m=k?a[f.expando]:a[f.expando]&&f.expando;if((!m||e&&m&&l[m]&&!l[m][i])&&j&&d===b)return;m||(k?a[f.expando]=m=++f.uuid:m=f.expando),l[m]||(l[m]={},k||(l[m].toJSON=f.noop));if(typeof c=="object"||typeof c=="function")e?l[m][i]=f.extend(l[m][i],c):l[m]=f.extend(l[m],c);g=l[m],e&&(g[i]||(g[i]={}),g=g[i]),d!==b&&(g[f.camelCase(c)]=d);if(c==="events"&&!g[c])return g[i]&&g[i].events;j?(h=g[c],h==null&&(h=g[f.camelCase(c)])):h=g;return h}},removeData:function(a,b,c){if(!!f.acceptData(a)){var d,e=f.expando,g=a.nodeType,h=g?f.cache:a,i=g?a[f.expando]:f.expando;if(!h[i])return;if(b){d=c?h[i][e]:h[i];if(d){d[b]||(b=f.camelCase(b)),delete d[b];if(!l(d))return}}if(c){delete h[i][e];if(!l(h[i]))return}var j=h[i][e];f.support.deleteExpando||!h.setInterval?delete h[i]:h[i]=null,j?(h[i]={},g||(h[i].toJSON=f.noop),h[i][e]=j):g&&(f.support.deleteExpando?delete a[f.expando]:a.removeAttribute?a.removeAttribute(f.expando):a[f.expando]=null)}},_data:function(a,b,c){return f.data(a,b,c,!0)},acceptData:function(a){if(a.nodeName){var b=f.noData[a.nodeName.toLowerCase()];if(b)return b!==!0&&a.getAttribute("classid")===b}return!0}}),f.fn.extend({data:function(a,c){var d=null;if(typeof a=="undefined"){if(this.length){d=f.data(this[0]);if(this[0].nodeType===1){var e=this[0].attributes,g;for(var h=0,i=e.length;h<i;h++)g=e[h].name,g.indexOf("data-")===0&&(g=f.camelCase(g.substring(5)),k(this[0],g,d[g]))}}return d}if(typeof a=="object")return this.each(function(){f.data(this,a)});var j=a.split(".");j[1]=j[1]?"."+j[1]:"";if(c===b){d=this.triggerHandler("getData"+j[1]+"!",[j[0]]),d===b&&this.length&&(d=f.data(this[0],a),d=k(this[0],a,d));return d===b&&j[1]?this.data(j[0]):d}return this.each(function(){var b=f(this),d=[j[0],c];b.triggerHandler("setData"+j[1]+"!",d),f.data(this,a,c),b.triggerHandler("changeData"+j[1]+"!",d)})},removeData:function(a){return this.each(function(){f.removeData(this,a)})}}),f.extend({_mark:function(a,c){a&&(c=(c||"fx")+"mark",f.data(a,c,(f.data(a,c,b,!0)||0)+1,!0))},_unmark:function(a,c,d){a!==!0&&(d=c,c=a,a=!1);if(c){d=d||"fx";var e=d+"mark",g=a?0:(f.data(c,e,b,!0)||1)-1;g?f.data(c,e,g,!0):(f.removeData(c,e,!0),m(c,d,"mark"))}},queue:function(a,c,d){if(a){c=(c||"fx")+"queue";var e=f.data(a,c,b,!0);d&&(!e||f.isArray(d)?e=f.data(a,c,f.makeArray(d),!0):e.push(d));return e||[]}},dequeue:function(a,b){b=b||"fx";var c=f.queue(a,b),d=c.shift(),e;d==="inprogress"&&(d=c.shift()),d&&(b==="fx"&&c.unshift("inprogress"),d.call(a,function(){f.dequeue(a,b)})),c.length||(f.removeData(a,b+"queue",!0),m(a,b,"queue"))}}),f.fn.extend({queue:function(a,c){typeof a!="string"&&(c=a,a="fx");if(c===b)return f.queue(this[0],a);return this.each(function(){var b=f.queue(this,a,c);a==="fx"&&b[0]!=="inprogress"&&f.dequeue(this,a)})},dequeue:function(a){return this.each(function(){f.dequeue(this,a)})},delay:function(a,b){a=f.fx?f.fx.speeds[a]||a:a,b=b||"fx";return this.queue(b,function(){var c=this;setTimeout(function(){f.dequeue(c,b)},a)})},clearQueue:function(a){return this.queue(a||"fx",[])},promise:function(a,c){function m(){--h||d.resolveWith(e,[e])}typeof a!="string"&&(c=a,a=b),a=a||"fx";var d=f.Deferred(),e=this,g=e.length,h=1,i=a+"defer",j=a+"queue",k=a+"mark",l;while(g--)if(l=f.data(e[g],i,b,!0)||(f.data(e[g],j,b,!0)||f.data(e[g],k,b,!0))&&f.data(e[g],i,f._Deferred(),!0))h++,l.done(m);m();return d.promise()}});var n=/[\n\t\r]/g,o=/\s+/,p=/\r/g,q=/^(?:button|input)$/i,r=/^(?:button|input|object|select|textarea)$/i,s=/^a(?:rea)?$/i,t=/^(?:autofocus|autoplay|async|checked|controls|defer|disabled|hidden|loop|multiple|open|readonly|required|scoped|selected)$/i,u,v;f.fn.extend({attr:function(a,b){return f.access(this,a,b,!0,f.attr)},removeAttr:function(a){return this.each(function(){f.removeAttr(this,a)})},prop:function(a,b){return f.access(this,a,b,!0,f.prop)},removeProp:function(a){a=f.propFix[a]||a;return this.each(function(){try{this[a]=b,delete this[a]}catch(c){}})},addClass:function(a){var b,c,d,e,g,h,i;if(f.isFunction(a))return this.each(function(b){f(this).addClass(a.call(this,b,this.className))});if(a&&typeof a=="string"){b=a.split(o);for(c=0,d=this.length;c<d;c++){e=this[c];if(e.nodeType===1)if(!e.className&&b.length===1)e.className=a;else{g=" "+e.className+" ";for(h=0,i=b.length;h<i;h++)~g.indexOf(" "+b[h]+" ")||(g+=b[h]+" ");e.className=f.trim(g)}}}return this},removeClass:function(a){var c,d,e,g,h,i,j;if(f.isFunction(a))return this.each(function(b){f(this).removeClass(a.call(this,b,this.className))});if(a&&typeof a=="string"||a===b){c=(a||"").split(o);for(d=0,e=this.length;d<e;d++){g=this[d];if(g.nodeType===1&&g.className)if(a){h=(" "+g.className+" ").replace(n," ");for(i=0,j=c.length;i<j;i++)h=h.replace(" "+c[i]+" "," ");g.className=f.trim(h)}else g.className=""}}return this},toggleClass:function(a,b){var c=typeof a,d=typeof b=="boolean";if(f.isFunction(a))return this.each(function(c){f(this).toggleClass(a.call(this,c,this.className,b),b)});return this.each(function(){if(c==="string"){var e,g=0,h=f(this),i=b,j=a.split(o);while(e=j[g++])i=d?i:!h.hasClass(e),h[i?"addClass":"removeClass"](e)}else if(c==="undefined"||c==="boolean")this.className&&f._data(this,"__className__",this.className),this.className=this.className||a===!1?"":f._data(this,"__className__")||""})},hasClass:function(a){var b=" "+a+" ";for(var c=0,d=this.length;c<d;c++)if(this[c].nodeType===1&&(" "+this[c].className+" ").replace(n," ").indexOf(b)>-1)return!0;return!1},val:function(a){var c,d,e=this[0];if(!arguments.length){if(e){c=f.valHooks[e.nodeName.toLowerCase()]||f.valHooks[e.type];if(c&&"get"in c&&(d=c.get(e,"value"))!==b)return d;d=e.value;return typeof d=="string"?d.replace(p,""):d==null?"":d}return b}var g=f.isFunction(a);return this.each(function(d){var e=f(this),h;if(this.nodeType===1){g?h=a.call(this,d,e.val()):h=a,h==null?h="":typeof h=="number"?h+="":f.isArray(h)&&(h=f.map(h,function(a){return a==null?"":a+""})),c=f.valHooks[this.nodeName.toLowerCase()]||f.valHooks[this.type];if(!c||!("set"in c)||c.set(this,h,"value")===b)this.value=h}})}}),f.extend({valHooks:{option:{get:function(a){var b=a.attributes.value;return!b||b.specified?a.value:a.text}},select:{get:function(a){var b,c=a.selectedIndex,d=[],e=a.options,g=a.type==="select-one";if(c<0)return null;for(var h=g?c:0,i=g?c+1:e.length;h<i;h++){var j=e[h];if(j.selected&&(f.support.optDisabled?!j.disabled:j.getAttribute("disabled")===null)&&(!j.parentNode.disabled||!f.nodeName(j.parentNode,"optgroup"))){b=f(j).val();if(g)return b;d.push(b)}}if(g&&!d.length&&e.length)return f(e[c]).val();return d},set:function(a,b){var c=f.makeArray(b);f(a).find("option").each(function(){this.selected=f.inArray(f(this).val(),c)>=0}),c.length||(a.selectedIndex=-1);return c}}},attrFn:{val:!0,css:!0,html:!0,text:!0,data:!0,width:!0,height:!0,offset:!0},attrFix:{tabindex:"tabIndex"},attr:function(a,c,d,e){var g=a.nodeType;if(!a||g===3||g===8||g===2)return b;if(e&&c in f.attrFn)return f(a)[c](d);if(!("getAttribute"in a))return f.prop(a,c,d);var h,i,j=g!==1||!f.isXMLDoc(a);j&&(c=f.attrFix[c]||c,i=f.attrHooks[c],i||(t.test(c)?i=v:u&&(i=u)));if(d!==b){if(d===null){f.removeAttr(a,c);return b}if(i&&"set"in i&&j&&(h=i.set(a,d,c))!==b)return h;a.setAttribute(c,""+d);return d}if(i&&"get"in i&&j&&(h=i.get(a,c))!==null)return h;h=a.getAttribute(c);return h===null?b:h},removeAttr:function(a,b){var c;a.nodeType===1&&(b=f.attrFix[b]||b,f.attr(a,b,""),a.removeAttribute(b),t.test(b)&&(c=f.propFix[b]||b)in a&&(a[c]=!1))},attrHooks:{type:{set:function(a,b){if(q.test(a.nodeName)&&a.parentNode)f.error("type property can't be changed");else if(!f.support.radioValue&&b==="radio"&&f.nodeName(a,"input")){var c=a.value;a.setAttribute("type",b),c&&(a.value=c);return b}}},value:{get:function(a,b){if(u&&f.nodeName(a,"button"))return u.get(a,b);return b in a?a.value:null},set:function(a,b,c){if(u&&f.nodeName(a,"button"))return u.set(a,b,c);a.value=b}}},propFix:{tabindex:"tabIndex",readonly:"readOnly","for":"htmlFor","class":"className",maxlength:"maxLength",cellspacing:"cellSpacing",cellpadding:"cellPadding",rowspan:"rowSpan",colspan:"colSpan",usemap:"useMap",frameborder:"frameBorder",contenteditable:"contentEditable"},prop:function(a,c,d){var e=a.nodeType;if(!a||e===3||e===8||e===2)return b;var g,h,i=e!==1||!f.isXMLDoc(a);i&&(c=f.propFix[c]||c,h=f.propHooks[c]);return d!==b?h&&"set"in h&&(g=h.set(a,d,c))!==b?g:a[c]=d:h&&"get"in h&&(g=h.get(a,c))!==null?g:a[c]},propHooks:{tabIndex:{get:function(a){var c=a.getAttributeNode("tabindex");return c&&c.specified?parseInt(c.value,10):r.test(a.nodeName)||s.test(a.nodeName)&&a.href?0:b}}}}),f.attrHooks.tabIndex=f.propHooks.tabIndex,v={get:function(a,c){var d;return f.prop(a,c)===!0||(d=a.getAttributeNode(c))&&d.nodeValue!==!1?c.toLowerCase():b},set:function(a,b,c){var d;b===!1?f.removeAttr(a,c):(d=f.propFix[c]||c,d in a&&(a[d]=!0),a.setAttribute(c,c.toLowerCase()));return c}},f.support.getSetAttribute||(u=f.valHooks.button={get:function(a,c){var d;d=a.getAttributeNode(c);return d&&d.nodeValue!==""?d.nodeValue:b},set:function(a,b,d){var e=a.getAttributeNode(d);e||(e=c.createAttribute(d),a.setAttributeNode(e));return e.nodeValue=b+""}},f.each(["width","height"],function(a,b){f.attrHooks[b]=f.extend(f.attrHooks[b],{set:function(a,c){if(c===""){a.setAttribute(b,"auto");return c}}})})),f.support.hrefNormalized||f.each(["href","src","width","height"],function(a,c){f.attrHooks[c]=f.extend(f.attrHooks[c],{get:function(a){var d=a.getAttribute(c,2);return d===null?b:d}})}),f.support.style||(f.attrHooks.style={get:function(a){return a.style.cssText.toLowerCase()||b},set:function(a,b){return a.style.cssText=""+b}}),f.support.optSelected||(f.propHooks.selected=f.extend(f.propHooks.selected,{get:function(a){var b=a.parentNode;b&&(b.selectedIndex,b.parentNode&&b.parentNode.selectedIndex);return null}})),f.support.checkOn||f.each(["radio","checkbox"],function(){f.valHooks[this]={get:function(a){return a.getAttribute("value")===null?"on":a.value}}}),f.each(["radio","checkbox"],function(){f.valHooks[this]=f.extend(f.valHooks[this],{set:function(a,b){if(f.isArray(b))return a.checked=f.inArray(f(a).val(),b)>=0}})});var w=/\.(.*)$/,x=/^(?:textarea|input|select)$/i,y=/\./g,z=/ /g,A=/[^\w\s.|`]/g,B=function(a){return a.replace(A,"\\$&")};f.event={add:function(a,c,d,e){if(a.nodeType!==3&&a.nodeType!==8){if(d===!1)d=C;else if(!d)return;var g,h;d.handler&&(g=d,d=g.handler),d.guid||(d.guid=f.guid++);var i=f._data(a);if(!i)return;var j=i.events,k=i.handle;j||(i.events=j={}),k||(i.handle=k=function(a){return typeof f!="undefined"&&(!a||f.event.triggered!==a.type)?f.event.handle.apply(k.elem,arguments):b}),k.elem=a,c=c.split(" ");var l,m=0,n;while(l=c[m++]){h=g?f.extend({},g):{handler:d,data:e},l.indexOf(".")>-1?(n=l.split("."),l=n.shift(),h.namespace=n.slice(0).sort().join(".")):(n=[],h.namespace=""),h.type=l,h.guid||(h.guid=d.guid);var o=j[l],p=f.event.special[l]||{};if(!o){o=j[l]=[];if(!p.setup||p.setup.call(a,e,n,k)===!1)a.addEventListener?a.addEventListener(l,k,!1):a.attachEvent&&a.attachEvent("on"+l,k)}p.add&&(p.add.call(a,h),h.handler.guid||(h.handler.guid=d.guid)),o.push(h),f.event.global[l]=!0}a=null}},global:{},remove:function(a,c,d,e){if(a.nodeType!==3&&a.nodeType!==8){d===!1&&(d=C);var g,h,i,j,k=0,l,m,n,o,p,q,r,s=f.hasData(a)&&f._data(a),t=s&&s.events;if(!s||!t)return;c&&c.type&&(d=c.handler,c=c.type);if(!c||typeof c=="string"&&c.charAt(0)==="."){c=c||"";for(h in t)f.event.remove(a,h+c);return}c=c.split(" ");while(h=c[k++]){r=h,q=null,l=h.indexOf(".")<0,m=[],l||(m=h.split("."),h=m.shift(),n=new RegExp("(^|\\.)"+f.map(m.slice(0).sort(),B).join("\\.(?:.*\\.)?")+"(\\.|$)")),p=t[h];if(!p)continue;if(!d){for(j=0;j<p.length;j++){q=p[j];if(l||n.test(q.namespace))f.event.remove(a,r,q.handler,j),p.splice(j--,1)}continue}o=f.event.special[h]||{};for(j=e||0;j<p.length;j++){q=p[j];if(d.guid===q.guid){if(l||n.test(q.namespace))e==null&&p.splice(j--,1),o.remove&&o.remove.call(a,q);if(e!=null)break}}if(p.length===0||e!=null&&p.length===1)(!o.teardown||o.teardown.call(a,m)===!1)&&f.removeEvent(a,h,s.handle),g=null
+,delete t[h]}if(f.isEmptyObject(t)){var u=s.handle;u&&(u.elem=null),delete s.events,delete s.handle,f.isEmptyObject(s)&&f.removeData(a,b,!0)}}},customEvent:{getData:!0,setData:!0,changeData:!0},trigger:function(c,d,e,g){var h=c.type||c,i=[],j;h.indexOf("!")>=0&&(h=h.slice(0,-1),j=!0),h.indexOf(".")>=0&&(i=h.split("."),h=i.shift(),i.sort());if(!!e&&!f.event.customEvent[h]||!!f.event.global[h]){c=typeof c=="object"?c[f.expando]?c:new f.Event(h,c):new f.Event(h),c.type=h,c.exclusive=j,c.namespace=i.join("."),c.namespace_re=new RegExp("(^|\\.)"+i.join("\\.(?:.*\\.)?")+"(\\.|$)");if(g||!e)c.preventDefault(),c.stopPropagation();if(!e){f.each(f.cache,function(){var a=f.expando,b=this[a];b&&b.events&&b.events[h]&&f.event.trigger(c,d,b.handle.elem)});return}if(e.nodeType===3||e.nodeType===8)return;c.result=b,c.target=e,d=d!=null?f.makeArray(d):[],d.unshift(c);var k=e,l=h.indexOf(":")<0?"on"+h:"";do{var m=f._data(k,"handle");c.currentTarget=k,m&&m.apply(k,d),l&&f.acceptData(k)&&k[l]&&k[l].apply(k,d)===!1&&(c.result=!1,c.preventDefault()),k=k.parentNode||k.ownerDocument||k===c.target.ownerDocument&&a}while(k&&!c.isPropagationStopped());if(!c.isDefaultPrevented()){var n,o=f.event.special[h]||{};if((!o._default||o._default.call(e.ownerDocument,c)===!1)&&(h!=="click"||!f.nodeName(e,"a"))&&f.acceptData(e)){try{l&&e[h]&&(n=e[l],n&&(e[l]=null),f.event.triggered=h,e[h]())}catch(p){}n&&(e[l]=n),f.event.triggered=b}}return c.result}},handle:function(c){c=f.event.fix(c||a.event);var d=((f._data(this,"events")||{})[c.type]||[]).slice(0),e=!c.exclusive&&!c.namespace,g=Array.prototype.slice.call(arguments,0);g[0]=c,c.currentTarget=this;for(var h=0,i=d.length;h<i;h++){var j=d[h];if(e||c.namespace_re.test(j.namespace)){c.handler=j.handler,c.data=j.data,c.handleObj=j;var k=j.handler.apply(this,g);k!==b&&(c.result=k,k===!1&&(c.preventDefault(),c.stopPropagation()));if(c.isImmediatePropagationStopped())break}}return c.result},props:"altKey attrChange attrName bubbles button cancelable charCode clientX clientY ctrlKey currentTarget data detail eventPhase fromElement handler keyCode layerX layerY metaKey newValue offsetX offsetY pageX pageY prevValue relatedNode relatedTarget screenX screenY shiftKey srcElement target toElement view wheelDelta which".split(" "),fix:function(a){if(a[f.expando])return a;var d=a;a=f.Event(d);for(var e=this.props.length,g;e;)g=this.props[--e],a[g]=d[g];a.target||(a.target=a.srcElement||c),a.target.nodeType===3&&(a.target=a.target.parentNode),!a.relatedTarget&&a.fromElement&&(a.relatedTarget=a.fromElement===a.target?a.toElement:a.fromElement);if(a.pageX==null&&a.clientX!=null){var h=a.target.ownerDocument||c,i=h.documentElement,j=h.body;a.pageX=a.clientX+(i&&i.scrollLeft||j&&j.scrollLeft||0)-(i&&i.clientLeft||j&&j.clientLeft||0),a.pageY=a.clientY+(i&&i.scrollTop||j&&j.scrollTop||0)-(i&&i.clientTop||j&&j.clientTop||0)}a.which==null&&(a.charCode!=null||a.keyCode!=null)&&(a.which=a.charCode!=null?a.charCode:a.keyCode),!a.metaKey&&a.ctrlKey&&(a.metaKey=a.ctrlKey),!a.which&&a.button!==b&&(a.which=a.button&1?1:a.button&2?3:a.button&4?2:0);return a},guid:1e8,proxy:f.proxy,special:{ready:{setup:f.bindReady,teardown:f.noop},live:{add:function(a){f.event.add(this,M(a.origType,a.selector),f.extend({},a,{handler:L,guid:a.handler.guid}))},remove:function(a){f.event.remove(this,M(a.origType,a.selector),a)}},beforeunload:{setup:function(a,b,c){f.isWindow(this)&&(this.onbeforeunload=c)},teardown:function(a,b){this.onbeforeunload===b&&(this.onbeforeunload=null)}}}},f.removeEvent=c.removeEventListener?function(a,b,c){a.removeEventListener&&a.removeEventListener(b,c,!1)}:function(a,b,c){a.detachEvent&&a.detachEvent("on"+b,c)},f.Event=function(a,b){if(!this.preventDefault)return new f.Event(a,b);a&&a.type?(this.originalEvent=a,this.type=a.type,this.isDefaultPrevented=a.defaultPrevented||a.returnValue===!1||a.getPreventDefault&&a.getPreventDefault()?D:C):this.type=a,b&&f.extend(this,b),this.timeStamp=f.now(),this[f.expando]=!0},f.Event.prototype={preventDefault:function(){this.isDefaultPrevented=D;var a=this.originalEvent;!a||(a.preventDefault?a.preventDefault():a.returnValue=!1)},stopPropagation:function(){this.isPropagationStopped=D;var a=this.originalEvent;!a||(a.stopPropagation&&a.stopPropagation(),a.cancelBubble=!0)},stopImmediatePropagation:function(){this.isImmediatePropagationStopped=D,this.stopPropagation()},isDefaultPrevented:C,isPropagationStopped:C,isImmediatePropagationStopped:C};var E=function(a){var b=a.relatedTarget,c=!1,d=a.type;a.type=a.data,b!==this&&(b&&(c=f.contains(this,b)),c||(f.event.handle.apply(this,arguments),a.type=d))},F=function(a){a.type=a.data,f.event.handle.apply(this,arguments)};f.each({mouseenter:"mouseover",mouseleave:"mouseout"},function(a,b){f.event.special[a]={setup:function(c){f.event.add(this,b,c&&c.selector?F:E,a)},teardown:function(a){f.event.remove(this,b,a&&a.selector?F:E)}}}),f.support.submitBubbles||(f.event.special.submit={setup:function(a,b){if(!f.nodeName(this,"form"))f.event.add(this,"click.specialSubmit",function(a){var b=a.target,c=f.nodeName(b,"input")?b.type:"";(c==="submit"||c==="image")&&f(b).closest("form").length&&J("submit",this,arguments)}),f.event.add(this,"keypress.specialSubmit",function(a){var b=a.target,c=f.nodeName(b,"input")?b.type:"";(c==="text"||c==="password")&&f(b).closest("form").length&&a.keyCode===13&&J("submit",this,arguments)});else return!1},teardown:function(a){f.event.remove(this,".specialSubmit")}});if(!f.support.changeBubbles){var G,H=function(a){var b=f.nodeName(a,"input")?a.type:"",c=a.value;b==="radio"||b==="checkbox"?c=a.checked:b==="select-multiple"?c=a.selectedIndex>-1?f.map(a.options,function(a){return a.selected}).join("-"):"":f.nodeName(a,"select")&&(c=a.selectedIndex);return c},I=function(c){var d=c.target,e,g;if(!!x.test(d.nodeName)&&!d.readOnly){e=f._data(d,"_change_data"),g=H(d),(c.type!=="focusout"||d.type!=="radio")&&f._data(d,"_change_data",g);if(e===b||g===e)return;if(e!=null||g)c.type="change",c.liveFired=b,f.event.trigger(c,arguments[1],d)}};f.event.special.change={filters:{focusout:I,beforedeactivate:I,click:function(a){var b=a.target,c=f.nodeName(b,"input")?b.type:"";(c==="radio"||c==="checkbox"||f.nodeName(b,"select"))&&I.call(this,a)},keydown:function(a){var b=a.target,c=f.nodeName(b,"input")?b.type:"";(a.keyCode===13&&!f.nodeName(b,"textarea")||a.keyCode===32&&(c==="checkbox"||c==="radio")||c==="select-multiple")&&I.call(this,a)},beforeactivate:function(a){var b=a.target;f._data(b,"_change_data",H(b))}},setup:function(a,b){if(this.type==="file")return!1;for(var c in G)f.event.add(this,c+".specialChange",G[c]);return x.test(this.nodeName)},teardown:function(a){f.event.remove(this,".specialChange");return x.test(this.nodeName)}},G=f.event.special.change.filters,G.focus=G.beforeactivate}f.support.focusinBubbles||f.each({focus:"focusin",blur:"focusout"},function(a,b){function e(a){var c=f.event.fix(a);c.type=b,c.originalEvent={},f.event.trigger(c,null,c.target),c.isDefaultPrevented()&&a.preventDefault()}var d=0;f.event.special[b]={setup:function(){d++===0&&c.addEventListener(a,e,!0)},teardown:function(){--d===0&&c.removeEventListener(a,e,!0)}}}),f.each(["bind","one"],function(a,c){f.fn[c]=function(a,d,e){var g;if(typeof a=="object"){for(var h in a)this[c](h,d,a[h],e);return this}if(arguments.length===2||d===!1)e=d,d=b;c==="one"?(g=function(a){f(this).unbind(a,g);return e.apply(this,arguments)},g.guid=e.guid||f.guid++):g=e;if(a==="unload"&&c!=="one")this.one(a,d,e);else for(var i=0,j=this.length;i<j;i++)f.event.add(this[i],a,g,d);return this}}),f.fn.extend({unbind:function(a,b){if(typeof a=="object"&&!a.preventDefault)for(var c in a)this.unbind(c,a[c]);else for(var d=0,e=this.length;d<e;d++)f.event.remove(this[d],a,b);return this},delegate:function(a,b,c,d){return this.live(b,c,d,a)},undelegate:function(a,b,c){return arguments.length===0?this.unbind("live"):this.die(b,null,c,a)},trigger:function(a,b){return this.each(function(){f.event.trigger(a,b,this)})},triggerHandler:function(a,b){if(this[0])return f.event.trigger(a,b,this[0],!0)},toggle:function(a){var b=arguments,c=a.guid||f.guid++,d=0,e=function(c){var e=(f.data(this,"lastToggle"+a.guid)||0)%d;f.data(this,"lastToggle"+a.guid,e+1),c.preventDefault();return b[e].apply(this,arguments)||!1};e.guid=c;while(d<b.length)b[d++].guid=c;return this.click(e)},hover:function(a,b){return this.mouseenter(a).mouseleave(b||a)}});var K={focus:"focusin",blur:"focusout",mouseenter:"mouseover",mouseleave:"mouseout"};f.each(["live","die"],function(a,c){f.fn[c]=function(a,d,e,g){var h,i=0,j,k,l,m=g||this.selector,n=g?this:f(this.context);if(typeof a=="object"&&!a.preventDefault){for(var o in a)n[c](o,d,a[o],m);return this}if(c==="die"&&!a&&g&&g.charAt(0)==="."){n.unbind(g);return this}if(d===!1||f.isFunction(d))e=d||C,d=b;a=(a||"").split(" ");while((h=a[i++])!=null){j=w.exec(h),k="",j&&(k=j[0],h=h.replace(w,""));if(h==="hover"){a.push("mouseenter"+k,"mouseleave"+k);continue}l=h,K[h]?(a.push(K[h]+k),h=h+k):h=(K[h]||h)+k;if(c==="live")for(var p=0,q=n.length;p<q;p++)f.event.add(n[p],"live."+M(h,m),{data:d,selector:m,handler:e,origType:h,origHandler:e,preType:l});else n.unbind("live."+M(h,m),e)}return this}}),f.each("blur focus focusin focusout load resize scroll unload click dblclick mousedown mouseup mousemove mouseover mouseout mouseenter mouseleave change select submit keydown keypress keyup error".split(" "),function(a,b){f.fn[b]=function(a,c){c==null&&(c=a,a=null);return arguments.length>0?this.bind(b,a,c):this.trigger(b)},f.attrFn&&(f.attrFn[b]=!0)}),function(){function u(a,b,c,d,e,f){for(var g=0,h=d.length;g<h;g++){var i=d[g];if(i){var j=!1;i=i[a];while(i){if(i.sizcache===c){j=d[i.sizset];break}if(i.nodeType===1){f||(i.sizcache=c,i.sizset=g);if(typeof b!="string"){if(i===b){j=!0;break}}else if(k.filter(b,[i]).length>0){j=i;break}}i=i[a]}d[g]=j}}}function t(a,b,c,d,e,f){for(var g=0,h=d.length;g<h;g++){var i=d[g];if(i){var j=!1;i=i[a];while(i){if(i.sizcache===c){j=d[i.sizset];break}i.nodeType===1&&!f&&(i.sizcache=c,i.sizset=g);if(i.nodeName.toLowerCase()===b){j=i;break}i=i[a]}d[g]=j}}}var a=/((?:\((?:\([^()]+\)|[^()]+)+\)|\[(?:\[[^\[\]]*\]|['"][^'"]*['"]|[^\[\]'"]+)+\]|\\.|[^ >+~,(\[\\]+)+|[>+~])(\s*,\s*)?((?:.|\r|\n)*)/g,d=0,e=Object.prototype.toString,g=!1,h=!0,i=/\\/g,j=/\W/;[0,0].sort(function(){h=!1;return 0});var k=function(b,d,f,g){f=f||[],d=d||c;var h=d;if(d.nodeType!==1&&d.nodeType!==9)return[];if(!b||typeof b!="string")return f;var i,j,n,o,q,r,s,t,u=!0,w=k.isXML(d),x=[],y=b;do{a.exec(""),i=a.exec(y);if(i){y=i[3],x.push(i[1]);if(i[2]){o=i[3];break}}}while(i);if(x.length>1&&m.exec(b))if(x.length===2&&l.relative[x[0]])j=v(x[0]+x[1],d);else{j=l.relative[x[0]]?[d]:k(x.shift(),d);while(x.length)b=x.shift(),l.relative[b]&&(b+=x.shift()),j=v(b,j)}else{!g&&x.length>1&&d.nodeType===9&&!w&&l.match.ID.test(x[0])&&!l.match.ID.test(x[x.length-1])&&(q=k.find(x.shift(),d,w),d=q.expr?k.filter(q.expr,q.set)[0]:q.set[0]);if(d){q=g?{expr:x.pop(),set:p(g)}:k.find(x.pop(),x.length===1&&(x[0]==="~"||x[0]==="+")&&d.parentNode?d.parentNode:d,w),j=q.expr?k.filter(q.expr,q.set):q.set,x.length>0?n=p(j):u=!1;while(x.length)r=x.pop(),s=r,l.relative[r]?s=x.pop():r="",s==null&&(s=d),l.relative[r](n,s,w)}else n=x=[]}n||(n=j),n||k.error(r||b);if(e.call(n)==="[object Array]")if(!u)f.push.apply(f,n);else if(d&&d.nodeType===1)for(t=0;n[t]!=null;t++)n[t]&&(n[t]===!0||n[t].nodeType===1&&k.contains(d,n[t]))&&f.push(j[t]);else for(t=0;n[t]!=null;t++)n[t]&&n[t].nodeType===1&&f.push(j[t]);else p(n,f);o&&(k(o,h,f,g),k.uniqueSort(f));return f};k.uniqueSort=function(a){if(r){g=h,a.sort(r);if(g)for(var b=1;b<a.length;b++)a[b]===a[b-1]&&a.splice(b--,1)}return a},k.matches=function(a,b){return k(a,null,null,b)},k.matchesSelector=function(a,b){return k(b,null,null,[a]).length>0},k.find=function(a,b,c){var d;if(!a)return[];for(var e=0,f=l.order.length;e<f;e++){var g,h=l.order[e];if(g=l.leftMatch[h].exec(a)){var j=g[1];g.splice(1,1);if(j.substr(j.length-1)!=="\\"){g[1]=(g[1]||"").replace(i,""),d=l.find[h](g,b,c);if(d!=null){a=a.replace(l.match[h],"");break}}}}d||(d=typeof b.getElementsByTagName!="undefined"?b.getElementsByTagName("*"):[]);return{set:d,expr:a}},k.filter=function(a,c,d,e){var f,g,h=a,i=[],j=c,m=c&&c[0]&&k.isXML(c[0]);while(a&&c.length){for(var n in l.filter)if((f=l.leftMatch[n].exec(a))!=null&&f[2]){var o,p,q=l.filter[n],r=f[1];g=!1,f.splice(1,1);if(r.substr(r.length-1)==="\\")continue;j===i&&(i=[]);if(l.preFilter[n]){f=l.preFilter[n](f,j,d,i,e,m);if(!f)g=o=!0;else if(f===!0)continue}if(f)for(var s=0;(p=j[s])!=null;s++)if(p){o=q(p,f,s,j);var t=e^!!o;d&&o!=null?t?g=!0:j[s]=!1:t&&(i.push(p),g=!0)}if(o!==b){d||(j=i),a=a.replace(l.match[n],"");if(!g)return[];break}}if(a===h)if(g==null)k.error(a);else break;h=a}return j},k.error=function(a){throw"Syntax error, unrecognized expression: "+a};var l=k.selectors={order:["ID","NAME","TAG"],match:{ID:/#((?:[\w\u00c0-\uFFFF\-]|\\.)+)/,CLASS:/\.((?:[\w\u00c0-\uFFFF\-]|\\.)+)/,NAME:/\[name=['"]*((?:[\w\u00c0-\uFFFF\-]|\\.)+)['"]*\]/,ATTR:/\[\s*((?:[\w\u00c0-\uFFFF\-]|\\.)+)\s*(?:(\S?=)\s*(?:(['"])(.*?)\3|(#?(?:[\w\u00c0-\uFFFF\-]|\\.)*)|)|)\s*\]/,TAG:/^((?:[\w\u00c0-\uFFFF\*\-]|\\.)+)/,CHILD:/:(only|nth|last|first)-child(?:\(\s*(even|odd|(?:[+\-]?\d+|(?:[+\-]?\d*)?n\s*(?:[+\-]\s*\d+)?))\s*\))?/,POS:/:(nth|eq|gt|lt|first|last|even|odd)(?:\((\d*)\))?(?=[^\-]|$)/,PSEUDO:/:((?:[\w\u00c0-\uFFFF\-]|\\.)+)(?:\((['"]?)((?:\([^\)]+\)|[^\(\)]*)+)\2\))?/},leftMatch:{},attrMap:{"class":"className","for":"htmlFor"},attrHandle:{href:function(a){return a.getAttribute("href")},type:function(a){return a.getAttribute("type")}},relative:{"+":function(a,b){var c=typeof b=="string",d=c&&!j.test(b),e=c&&!d;d&&(b=b.toLowerCase());for(var f=0,g=a.length,h;f<g;f++)if(h=a[f]){while((h=h.previousSibling)&&h.nodeType!==1);a[f]=e||h&&h.nodeName.toLowerCase()===b?h||!1:h===b}e&&k.filter(b,a,!0)},">":function(a,b){var c,d=typeof b=="string",e=0,f=a.length;if(d&&!j.test(b)){b=b.toLowerCase();for(;e<f;e++){c=a[e];if(c){var g=c.parentNode;a[e]=g.nodeName.toLowerCase()===b?g:!1}}}else{for(;e<f;e++)c=a[e],c&&(a[e]=d?c.parentNode:c.parentNode===b);d&&k.filter(b,a,!0)}},"":function(a,b,c){var e,f=d++,g=u;typeof b=="string"&&!j.test(b)&&(b=b.toLowerCase(),e=b,g=t),g("parentNode",b,f,a,e,c)},"~":function(a,b,c){var e,f=d++,g=u;typeof b=="string"&&!j.test(b)&&(b=b.toLowerCase(),e=b,g=t),g("previousSibling",b,f,a,e,c)}},find:{ID:function(a,b,c){if(typeof b.getElementById!="undefined"&&!c){var d=b.getElementById(a[1]);return d&&d.parentNode?[d]:[]}},NAME:function(a,b){if(typeof b.getElementsByName!="undefined"){var c=[],d=b.getElementsByName(a[1]);for(var e=0,f=d.length;e<f;e++)d[e].getAttribute("name")===a[1]&&c.push(d[e]);return c.length===0?null:c}},TAG:function(a,b){if(typeof b.getElementsByTagName!="undefined")return b.getElementsByTagName(a[1])}},preFilter:{CLASS:function(a,b,c,d,e,f){a=" "+a[1].replace(i,"")+" ";if(f)return a;for(var g=0,h;(h=b[g])!=null;g++)h&&(e^(h.className&&(" "+h.className+" ").replace(/[\t\n\r]/g," ").indexOf(a)>=0)?c||d.push(h):c&&(b[g]=!1));return!1},ID:function(a){return a[1].replace(i,"")},TAG:function(a,b){return a[1].replace(i,"").toLowerCase()},CHILD:function(a){if(a[1]==="nth"){a[2]||k.error(a[0]),a[2]=a[2].replace(/^\+|\s*/g,"");var b=/(-?)(\d*)(?:n([+\-]?\d*))?/.exec(a[2]==="even"&&"2n"||a[2]==="odd"&&"2n+1"||!/\D/.test(a[2])&&"0n+"+a[2]||a[2]);a[2]=b[1]+(b[2]||1)-0,a[3]=b[3]-0}else a[2]&&k.error(a[0]);a[0]=d++;return a},ATTR:function(a,b,c,d,e,f){var g=a[1]=a[1].replace(i,"");!f&&l.attrMap[g]&&(a[1]=l.attrMap[g]),a[4]=(a[4]||a[5]||"").replace(i,""),a[2]==="~="&&(a[4]=" "+a[4]+" ");return a},PSEUDO:function(b,c,d,e,f){if(b[1]==="not")if((a.exec(b[3])||"").length>1||/^\w/.test(b[3]))b[3]=k(b[3],null,null,c);else{var g=k.filter(b[3],c,d,!0^f);d||e.push.apply(e,g);return!1}else if(l.match.POS.test(b[0])||l.match.CHILD.test(b[0]))return!0;return b},POS:function(a){a.unshift(!0);return a}},filters:{enabled:function(a){return a.disabled===!1&&a.type!=="hidden"},disabled:function(a){return a.disabled===!0},checked:function(a){return a.checked===!0},selected:function(a){a.parentNode&&a.parentNode.selectedIndex;return a.selected===!0},parent:function(a){return!!a.firstChild},empty:function(a){return!a.firstChild},has:function(a,b,c){return!!k(c[3],a).length},header:function(a){return/h\d/i.test(a.nodeName)},text:function(a){var b=a.getAttribute("type"),c=a.type;return a.nodeName.toLowerCase()==="input"&&"text"===c&&(b===c||b===null)},radio:function(a){return a.nodeName.toLowerCase()==="input"&&"radio"===a.type},checkbox:function(a){return a.nodeName.toLowerCase()==="input"&&"checkbox"===a.type},file:function(a){return a.nodeName.toLowerCase()==="input"&&"file"===a.type},password:function(a){return a.nodeName.toLowerCase()==="input"&&"password"===a.type},submit:function(a){var b=a.nodeName.toLowerCase();return(b==="input"||b==="button")&&"submit"===a.type},image:function(a){return a.nodeName.toLowerCase()==="input"&&"image"===a.type},reset:function(a){var b=a.nodeName.toLowerCase();return(b==="input"||b==="button")&&"reset"===a.type},button:function(a){var b=a.nodeName.toLowerCase();return b==="input"&&"button"===a.type||b==="button"},input:function(a){return/input|select|textarea|button/i.test(a.nodeName)},focus:function(a){return a===a.ownerDocument.activeElement}},setFilters:{first:function(a,b){return b===0},last:function(a,b,c,d){return b===d.length-1},even:function(a,b){return b%2===0},odd:function(a,b){return b%2===1},lt:function(a,b,c){return b<c[3]-0},gt:function(a,b,c){return b>c[3]-0},nth:function(a,b,c){return c[3]-0===b},eq:function(a,b,c){return c[3]-0===b}},filter:{PSEUDO:function(a,b,c,d){var e=b[1],f=l.filters[e];if(f)return f(a,c,b,d);if(e==="contains")return(a.textContent||a.innerText||k.getText([a])||"").indexOf(b[3])>=0;if(e==="not"){var g=b[3];for(var h=0,i=g.length;h<i;h++)if(g[h]===a)return!1;return!0}k.error(e)},CHILD:function(a,b){var c=b[1],d=a;switch(c){case"only":case"first":while(d=d.previousSibling)if(d.nodeType===1)return!1;if(c==="first")return!0;d=a;case"last":while(d=d.nextSibling)if(d.nodeType===1)return!1;return!0;case"nth":var e=b[2],f=b[3];if(e===1&&f===0)return!0;var g=b[0],h=a.parentNode;if(h&&(h.sizcache!==g||!a.nodeIndex)){var i=0;for(d=h.firstChild;d;d=d.nextSibling)d.nodeType===1&&(d.nodeIndex=++i);h.sizcache=g}var j=a.nodeIndex-f;return e===0?j===0:j%e===0&&j/e>=0}},ID:function(a,b){return a.nodeType===1&&a.getAttribute("id")===b},TAG:function(a,b){return b==="*"&&a.nodeType===1||a.nodeName.toLowerCase()===b},CLASS:function(a,b){return(" "+(a.className||a.getAttribute("class"))+" ").indexOf(b)>-1},ATTR:function(a,b){var c=b[1],d=l.attrHandle[c]?l.attrHandle[c](a):a[c]!=null?a[c]:a.getAttribute(c),e=d+"",f=b[2],g=b[4];return d==null?f==="!=":f==="="?e===g:f==="*="?e.indexOf(g)>=0:f==="~="?(" "+e+" ").indexOf(g)>=0:g?f==="!="?e!==g:f==="^="?e.indexOf(g)===0:f==="$="?e.substr(e.length-g.length)===g:f==="|="?e===g||e.substr(0,g.length+1)===g+"-":!1:e&&d!==!1},POS:function(a,b,c,d){var e=b[2],f=l.setFilters[e];if(f)return f(a,c,b,d)}}},m=l.match.POS,n=function(a,b){return"\\"+(b-0+1)};for(var o in l.match)l.match[o]=new RegExp(l.match[o].source+/(?![^\[]*\])(?![^\(]*\))/.source),l.leftMatch[o]=new RegExp(/(^(?:.|\r|\n)*?)/.source+l.match[o].source.replace(/\\(\d+)/g,n));var p=function(a,b){a=Array.prototype.slice.call(a,0);if(b){b.push.apply(b,a);return b}return a};try{Array.prototype.slice.call(c.documentElement.childNodes,0)[0].nodeType}catch(q){p=function(a,b){var c=0,d=b||[];if(e.call(a)==="[object Array]")Array.prototype.push.apply(d,a);else if(typeof a.length=="number")for(var f=a.length;c<f;c++)d.push(a[c]);else for(;a[c];c++)d.push(a[c]);return d}}var r,s;c.documentElement.compareDocumentPosition?r=function(a,b){if(a===b){g=!0;return 0}if(!a.compareDocumentPosition||!b.compareDocumentPosition)return a.compareDocumentPosition?-1:1;return a.compareDocumentPosition(b)&4?-1:1}:(r=function(a,b){if(a===b){g=!0;return 0}if(a.sourceIndex&&b.sourceIndex)return a.sourceIndex-b.sourceIndex;var c,d,e=[],f=[],h=a.parentNode,i=b.parentNode,j=h;if(h===i)return s(a,b);if(!h)return-1;if(!i)return 1;while(j)e.unshift(j),j=j.parentNode;j=i;while(j)f.unshift(j),j=j.parentNode;c=e.length,d=f.length;for(var k=0;k<c&&k<d;k++)if(e[k]!==f[k])return s(e[k],f[k]);return k===c?s(a,f[k],-1):s(e[k],b,1)},s=function(a,b,c){if(a===b)return c;var d=a.nextSibling;while(d){if(d===b)return-1;d=d.nextSibling}return 1}),k.getText=function(a){var b="",c;for(var d=0;a[d];d++)c=a[d],c.nodeType===3||c.nodeType===4?b+=c.nodeValue:c.nodeType!==8&&(b+=k.getText(c.childNodes));return b},function(){var a=c.createElement("div"),d="script"+(new Date).getTime(),e=c.documentElement;a.innerHTML="<a name='"+d+"'/>",e.insertBefore(a,e.firstChild),c.getElementById(d)&&(l.find.ID=function(a,c,d){if(typeof c.getElementById!="undefined"&&!d){var e=c.getElementById(a[1]);return e?e.id===a[1]||typeof e.getAttributeNode!="undefined"&&e.getAttributeNode("id").nodeValue===a[1]?[e]:b:[]}},l.filter.ID=function(a,b){var c=typeof a.getAttributeNode!="undefined"&&a.getAttributeNode("id");return a.nodeType===1&&c&&c.nodeValue===b}),e.removeChild(a),e=a=null}(),function(){var a=c.createElement("div");a.appendChild(c.createComment("")),a.getElementsByTagName("*").length>0&&(l.find.TAG=function(a,b){var c=b.getElementsByTagName(a[1]);if(a[1]==="*"){var d=[];for(var e=0;c[e];e++)c[e].nodeType===1&&d.push(c[e]);c=d}return c}),a.innerHTML="<a href='#'></a>",a.firstChild&&typeof a.firstChild.getAttribute!="undefined"&&a.firstChild.getAttribute("href")!=="#"&&(l.attrHandle.href=function(a){return a.getAttribute("href",2)}),a=null}(),c.querySelectorAll&&function(){var a=k,b=c.createElement("div"),d="__sizzle__";b.innerHTML="<p class='TEST'></p>";if(!b.querySelectorAll||b.querySelectorAll(".TEST").length!==0){k=function(b,e,f,g){e=e||c;if(!g&&!k.isXML(e)){var h=/^(\w+$)|^\.([\w\-]+$)|^#([\w\-]+$)/.exec(b);if(h&&(e.nodeType===1||e.nodeType===9)){if(h[1])return p(e.getElementsByTagName(b),f);if(h[2]&&l.find.CLASS&&e.getElementsByClassName)return p(e.getElementsByClassName(h[2]),f)}if(e.nodeType===9){if(b==="body"&&e.body)return p([e.body],f);if(h&&h[3]){var i=e.getElementById(h[3]);if(!i||!i.parentNode)return p([],f);if(i.id===h[3])return p([i],f)}try{return p(e.querySelectorAll(b),f)}catch(j){}}else if(e.nodeType===1&&e.nodeName.toLowerCase()!=="object"){var m=e,n=e.getAttribute("id"),o=n||d,q=e.parentNode,r=/^\s*[+~]/.test(b);n?o=o.replace(/'/g,"\\$&"):e.setAttribute("id",o),r&&q&&(e=e.parentNode);try{if(!r||q)return p(e.querySelectorAll("[id='"+o+"'] "+b),f)}catch(s){}finally{n||m.removeAttribute("id")}}}return a(b,e,f,g)};for(var e in a)k[e]=a[e];b=null}}(),function(){var a=c.documentElement,b=a.matchesSelector||a.mozMatchesSelector||a.webkitMatchesSelector||a.msMatchesSelector;if(b){var d=!b.call(c.createElement("div"),"div"),e=!1;try{b.call(c.documentElement,"[test!='']:sizzle")}catch(f){e=!0}k.matchesSelector=function(a,c){c=c.replace(/\=\s*([^'"\]]*)\s*\]/g,"='$1']");if(!k.isXML(a))try{if(e||!l.match.PSEUDO.test(c)&&!/!=/.test(c)){var f=b.call(a,c);if(f||!d||a.document&&a.document.nodeType!==11)return f}}catch(g){}return k(c,null,null,[a]).length>0}}}(),function(){var a=c.createElement("div");a.innerHTML="<div class='test e'></div><div class='test'></div>";if(!!a.getElementsByClassName&&a.getElementsByClassName("e").length!==0){a.lastChild.className="e";if(a.getElementsByClassName("e").length===1)return;l.order.splice(1,0,"CLASS"),l.find.CLASS=function(a,b,c){if(typeof b.getElementsByClassName!="undefined"&&!c)return b.getElementsByClassName(a[1])},a=null}}(),c.documentElement.contains?k.contains=function(a,b){return a!==b&&(a.contains?a.contains(b):!0)}:c.documentElement.compareDocumentPosition?k.contains=function(a,b){return!!(a.compareDocumentPosition(b)&16)}:k.contains=function(){return!1},k.isXML=function(a){var b=(a?a.ownerDocument||a:0).documentElement;return b?b.nodeName!=="HTML":!1};var v=function(a,b){var c,d=[],e="",f=b.nodeType?[b]:b;while(c=l.match.PSEUDO.exec(a))e+=c[0],a=a.replace(l.match.PSEUDO,"");a=l.relative[a]?a+"*":a;for(var g=0,h=f.length;g<h;g++)k(a,f[g],d);return k.filter(e,d)};f.find=k,f.expr=k.selectors,f.expr[":"]=f.expr.filters,f.unique=k.uniqueSort,f.text=k.getText,f.isXMLDoc=k.isXML,f.contains=k.contains}();var N=/Until$/,O=/^(?:parents|prevUntil|prevAll)/,P=/,/,Q=/^.[^:#\[\.,]*$/,R=Array.prototype.slice,S=f.expr.match.POS,T={children:!0,contents:!0,next:!0,prev:!0};f.fn.extend({find:function(a){var b=this,c,d;if(typeof a!="string")return f(a).filter(function(){for(c=0,d=b.length;c<d;c++)if(f.contains(b[c],this))return!0});var e=this.pushStack("","find",a),g,h,i;for(c=0,d=this.length;c<d;c++){g=e.length,f.find(a,this[c],e);if(c>0)for(h=g;h<e.length;h++)for(i=0;i<g;i++)if(e[i]===e[h]){e.splice(h--,1);break}}return e},has:function(a){var b=f(a);return this.filter(function(){for(var a=0,c=b.length;a<c;a++)if(f.contains(this,b[a]))return!0})},not:function(a){return this.pushStack(V(this,a,!1),"not",a)},filter:function(a){return this.pushStack(V(this,a,!0),"filter",a)},is:function(a){return!!a&&(typeof a=="string"?f.filter(a,this).length>0:this.filter(a).length>0)},closest:function(a,b){var c=[],d,e,g=this[0];if(f.isArray(a)){var h,i,j={},k=1;if(g&&a.length){for(d=0,e=a.length;d<e;d++)i=a[d],j[i]||(j[i]=S.test(i)?f(i,b||this.context):i);while(g&&g.ownerDocument&&g!==b){for(i in j)h=j[i],(h.jquery?h.index(g)>-1:f(g).is(h))&&c.push({selector:i,elem:g,level:k});g=g.parentNode,k++}}return c}var l=S.test(a)||typeof a!="string"?f(a,b||this.context):0;for(d=0,e=this.length;d<e;d++){g=this[d];while(g){if(l?l.index(g)>-1:f.find.matchesSelector(g,a)){c.push(g);break}g=g.parentNode;if(!g||!g.ownerDocument||g===b||g.nodeType===11)break}}c=c.length>1?f.unique(c):c;return this.pushStack(c,"closest",a)},index:function(a){if(!a)return this[0]&&this[0].parentNode?this.prevAll().length:-1;if(typeof a=="string")return f.inArray(this[0],f(a));return f.inArray(a.jquery?a[0]:a,this)},add:function(a,b){var c=typeof a=="string"?f(a,b):f.makeArray(a&&a.nodeType?[a]:a),d=f.merge(this.get(),c);return this.pushStack(U(c[0])||U(d[0])?d:f.unique(d))},andSelf:function(){return this.add(this.prevObject)}}),f.each({parent:function(a){var b=a.parentNode;return b&&b.nodeType!==11?b:null},parents:function(a){return f.dir(a,"parentNode")},parentsUntil:function(a,b,c){return f.dir(a,"parentNode",c)},next:function(a){return f.nth(a,2,"nextSibling")},prev:function(a){return f.nth(a,2,"previousSibling")},nextAll:function(a){return f.dir(a,"nextSibling")},prevAll:function(a){return f.dir(a,"previousSibling")},nextUntil:function(a,b,c){return f.dir(a,"nextSibling",c)},prevUntil:function(a,b,c){return f.dir(a,"previousSibling",c)},siblings:function(a){return f.sibling(a.parentNode.firstChild,a)},children:function(a){return f.sibling(a.firstChild)},contents:function(a){return f.nodeName(a,"iframe")?a.contentDocument||a.contentWindow.document:f.makeArray(a.childNodes)}},function(a,b){f.fn[a]=function(c,d){var e=f.map(this,b,c),g=R.call(arguments);N.test(a)||(d=c),d&&typeof d=="string"&&(e=f.filter(d,e)),e=this.length>1&&!T[a]?f.unique(e):e,(this.length>1||P.test(d))&&O.test(a)&&(e=e.reverse());return this.pushStack(e,a,g.join(","))}}),f.extend({filter:function(a,b,c){c&&(a=":not("+a+")");return b.length===1?f.find.matchesSelector(b[0],a)?[b[0]]:[]:f.find.matches(a,b)},dir:function(a,c,d){var e=[],g=a[c];while(g&&g.nodeType!==9&&(d===b||g.nodeType!==1||!f(g).is(d)))g.nodeType===1&&e.push(g),g=g[c];return e},nth:function(a,b,c,d){b=b||1;var e=0;for(;a;a=a[c])if(a.nodeType===1&&++e===b)break;return a},sibling:function(a,b){var c=[];for(;a;a=a.nextSibling)a.nodeType===1&&a!==b&&c.push(a);return c}});var W=/ jQuery\d+="(?:\d+|null)"/g,X=/^\s+/,Y=/<(?!area|br|col|embed|hr|img|input|link|meta|param)(([\w:]+)[^>]*)\/>/ig,Z=/<([\w:]+)/,$=/<tbody/i,_=/<|&#?\w+;/,ba=/<(?:script|object|embed|option|style)/i,bb=/checked\s*(?:[^=]|=\s*.checked.)/i,bc=/\/(java|ecma)script/i,bd=/^\s*<!(?:\[CDATA\[|\-\-)/,be={option:[1,"<select multiple='multiple'>","</select>"],legend:[1,"<fieldset>","</fieldset>"],thead:[1,"<table>","</table>"],tr:[2,"<table><tbody>","</tbody></table>"],td:[3,"<table><tbody><tr>","</tr></tbody></table>"],col:[2,"<table><tbody></tbody><colgroup>","</colgroup></table>"],area:[1,"<map>","</map>"],_default:[0,"",""]};be.optgroup=be.option,be.tbody=be.tfoot=be.colgroup=be.caption=be.thead,be.th=be.td,f.support.htmlSerialize||(be._default=[1,"div<div>","</div>"]),f.fn.extend({text:function(a){if(f.isFunction(a))return this.each(function(b){var c=f(this);c.text(a.call(this,b,c.text()))});if(typeof a!="object"&&a!==b)return this.empty().append((this[0]&&this[0].ownerDocument||c).createTextNode(a));return f.text(this)},wrapAll:function(a){if(f.isFunction(a))return this.each(function(b){f(this).wrapAll(a.call(this,b))});if(this[0]){var b=f(a,this[0].ownerDocument).eq(0).clone(!0);this[0].parentNode&&b.insertBefore(this[0]),b.map(function(){var a=this;while(a.firstChild&&a.firstChild.nodeType===1)a=a.firstChild;return a}).append(this)}return this},wrapInner:function(a){if(f.isFunction(a))return this.each(function(b){f(this).wrapInner(a.call(this,b))});return this.each(function(){var b=f(this),c=b.contents();c.length?c.wrapAll(a):b.append(a)})},wrap:function(a){return this.each(function(){f(this).wrapAll(a)})},unwrap:function(){return this.parent().each(function(){f.nodeName(this,"body")||f(this).replaceWith(this.childNodes)}).end()},append:function(){return this.domManip(arguments,!0,function(a){this.nodeType===1&&this.appendChild(a)})},prepend:function(){return this.domManip(arguments,!0,function(a){this.nodeType===1&&this.insertBefore(a,this.firstChild)})},before:function(){if(this[0]&&this[0].parentNode)return this.domManip(arguments,!1,function(a){this.parentNode.insertBefore(a,this)});if(arguments.length){var a=f(arguments[0]);a.push.apply(a,this.toArray());return this.pushStack(a,"before",arguments)}},after:function(){if(this[0]&&this[0].parentNode)return this.domManip(arguments,!1,function(a){this.parentNode.insertBefore(a,this.nextSibling)});if(arguments.length){var a=this.pushStack(this,"after",arguments);a.push.apply(a,f(arguments[0]).toArray());return a}},remove:function(a,b){for(var c=0,d;(d=this[c])!=null;c++)if(!a||f.filter(a,[d]).length)!b&&d.nodeType===1&&(f.cleanData(d.getElementsByTagName("*")),f.cleanData([d])),d.parentNode&&d.parentNode.removeChild(d);return this},empty:function(){for(var a=0,b;(b=this[a])!=null;a++){b.nodeType===1&&f.cleanData(b.getElementsByTagName("*"));while(b.firstChild)b.removeChild(b.firstChild)}return this},clone:function(a,b){a=a==null?!1:a,b=b==null?a:b;return this.map(function(){return f.clone(this,a,b)})},html:function(a){if(a===b)return this[0]&&this[0].nodeType===1?this[0].innerHTML.replace(W,""):null;if(typeof a=="string"&&!ba.test(a)&&(f.support.leadingWhitespace||!X.test(a))&&!be[(Z.exec(a)||["",""])[1].toLowerCase()]){a=a.replace(Y,"<$1></$2>");try{for(var c=0,d=this.length;c<d;c++)this[c].nodeType===1&&(f.cleanData(this[c].getElementsByTagName("*")),this[c].innerHTML=a)}catch(e){this.empty().append(a)}}else f.isFunction(a)?this.each(function(b){var c=f(this);c.html(a.call(this,b,c.html()))}):this.empty().append(a);return this},replaceWith:function(a){if(this[0]&&this[0].parentNode){if(f.isFunction(a))return this.each(function(b){var c=f(this),d=c.html();c.replaceWith(a.call(this,b,d))});typeof a!="string"&&(a=f(a).detach());return this.each(function(){var b=this.nextSibling,c=this.parentNode;f(this).remove(),b?f(b).before(a):f(c).append(a)})}return this.length?this.pushStack(f(f.isFunction(a)?a():a),"replaceWith",a):this},detach:function(a){return this.remove(a,!0)},domManip:function(a,c,d){var e,g,h,i,j=a[0],k=[];if(!f.support.checkClone&&arguments.length===3&&typeof j=="string"&&bb.test(j))return this.each(function(){f(this).domManip(a,c,d,!0)});if(f.isFunction(j))return this.each(function(e){var g=f(this);a[0]=j.call(this,e,c?g.html():b),g.domManip(a,c,d)});if(this[0]){i=j&&j.parentNode,f.support.parentNode&&i&&i.nodeType===11&&i.childNodes.length===this.length?e={fragment:i}:e=f.buildFragment(a,this,k),h=e.fragment,h.childNodes.length===1?g=h=h.firstChild:g=h.firstChild;if(g){c=c&&f.nodeName(g,"tr");for(var l=0,m=this.length,n=m-1;l<m;l++)d.call(c?bf(this[l],g):this[l],e.cacheable||m>1&&l<n?f.clone(h,!0,!0):h)}k.length&&f.each(k,bl)}return this}}),f.buildFragment=function(a,b,d){var e,g,h,i;b&&b[0]&&(i=b[0].ownerDocument||b[0]),i.createDocumentFragment||(i=c),a.length===1&&typeof a[0]=="string"&&a[0].length<512&&i===c&&a[0].charAt(0)==="<"&&!ba.test(a[0])&&(f.support.checkClone||!bb.test(a[0]))&&(g=!0,h=f.fragments[a[0]],h&&h!==1&&(e=h)),e||(e=i.createDocumentFragment(),f.clean(a,i,e,d)),g&&(f.fragments[a[0]]=h?e:1);
+return{fragment:e,cacheable:g}},f.fragments={},f.each({appendTo:"append",prependTo:"prepend",insertBefore:"before",insertAfter:"after",replaceAll:"replaceWith"},function(a,b){f.fn[a]=function(c){var d=[],e=f(c),g=this.length===1&&this[0].parentNode;if(g&&g.nodeType===11&&g.childNodes.length===1&&e.length===1){e[b](this[0]);return this}for(var h=0,i=e.length;h<i;h++){var j=(h>0?this.clone(!0):this).get();f(e[h])[b](j),d=d.concat(j)}return this.pushStack(d,a,e.selector)}}),f.extend({clone:function(a,b,c){var d=a.cloneNode(!0),e,g,h;if((!f.support.noCloneEvent||!f.support.noCloneChecked)&&(a.nodeType===1||a.nodeType===11)&&!f.isXMLDoc(a)){bh(a,d),e=bi(a),g=bi(d);for(h=0;e[h];++h)g[h]&&bh(e[h],g[h])}if(b){bg(a,d);if(c){e=bi(a),g=bi(d);for(h=0;e[h];++h)bg(e[h],g[h])}}e=g=null;return d},clean:function(a,b,d,e){var g;b=b||c,typeof b.createElement=="undefined"&&(b=b.ownerDocument||b[0]&&b[0].ownerDocument||c);var h=[],i;for(var j=0,k;(k=a[j])!=null;j++){typeof k=="number"&&(k+="");if(!k)continue;if(typeof k=="string")if(!_.test(k))k=b.createTextNode(k);else{k=k.replace(Y,"<$1></$2>");var l=(Z.exec(k)||["",""])[1].toLowerCase(),m=be[l]||be._default,n=m[0],o=b.createElement("div");o.innerHTML=m[1]+k+m[2];while(n--)o=o.lastChild;if(!f.support.tbody){var p=$.test(k),q=l==="table"&&!p?o.firstChild&&o.firstChild.childNodes:m[1]==="<table>"&&!p?o.childNodes:[];for(i=q.length-1;i>=0;--i)f.nodeName(q[i],"tbody")&&!q[i].childNodes.length&&q[i].parentNode.removeChild(q[i])}!f.support.leadingWhitespace&&X.test(k)&&o.insertBefore(b.createTextNode(X.exec(k)[0]),o.firstChild),k=o.childNodes}var r;if(!f.support.appendChecked)if(k[0]&&typeof (r=k.length)=="number")for(i=0;i<r;i++)bk(k[i]);else bk(k);k.nodeType?h.push(k):h=f.merge(h,k)}if(d){g=function(a){return!a.type||bc.test(a.type)};for(j=0;h[j];j++)if(e&&f.nodeName(h[j],"script")&&(!h[j].type||h[j].type.toLowerCase()==="text/javascript"))e.push(h[j].parentNode?h[j].parentNode.removeChild(h[j]):h[j]);else{if(h[j].nodeType===1){var s=f.grep(h[j].getElementsByTagName("script"),g);h.splice.apply(h,[j+1,0].concat(s))}d.appendChild(h[j])}}return h},cleanData:function(a){var b,c,d=f.cache,e=f.expando,g=f.event.special,h=f.support.deleteExpando;for(var i=0,j;(j=a[i])!=null;i++){if(j.nodeName&&f.noData[j.nodeName.toLowerCase()])continue;c=j[f.expando];if(c){b=d[c]&&d[c][e];if(b&&b.events){for(var k in b.events)g[k]?f.event.remove(j,k):f.removeEvent(j,k,b.handle);b.handle&&(b.handle.elem=null)}h?delete j[f.expando]:j.removeAttribute&&j.removeAttribute(f.expando),delete d[c]}}}});var bm=/alpha\([^)]*\)/i,bn=/opacity=([^)]*)/,bo=/([A-Z]|^ms)/g,bp=/^-?\d+(?:px)?$/i,bq=/^-?\d/,br=/^([\-+])=([\-+.\de]+)/,bs={position:"absolute",visibility:"hidden",display:"block"},bt=["Left","Right"],bu=["Top","Bottom"],bv,bw,bx;f.fn.css=function(a,c){if(arguments.length===2&&c===b)return this;return f.access(this,a,c,!0,function(a,c,d){return d!==b?f.style(a,c,d):f.css(a,c)})},f.extend({cssHooks:{opacity:{get:function(a,b){if(b){var c=bv(a,"opacity","opacity");return c===""?"1":c}return a.style.opacity}}},cssNumber:{fillOpacity:!0,fontWeight:!0,lineHeight:!0,opacity:!0,orphans:!0,widows:!0,zIndex:!0,zoom:!0},cssProps:{"float":f.support.cssFloat?"cssFloat":"styleFloat"},style:function(a,c,d,e){if(!!a&&a.nodeType!==3&&a.nodeType!==8&&!!a.style){var g,h,i=f.camelCase(c),j=a.style,k=f.cssHooks[i];c=f.cssProps[i]||i;if(d===b){if(k&&"get"in k&&(g=k.get(a,!1,e))!==b)return g;return j[c]}h=typeof d,h==="string"&&(g=br.exec(d))&&(d=+(g[1]+1)*+g[2]+parseFloat(f.css(a,c)),h="number");if(d==null||h==="number"&&isNaN(d))return;h==="number"&&!f.cssNumber[i]&&(d+="px");if(!k||!("set"in k)||(d=k.set(a,d))!==b)try{j[c]=d}catch(l){}}},css:function(a,c,d){var e,g;c=f.camelCase(c),g=f.cssHooks[c],c=f.cssProps[c]||c,c==="cssFloat"&&(c="float");if(g&&"get"in g&&(e=g.get(a,!0,d))!==b)return e;if(bv)return bv(a,c)},swap:function(a,b,c){var d={};for(var e in b)d[e]=a.style[e],a.style[e]=b[e];c.call(a);for(e in b)a.style[e]=d[e]}}),f.curCSS=f.css,f.each(["height","width"],function(a,b){f.cssHooks[b]={get:function(a,c,d){var e;if(c){if(a.offsetWidth!==0)return by(a,b,d);f.swap(a,bs,function(){e=by(a,b,d)});return e}},set:function(a,b){if(!bp.test(b))return b;b=parseFloat(b);if(b>=0)return b+"px"}}}),f.support.opacity||(f.cssHooks.opacity={get:function(a,b){return bn.test((b&&a.currentStyle?a.currentStyle.filter:a.style.filter)||"")?parseFloat(RegExp.$1)/100+"":b?"1":""},set:function(a,b){var c=a.style,d=a.currentStyle,e=f.isNaN(b)?"":"alpha(opacity="+b*100+")",g=d&&d.filter||c.filter||"";c.zoom=1;if(b>=1&&f.trim(g.replace(bm,""))===""){c.removeAttribute("filter");if(d&&!d.filter)return}c.filter=bm.test(g)?g.replace(bm,e):g+" "+e}}),f(function(){f.support.reliableMarginRight||(f.cssHooks.marginRight={get:function(a,b){var c;f.swap(a,{display:"inline-block"},function(){b?c=bv(a,"margin-right","marginRight"):c=a.style.marginRight});return c}})}),c.defaultView&&c.defaultView.getComputedStyle&&(bw=function(a,c){var d,e,g;c=c.replace(bo,"-$1").toLowerCase();if(!(e=a.ownerDocument.defaultView))return b;if(g=e.getComputedStyle(a,null))d=g.getPropertyValue(c),d===""&&!f.contains(a.ownerDocument.documentElement,a)&&(d=f.style(a,c));return d}),c.documentElement.currentStyle&&(bx=function(a,b){var c,d=a.currentStyle&&a.currentStyle[b],e=a.runtimeStyle&&a.runtimeStyle[b],f=a.style;!bp.test(d)&&bq.test(d)&&(c=f.left,e&&(a.runtimeStyle.left=a.currentStyle.left),f.left=b==="fontSize"?"1em":d||0,d=f.pixelLeft+"px",f.left=c,e&&(a.runtimeStyle.left=e));return d===""?"auto":d}),bv=bw||bx,f.expr&&f.expr.filters&&(f.expr.filters.hidden=function(a){var b=a.offsetWidth,c=a.offsetHeight;return b===0&&c===0||!f.support.reliableHiddenOffsets&&(a.style.display||f.css(a,"display"))==="none"},f.expr.filters.visible=function(a){return!f.expr.filters.hidden(a)});var bz=/%20/g,bA=/\[\]$/,bB=/\r?\n/g,bC=/#.*$/,bD=/^(.*?):[ \t]*([^\r\n]*)\r?$/mg,bE=/^(?:color|date|datetime|datetime-local|email|hidden|month|number|password|range|search|tel|text|time|url|week)$/i,bF=/^(?:about|app|app\-storage|.+\-extension|file|res|widget):$/,bG=/^(?:GET|HEAD)$/,bH=/^\/\//,bI=/\?/,bJ=/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi,bK=/^(?:select|textarea)/i,bL=/\s+/,bM=/([?&])_=[^&]*/,bN=/^([\w\+\.\-]+:)(?:\/\/([^\/?#:]*)(?::(\d+))?)?/,bO=f.fn.load,bP={},bQ={},bR,bS,bT=["*/"]+["*"];try{bR=e.href}catch(bU){bR=c.createElement("a"),bR.href="",bR=bR.href}bS=bN.exec(bR.toLowerCase())||[],f.fn.extend({load:function(a,c,d){if(typeof a!="string"&&bO)return bO.apply(this,arguments);if(!this.length)return this;var e=a.indexOf(" ");if(e>=0){var g=a.slice(e,a.length);a=a.slice(0,e)}var h="GET";c&&(f.isFunction(c)?(d=c,c=b):typeof c=="object"&&(c=f.param(c,f.ajaxSettings.traditional),h="POST"));var i=this;f.ajax({url:a,type:h,dataType:"html",data:c,complete:function(a,b,c){c=a.responseText,a.isResolved()&&(a.done(function(a){c=a}),i.html(g?f("<div>").append(c.replace(bJ,"")).find(g):c)),d&&i.each(d,[c,b,a])}});return this},serialize:function(){return f.param(this.serializeArray())},serializeArray:function(){return this.map(function(){return this.elements?f.makeArray(this.elements):this}).filter(function(){return this.name&&!this.disabled&&(this.checked||bK.test(this.nodeName)||bE.test(this.type))}).map(function(a,b){var c=f(this).val();return c==null?null:f.isArray(c)?f.map(c,function(a,c){return{name:b.name,value:a.replace(bB,"\r\n")}}):{name:b.name,value:c.replace(bB,"\r\n")}}).get()}}),f.each("ajaxStart ajaxStop ajaxComplete ajaxError ajaxSuccess ajaxSend".split(" "),function(a,b){f.fn[b]=function(a){return this.bind(b,a)}}),f.each(["get","post"],function(a,c){f[c]=function(a,d,e,g){f.isFunction(d)&&(g=g||e,e=d,d=b);return f.ajax({type:c,url:a,data:d,success:e,dataType:g})}}),f.extend({getScript:function(a,c){return f.get(a,b,c,"script")},getJSON:function(a,b,c){return f.get(a,b,c,"json")},ajaxSetup:function(a,b){b?bX(a,f.ajaxSettings):(b=a,a=f.ajaxSettings),bX(a,b);return a},ajaxSettings:{url:bR,isLocal:bF.test(bS[1]),global:!0,type:"GET",contentType:"application/x-www-form-urlencoded",processData:!0,async:!0,accepts:{xml:"application/xml, text/xml",html:"text/html",text:"text/plain",json:"application/json, text/javascript","*":bT},contents:{xml:/xml/,html:/html/,json:/json/},responseFields:{xml:"responseXML",text:"responseText"},converters:{"* text":a.String,"text html":!0,"text json":f.parseJSON,"text xml":f.parseXML},flatOptions:{context:!0,url:!0}},ajaxPrefilter:bV(bP),ajaxTransport:bV(bQ),ajax:function(a,c){function w(a,c,l,m){if(s!==2){s=2,q&&clearTimeout(q),p=b,n=m||"",v.readyState=a>0?4:0;var o,r,u,w=c,x=l?bZ(d,v,l):b,y,z;if(a>=200&&a<300||a===304){if(d.ifModified){if(y=v.getResponseHeader("Last-Modified"))f.lastModified[k]=y;if(z=v.getResponseHeader("Etag"))f.etag[k]=z}if(a===304)w="notmodified",o=!0;else try{r=b$(d,x),w="success",o=!0}catch(A){w="parsererror",u=A}}else{u=w;if(!w||a)w="error",a<0&&(a=0)}v.status=a,v.statusText=""+(c||w),o?h.resolveWith(e,[r,w,v]):h.rejectWith(e,[v,w,u]),v.statusCode(j),j=b,t&&g.trigger("ajax"+(o?"Success":"Error"),[v,d,o?r:u]),i.resolveWith(e,[v,w]),t&&(g.trigger("ajaxComplete",[v,d]),--f.active||f.event.trigger("ajaxStop"))}}typeof a=="object"&&(c=a,a=b),c=c||{};var d=f.ajaxSetup({},c),e=d.context||d,g=e!==d&&(e.nodeType||e instanceof f)?f(e):f.event,h=f.Deferred(),i=f._Deferred(),j=d.statusCode||{},k,l={},m={},n,o,p,q,r,s=0,t,u,v={readyState:0,setRequestHeader:function(a,b){if(!s){var c=a.toLowerCase();a=m[c]=m[c]||a,l[a]=b}return this},getAllResponseHeaders:function(){return s===2?n:null},getResponseHeader:function(a){var c;if(s===2){if(!o){o={};while(c=bD.exec(n))o[c[1].toLowerCase()]=c[2]}c=o[a.toLowerCase()]}return c===b?null:c},overrideMimeType:function(a){s||(d.mimeType=a);return this},abort:function(a){a=a||"abort",p&&p.abort(a),w(0,a);return this}};h.promise(v),v.success=v.done,v.error=v.fail,v.complete=i.done,v.statusCode=function(a){if(a){var b;if(s<2)for(b in a)j[b]=[j[b],a[b]];else b=a[v.status],v.then(b,b)}return this},d.url=((a||d.url)+"").replace(bC,"").replace(bH,bS[1]+"//"),d.dataTypes=f.trim(d.dataType||"*").toLowerCase().split(bL),d.crossDomain==null&&(r=bN.exec(d.url.toLowerCase()),d.crossDomain=!(!r||r[1]==bS[1]&&r[2]==bS[2]&&(r[3]||(r[1]==="http:"?80:443))==(bS[3]||(bS[1]==="http:"?80:443)))),d.data&&d.processData&&typeof d.data!="string"&&(d.data=f.param(d.data,d.traditional)),bW(bP,d,c,v);if(s===2)return!1;t=d.global,d.type=d.type.toUpperCase(),d.hasContent=!bG.test(d.type),t&&f.active++===0&&f.event.trigger("ajaxStart");if(!d.hasContent){d.data&&(d.url+=(bI.test(d.url)?"&":"?")+d.data,delete d.data),k=d.url;if(d.cache===!1){var x=f.now(),y=d.url.replace(bM,"$1_="+x);d.url=y+(y===d.url?(bI.test(d.url)?"&":"?")+"_="+x:"")}}(d.data&&d.hasContent&&d.contentType!==!1||c.contentType)&&v.setRequestHeader("Content-Type",d.contentType),d.ifModified&&(k=k||d.url,f.lastModified[k]&&v.setRequestHeader("If-Modified-Since",f.lastModified[k]),f.etag[k]&&v.setRequestHeader("If-None-Match",f.etag[k])),v.setRequestHeader("Accept",d.dataTypes[0]&&d.accepts[d.dataTypes[0]]?d.accepts[d.dataTypes[0]]+(d.dataTypes[0]!=="*"?", "+bT+"; q=0.01":""):d.accepts["*"]);for(u in d.headers)v.setRequestHeader(u,d.headers[u]);if(d.beforeSend&&(d.beforeSend.call(e,v,d)===!1||s===2)){v.abort();return!1}for(u in{success:1,error:1,complete:1})v[u](d[u]);p=bW(bQ,d,c,v);if(!p)w(-1,"No Transport");else{v.readyState=1,t&&g.trigger("ajaxSend",[v,d]),d.async&&d.timeout>0&&(q=setTimeout(function(){v.abort("timeout")},d.timeout));try{s=1,p.send(l,w)}catch(z){s<2?w(-1,z):f.error(z)}}return v},param:function(a,c){var d=[],e=function(a,b){b=f.isFunction(b)?b():b,d[d.length]=encodeURIComponent(a)+"="+encodeURIComponent(b)};c===b&&(c=f.ajaxSettings.traditional);if(f.isArray(a)||a.jquery&&!f.isPlainObject(a))f.each(a,function(){e(this.name,this.value)});else for(var g in a)bY(g,a[g],c,e);return d.join("&").replace(bz,"+")}}),f.extend({active:0,lastModified:{},etag:{}});var b_=f.now(),ca=/(\=)\?(&|$)|\?\?/i;f.ajaxSetup({jsonp:"callback",jsonpCallback:function(){return f.expando+"_"+b_++}}),f.ajaxPrefilter("json jsonp",function(b,c,d){var e=b.contentType==="application/x-www-form-urlencoded"&&typeof b.data=="string";if(b.dataTypes[0]==="jsonp"||b.jsonp!==!1&&(ca.test(b.url)||e&&ca.test(b.data))){var g,h=b.jsonpCallback=f.isFunction(b.jsonpCallback)?b.jsonpCallback():b.jsonpCallback,i=a[h],j=b.url,k=b.data,l="$1"+h+"$2";b.jsonp!==!1&&(j=j.replace(ca,l),b.url===j&&(e&&(k=k.replace(ca,l)),b.data===k&&(j+=(/\?/.test(j)?"&":"?")+b.jsonp+"="+h))),b.url=j,b.data=k,a[h]=function(a){g=[a]},d.always(function(){a[h]=i,g&&f.isFunction(i)&&a[h](g[0])}),b.converters["script json"]=function(){g||f.error(h+" was not called");return g[0]},b.dataTypes[0]="json";return"script"}}),f.ajaxSetup({accepts:{script:"text/javascript, application/javascript, application/ecmascript, application/x-ecmascript"},contents:{script:/javascript|ecmascript/},converters:{"text script":function(a){f.globalEval(a);return a}}}),f.ajaxPrefilter("script",function(a){a.cache===b&&(a.cache=!1),a.crossDomain&&(a.type="GET",a.global=!1)}),f.ajaxTransport("script",function(a){if(a.crossDomain){var d,e=c.head||c.getElementsByTagName("head")[0]||c.documentElement;return{send:function(f,g){d=c.createElement("script"),d.async="async",a.scriptCharset&&(d.charset=a.scriptCharset),d.src=a.url,d.onload=d.onreadystatechange=function(a,c){if(c||!d.readyState||/loaded|complete/.test(d.readyState))d.onload=d.onreadystatechange=null,e&&d.parentNode&&e.removeChild(d),d=b,c||g(200,"success")},e.insertBefore(d,e.firstChild)},abort:function(){d&&d.onload(0,1)}}}});var cb=a.ActiveXObject?function(){for(var a in cd)cd[a](0,1)}:!1,cc=0,cd;f.ajaxSettings.xhr=a.ActiveXObject?function(){return!this.isLocal&&ce()||cf()}:ce,function(a){f.extend(f.support,{ajax:!!a,cors:!!a&&"withCredentials"in a})}(f.ajaxSettings.xhr()),f.support.ajax&&f.ajaxTransport(function(c){if(!c.crossDomain||f.support.cors){var d;return{send:function(e,g){var h=c.xhr(),i,j;c.username?h.open(c.type,c.url,c.async,c.username,c.password):h.open(c.type,c.url,c.async);if(c.xhrFields)for(j in c.xhrFields)h[j]=c.xhrFields[j];c.mimeType&&h.overrideMimeType&&h.overrideMimeType(c.mimeType),!c.crossDomain&&!e["X-Requested-With"]&&(e["X-Requested-With"]="XMLHttpRequest");try{for(j in e)h.setRequestHeader(j,e[j])}catch(k){}h.send(c.hasContent&&c.data||null),d=function(a,e){var j,k,l,m,n;try{if(d&&(e||h.readyState===4)){d=b,i&&(h.onreadystatechange=f.noop,cb&&delete cd[i]);if(e)h.readyState!==4&&h.abort();else{j=h.status,l=h.getAllResponseHeaders(),m={},n=h.responseXML,n&&n.documentElement&&(m.xml=n),m.text=h.responseText;try{k=h.statusText}catch(o){k=""}!j&&c.isLocal&&!c.crossDomain?j=m.text?200:404:j===1223&&(j=204)}}}catch(p){e||g(-1,p)}m&&g(j,k,m,l)},!c.async||h.readyState===4?d():(i=++cc,cb&&(cd||(cd={},f(a).unload(cb)),cd[i]=d),h.onreadystatechange=d)},abort:function(){d&&d(0,1)}}}});var cg={},ch,ci,cj=/^(?:toggle|show|hide)$/,ck=/^([+\-]=)?([\d+.\-]+)([a-z%]*)$/i,cl,cm=[["height","marginTop","marginBottom","paddingTop","paddingBottom"],["width","marginLeft","marginRight","paddingLeft","paddingRight"],["opacity"]],cn;f.fn.extend({show:function(a,b,c){var d,e;if(a||a===0)return this.animate(cq("show",3),a,b,c);for(var g=0,h=this.length;g<h;g++)d=this[g],d.style&&(e=d.style.display,!f._data(d,"olddisplay")&&e==="none"&&(e=d.style.display=""),e===""&&f.css(d,"display")==="none"&&f._data(d,"olddisplay",cr(d.nodeName)));for(g=0;g<h;g++){d=this[g];if(d.style){e=d.style.display;if(e===""||e==="none")d.style.display=f._data(d,"olddisplay")||""}}return this},hide:function(a,b,c){if(a||a===0)return this.animate(cq("hide",3),a,b,c);for(var d=0,e=this.length;d<e;d++)if(this[d].style){var g=f.css(this[d],"display");g!=="none"&&!f._data(this[d],"olddisplay")&&f._data(this[d],"olddisplay",g)}for(d=0;d<e;d++)this[d].style&&(this[d].style.display="none");return this},_toggle:f.fn.toggle,toggle:function(a,b,c){var d=typeof a=="boolean";f.isFunction(a)&&f.isFunction(b)?this._toggle.apply(this,arguments):a==null||d?this.each(function(){var b=d?a:f(this).is(":hidden");f(this)[b?"show":"hide"]()}):this.animate(cq("toggle",3),a,b,c);return this},fadeTo:function(a,b,c,d){return this.filter(":hidden").css("opacity",0).show().end().animate({opacity:b},a,c,d)},animate:function(a,b,c,d){var e=f.speed(b,c,d);if(f.isEmptyObject(a))return this.each(e.complete,[!1]);a=f.extend({},a);return this[e.queue===!1?"each":"queue"](function(){e.queue===!1&&f._mark(this);var b=f.extend({},e),c=this.nodeType===1,d=c&&f(this).is(":hidden"),g,h,i,j,k,l,m,n,o;b.animatedProperties={};for(i in a){g=f.camelCase(i),i!==g&&(a[g]=a[i],delete a[i]),h=a[g],f.isArray(h)?(b.animatedProperties[g]=h[1],h=a[g]=h[0]):b.animatedProperties[g]=b.specialEasing&&b.specialEasing[g]||b.easing||"swing";if(h==="hide"&&d||h==="show"&&!d)return b.complete.call(this);c&&(g==="height"||g==="width")&&(b.overflow=[this.style.overflow,this.style.overflowX,this.style.overflowY],f.css(this,"display")==="inline"&&f.css(this,"float")==="none"&&(f.support.inlineBlockNeedsLayout?(j=cr(this.nodeName),j==="inline"?this.style.display="inline-block":(this.style.display="inline",this.style.zoom=1)):this.style.display="inline-block"))}b.overflow!=null&&(this.style.overflow="hidden");for(i in a)k=new f.fx(this,b,i),h=a[i],cj.test(h)?k[h==="toggle"?d?"show":"hide":h]():(l=ck.exec(h),m=k.cur(),l?(n=parseFloat(l[2]),o=l[3]||(f.cssNumber[i]?"":"px"),o!=="px"&&(f.style(this,i,(n||1)+o),m=(n||1)/k.cur()*m,f.style(this,i,m+o)),l[1]&&(n=(l[1]==="-="?-1:1)*n+m),k.custom(m,n,o)):k.custom(m,h,""));return!0})},stop:function(a,b){a&&this.queue([]),this.each(function(){var a=f.timers,c=a.length;b||f._unmark(!0,this);while(c--)a[c].elem===this&&(b&&a[c](!0),a.splice(c,1))}),b||this.dequeue();return this}}),f.each({slideDown:cq("show",1),slideUp:cq("hide",1),slideToggle:cq("toggle",1),fadeIn:{opacity:"show"},fadeOut:{opacity:"hide"},fadeToggle:{opacity:"toggle"}},function(a,b){f.fn[a]=function(a,c,d){return this.animate(b,a,c,d)}}),f.extend({speed:function(a,b,c){var d=a&&typeof a=="object"?f.extend({},a):{complete:c||!c&&b||f.isFunction(a)&&a,duration:a,easing:c&&b||b&&!f.isFunction(b)&&b};d.duration=f.fx.off?0:typeof d.duration=="number"?d.duration:d.duration in f.fx.speeds?f.fx.speeds[d.duration]:f.fx.speeds._default,d.old=d.complete,d.complete=function(a){f.isFunction(d.old)&&d.old.call(this),d.queue!==!1?f.dequeue(this):a!==!1&&f._unmark(this)};return d},easing:{linear:function(a,b,c,d){return c+d*a},swing:function(a,b,c,d){return(-Math.cos(a*Math.PI)/2+.5)*d+c}},timers:[],fx:function(a,b,c){this.options=b,this.elem=a,this.prop=c,b.orig=b.orig||{}}}),f.fx.prototype={update:function(){this.options.step&&this.options.step.call(this.elem,this.now,this),(f.fx.step[this.prop]||f.fx.step._default)(this)},cur:function(){if(this.elem[this.prop]!=null&&(!this.elem.style||this.elem.style[this.prop]==null))return this.elem[this.prop];var a,b=f.css(this.elem,this.prop);return isNaN(a=parseFloat(b))?!b||b==="auto"?0:b:a},custom:function(a,b,c){function g(a){return d.step(a)}var d=this,e=f.fx;this.startTime=cn||co(),this.start=a,this.end=b,this.unit=c||this.unit||(f.cssNumber[this.prop]?"":"px"),this.now=this.start,this.pos=this.state=0,g.elem=this.elem,g()&&f.timers.push(g)&&!cl&&(cl=setInterval(e.tick,e.interval))},show:function(){this.options.orig[this.prop]=f.style(this.elem,this.prop),this.options.show=!0,this.custom(this.prop==="width"||this.prop==="height"?1:0,this.cur()),f(this.elem).show()},hide:function(){this.options.orig[this.prop]=f.style(this.elem,this.prop),this.options.hide=!0,this.custom(this.cur(),0)},step:function(a){var b=cn||co(),c=!0,d=this.elem,e=this.options,g,h;if(a||b>=e.duration+this.startTime){this.now=this.end,this.pos=this.state=1,this.update(),e.animatedProperties[this.prop]=!0;for(g in e.animatedProperties)e.animatedProperties[g]!==!0&&(c=!1);if(c){e.overflow!=null&&!f.support.shrinkWrapBlocks&&f.each(["","X","Y"],function(a,b){d.style["overflow"+b]=e.overflow[a]}),e.hide&&f(d).hide();if(e.hide||e.show)for(var i in e.animatedProperties)f.style(d,i,e.orig[i]);e.complete.call(d)}return!1}e.duration==Infinity?this.now=b:(h=b-this.startTime,this.state=h/e.duration,this.pos=f.easing[e.animatedProperties[this.prop]](this.state,h,0,1,e.duration),this.now=this.start+(this.end-this.start)*this.pos),this.update();return!0}},f.extend(f.fx,{tick:function(){for(var a=f.timers,b=0;b<a.length;++b)a[b]()||a.splice(b--,1);a.length||f.fx.stop()},interval:13,stop:function(){clearInterval(cl),cl=null},speeds:{slow:600,fast:200,_default:400},step:{opacity:function(a){f.style(a.elem,"opacity",a.now)},_default:function(a){a.elem.style&&a.elem.style[a.prop]!=null?a.elem.style[a.prop]=(a.prop==="width"||a.prop==="height"?Math.max(0,a.now):a.now)+a.unit:a.elem[a.prop]=a.now}}}),f.expr&&f.expr.filters&&(f.expr.filters.animated=function(a){return f.grep(f.timers,function(b){return a===b.elem}).length});var cs=/^t(?:able|d|h)$/i,ct=/^(?:body|html)$/i;"getBoundingClientRect"in c.documentElement?f.fn.offset=function(a){var b=this[0],c;if(a)return this.each(function(b){f.offset.setOffset(this,a,b)});if(!b||!b.ownerDocument)return null;if(b===b.ownerDocument.body)return f.offset.bodyOffset(b);try{c=b.getBoundingClientRect()}catch(d){}var e=b.ownerDocument,g=e.documentElement;if(!c||!f.contains(g,b))return c?{top:c.top,left:c.left}:{top:0,left:0};var h=e.body,i=cu(e),j=g.clientTop||h.clientTop||0,k=g.clientLeft||h.clientLeft||0,l=i.pageYOffset||f.support.boxModel&&g.scrollTop||h.scrollTop,m=i.pageXOffset||f.support.boxModel&&g.scrollLeft||h.scrollLeft,n=c.top+l-j,o=c.left+m-k;return{top:n,left:o}}:f.fn.offset=function(a){var b=this[0];if(a)return this.each(function(b){f.offset.setOffset(this,a,b)});if(!b||!b.ownerDocument)return null;if(b===b.ownerDocument.body)return f.offset.bodyOffset(b);f.offset.initialize();var c,d=b.offsetParent,e=b,g=b.ownerDocument,h=g.documentElement,i=g.body,j=g.defaultView,k=j?j.getComputedStyle(b,null):b.currentStyle,l=b.offsetTop,m=b.offsetLeft;while((b=b.parentNode)&&b!==i&&b!==h){if(f.offset.supportsFixedPosition&&k.position==="fixed")break;c=j?j.getComputedStyle(b,null):b.currentStyle,l-=b.scrollTop,m-=b.scrollLeft,b===d&&(l+=b.offsetTop,m+=b.offsetLeft,f.offset.doesNotAddBorder&&(!f.offset.doesAddBorderForTableAndCells||!cs.test(b.nodeName))&&(l+=parseFloat(c.borderTopWidth)||0,m+=parseFloat(c.borderLeftWidth)||0),e=d,d=b.offsetParent),f.offset.subtractsBorderForOverflowNotVisible&&c.overflow!=="visible"&&(l+=parseFloat(c.borderTopWidth)||0,m+=parseFloat(c.borderLeftWidth)||0),k=c}if(k.position==="relative"||k.position==="static")l+=i.offsetTop,m+=i.offsetLeft;f.offset.supportsFixedPosition&&k.position==="fixed"&&(l+=Math.max(h.scrollTop,i.scrollTop),m+=Math.max(h.scrollLeft,i.scrollLeft));return{top:l,left:m}},f.offset={initialize:function(){var a=c.body,b=c.createElement("div"),d,e,g,h,i=parseFloat(f.css(a,"marginTop"))||0,j="<div style='position:absolute;top:0;left:0;margin:0;border:5px solid #000;padding:0;width:1px;height:1px;'><div></div></div><table style='position:absolute;top:0;left:0;margin:0;border:5px solid #000;padding:0;width:1px;height:1px;' cellpadding='0' cellspacing='0'><tr><td></td></tr></table>";f.extend(b.style,{position:"absolute",top:0,left:0,margin:0,border:0,width:"1px",height:"1px",visibility:"hidden"}),b.innerHTML=j,a.insertBefore(b,a.firstChild),d=b.firstChild,e=d.firstChild,h=d.nextSibling.firstChild.firstChild,this.doesNotAddBorder=e.offsetTop!==5,this.doesAddBorderForTableAndCells=h.offsetTop===5,e.style.position="fixed",e.style.top="20px",this.supportsFixedPosition=e.offsetTop===20||e.offsetTop===15,e.style.position=e.style.top="",d.style.overflow="hidden",d.style.position="relative",this.subtractsBorderForOverflowNotVisible=e.offsetTop===-5,this.doesNotIncludeMarginInBodyOffset=a.offsetTop!==i,a.removeChild(b),f.offset.initialize=f.noop},bodyOffset:function(a){var b=a.offsetTop,c=a.offsetLeft;f.offset.initialize(),f.offset.doesNotIncludeMarginInBodyOffset&&(b+=parseFloat(f.css(a,"marginTop"))||0,c+=parseFloat(f.css(a,"marginLeft"))||0);return{top:b,left:c}},setOffset:function(a,b,c){var d=f.css(a,"position");d==="static"&&(a.style.position="relative");var e=f(a),g=e.offset(),h=f.css(a,"top"),i=f.css(a,"left"),j=(d==="absolute"||d==="fixed")&&f.inArray("auto",[h,i])>-1,k={},l={},m,n;j?(l=e.position(),m=l.top,n=l.left):(m=parseFloat(h)||0,n=parseFloat(i)||0),f.isFunction(b)&&(b=b.call(a,c,g)),b.top!=null&&(k.top=b.top-g.top+m),b.left!=null&&(k.left=b.left-g.left+n),"using"in b?b.using.call(a,k):e.css(k)}},f.fn.extend({position:function(){if(!this[0])return null;var a=this[0],b=this.offsetParent(),c=this.offset(),d=ct.test(b[0].nodeName)?{top:0,left:0}:b.offset();c.top-=parseFloat(f.css(a,"marginTop"))||0,c.left-=parseFloat(f.css(a,"marginLeft"))||0,d.top+=parseFloat(f.css(b[0],"borderTopWidth"))||0,d.left+=parseFloat(f.css(b[0],"borderLeftWidth"))||0;return{top:c.top-d.top,left:c.left-d.left}},offsetParent:function(){return this.map(function(){var a=this.offsetParent||c.body;while(a&&!ct.test(a.nodeName)&&f.css(a,"position")==="static")a=a.offsetParent;return a})}}),f.each(["Left","Top"],function(a,c){var d="scroll"+c;f.fn[d]=function(c){var e,g;if(c===b){e=this[0];if(!e)return null;g=cu(e);return g?"pageXOffset"in g?g[a?"pageYOffset":"pageXOffset"]:f.support.boxModel&&g.document.documentElement[d]||g.document.body[d]:e[d]}return this.each(function(){g=cu(this),g?g.scrollTo(a?f(g).scrollLeft():c,a?c:f(g).scrollTop()):this[d]=c})}}),f.each(["Height","Width"],function(a,c){var d=c.toLowerCase();f.fn["inner"+c]=function(){var a=this[0];return a&&a.style?parseFloat(f.css(a,d,"padding")):null},f.fn["outer"+c]=function(a){var b=this[0];return b&&b.style?parseFloat(f.css(b,d,a?"margin":"border")):null},f.fn[d]=function(a){var e=this[0];if(!e)return a==null?null:this;if(f.isFunction(a))return this.each(function(b){var c=f(this);c[d](a.call(this,b,c[d]()))});if(f.isWindow(e)){var g=e.document.documentElement["client"+c],h=e.document.body;return e.document.compatMode==="CSS1Compat"&&g||h&&h["client"+c]||g}if(e.nodeType===9)return Math.max(e.documentElement["client"+c],e.body["scroll"+c],e.documentElement["scroll"+c],e.body["offset"+c],e.documentElement["offset"+c]);if(a===b){var i=f.css(e,d),j=parseFloat(i);return f.isNaN(j)?i:j}return this.css(d,typeof a=="string"?a:a+"px")}}),a.jQuery=a.$=f})(window);    }
+})(window, void(0));// Scheme numbers.
+
+
+var __PLTNUMBERS_TOP__;
+if (typeof(exports) !== 'undefined') {
+    __PLTNUMBERS_TOP__ = exports;
+} else {
+    if (! this['jsnums']) {
+ 	this['jsnums'] = {};
+    }
+    __PLTNUMBERS_TOP__  = this['jsnums'];
+}
+
+//var jsnums = {};
+
+
+// The numeric tower has the following levels:
+//     integers
+//     rationals
+//     floats
+//     complex numbers
+//
+// with the representations:
+//     integers: fixnum or BigInteger [level=0]
+//     rationals: Rational [level=1]
+//     floats: FloatPoint [level=2]
+//     complex numbers: Complex [level=3]
+
+// We try to stick with the unboxed fixnum representation for
+// integers, since that's what scheme programs commonly deal with, and
+// we want that common type to be lightweight.
+
+
+// A boxed-scheme-number is either BigInteger, Rational, FloatPoint, or Complex.
+// An integer-scheme-number is either fixnum or BigInteger.
+
+
+(function() {
+    'use strict';
+    // Abbreviation
+    var Numbers = __PLTNUMBERS_TOP__;
+    //var Numbers = jsnums;
+
+
+    // makeNumericBinop: (fixnum fixnum -> any) (scheme-number scheme-number -> any) -> (scheme-number scheme-number) X
+    // Creates a binary function that works either on fixnums or boxnums.
+    // Applies the appropriate binary function, ensuring that both scheme numbers are
+    // lifted to the same level.
+    var makeNumericBinop = function(onFixnums, onBoxednums, options) {
+	options = options || {};
+	return function(x, y) {
+	    if (options.isXSpecialCase && options.isXSpecialCase(x))
+		return options.onXSpecialCase(x, y);
+	    if (options.isYSpecialCase && options.isYSpecialCase(y))
+		return options.onYSpecialCase(x, y);
+
+	    if (typeof(x) === 'number' &&
+		typeof(y) === 'number') {
+		return onFixnums(x, y);
+	    }
+	    if (typeof(x) === 'number') {
+		x = liftFixnumInteger(x, y);
+	    }
+	    if (typeof(y) === 'number') {
+		y = liftFixnumInteger(y, x);
+	    }
+
+	    if (x.level < y.level) x = x.liftTo(y);
+	    if (y.level < x.level) y = y.liftTo(x);
+	    return onBoxednums(x, y);
+	};
+    }
+    
+    
+    // fromFixnum: fixnum -> scheme-number
+    var fromFixnum = function(x) {
+	if (isNaN(x) || (! isFinite(x))) {
+	    return FloatPoint.makeInstance(x);
+	}
+	var nf = Math.floor(x);
+	if (nf === x) {
+            if (isOverflow(nf)) {
+		return makeBignum(expandExponent(x+''));
+            } else {
+		return nf;
+	    }
+	} else {
+            return FloatPoint.makeInstance(x);
+	}
+    };
+
+    var expandExponent = function(s) {
+	var match = s.match(scientificPattern), mantissaChunks, exponent;
+	if (match) {
+	    mantissaChunks = match[1].match(/^([^.]*)(.*)$/);
+	    exponent = Number(match[2]);
+
+	    if (mantissaChunks[2].length === 0) {
+		return mantissaChunks[1] + zfill(exponent);
+	    }
+
+	    if (exponent >= mantissaChunks[2].length - 1) {
+		return (mantissaChunks[1] + 
+			mantissaChunks[2].substring(1) + 
+			zfill(exponent - (mantissaChunks[2].length - 1)));
+	    } else {
+		return (mantissaChunks[1] +
+			mantissaChunks[2].substring(1, 1+exponent));
+	    }
+	} else {
+	    return s;
+	}
+    };
+
+    // zfill: integer -> string
+    // builds a string of "0"'s of length n.
+    var zfill = function(n) {
+	var buffer = [];
+	buffer.length = n;
+	for (var i = 0; i < n; i++) {
+	    buffer[i] = '0';
+	}
+	return buffer.join('');
+    };
+    
+
+    
+    // liftFixnumInteger: fixnum-integer boxed-scheme-number -> boxed-scheme-number
+    // Lifts up fixnum integers to a boxed type.
+    var liftFixnumInteger = function(x, other) {
+	switch(other.level) {
+	case 0: // BigInteger
+	    return makeBignum(x);
+	case 1: // Rational
+	    return new Rational(x, 1);
+	case 2: // FloatPoint
+	    return new FloatPoint(x);
+	case 3: // Complex
+	    return new Complex(x, 0);
+	default:
+	    throwRuntimeError("IMPOSSIBLE: cannot lift fixnum integer to " + other.toString(), x, other);
+	}
+    };
+    
+    
+    // throwRuntimeError: string (scheme-number | undefined) (scheme-number | undefined) -> void
+    // Throws a runtime error with the given message string.
+    var throwRuntimeError = function(msg, x, y) {
+	Numbers['onThrowRuntimeError'](msg, x, y);
+    };
+
+
+
+    // onThrowRuntimeError: string (scheme-number | undefined) (scheme-number | undefined) -> void
+    // By default, will throw a new Error with the given message.
+    // Override Numbers['onThrowRuntimeError'] if you need to do something special.
+    var onThrowRuntimeError = function(msg, x, y) {
+	throw new Error(msg);
+    };
+
+
+    // isSchemeNumber: any -> boolean
+    // Returns true if the thing is a scheme number.
+    var isSchemeNumber = function(thing) {
+	return (typeof(thing) === 'number'
+		|| (thing instanceof Rational ||
+		    thing instanceof FloatPoint ||
+		    thing instanceof Complex ||
+		    thing instanceof BigInteger));
+    };
+
+
+    // isRational: scheme-number -> boolean
+    var isRational = function(n) {
+	return (typeof(n) === 'number' ||
+		(isSchemeNumber(n) && n.isRational()));
+    };
+
+    // isReal: scheme-number -> boolean
+    var isReal = function(n) {
+	return (typeof(n) === 'number' ||
+		(isSchemeNumber(n) && n.isReal()));
+    };
+
+    // isExact: scheme-number -> boolean
+    var isExact = function(n) {
+	return (typeof(n) === 'number' || 
+		(isSchemeNumber(n) && n.isExact()));
+    };
+
+    // isExact: scheme-number -> boolean
+    var isInexact = function(n) {
+	if (typeof(n) === 'number') {
+	    return false;
+	} else {
+	    return (isSchemeNumber(n) && n.isInexact());
+	}
+    };
+
+    // isInteger: scheme-number -> boolean
+    var isInteger = function(n) {
+	return (typeof(n) === 'number' ||
+		(isSchemeNumber(n) && n.isInteger()));
+    };
+
+    // isExactInteger: scheme-number -> boolean
+    var isExactInteger = function(n) {
+	return (typeof(n) === 'number' ||
+		(isSchemeNumber(n) && 
+		 n.isInteger() && 
+		 n.isExact()));
+    }
+
+
+
+    // toFixnum: scheme-number -> javascript-number
+    var toFixnum = function(n) {
+	if (typeof(n) === 'number')
+	    return n;
+	return n.toFixnum();
+    };
+
+    // toExact: scheme-number -> scheme-number
+    var toExact = function(n) {
+	if (typeof(n) === 'number')
+	    return n;
+	return n.toExact();
+    };
+
+
+    // toExact: scheme-number -> scheme-number
+    var toInexact = function(n) {
+	if (typeof(n) === 'number')
+	    return FloatPoint.makeInstance(n);
+	return n.toInexact();
+    };
+
+
+
+    //////////////////////////////////////////////////////////////////////
+
+
+    // add: scheme-number scheme-number -> scheme-number
+    var add = function(x, y) {
+        var sum;
+        if (typeof(x) === 'number' && typeof(y) === 'number') {
+            sum = x + y;
+            if (isOverflow(sum)) {
+		return (makeBignum(x)).add(makeBignum(y));
+            }
+        }
+        if (x instanceof FloatPoint && y instanceof FloatPoint) {
+            return x.add(y);
+        }
+        return addSlow(x, y);        
+    };
+
+    var addSlow = makeNumericBinop(
+	function(x, y) {
+	    var sum = x + y;
+	    if (isOverflow(sum)) {
+		return (makeBignum(x)).add(makeBignum(y));
+	    } else {
+		return sum;
+	    }
+	},
+	function(x, y) {
+	    return x.add(y);
+	},
+	{isXSpecialCase: function(x) { 
+	    return isExactInteger(x) && _integerIsZero(x) },
+	 onXSpecialCase: function(x, y) { return y; },
+	 isYSpecialCase: function(y) { 
+	     return isExactInteger(y) && _integerIsZero(y) },
+	 onYSpecialCase: function(x, y) { return x; }
+	});
+
+
+    // subtract: scheme-number scheme-number -> scheme-number
+    var subtract = makeNumericBinop(
+	function(x, y) {
+	    var diff = x - y;
+	    if (isOverflow(diff)) {
+		return (makeBignum(x)).subtract(makeBignum(y));
+	    } else {
+		return diff;
+	    }
+	},
+	function(x, y) {
+	    return x.subtract(y);
+	},
+	{isXSpecialCase: function(x) { 
+	    return isExactInteger(x) && _integerIsZero(x) },
+	 onXSpecialCase: function(x, y) { return negate(y); },
+	 isYSpecialCase: function(y) { 
+	     return isExactInteger(y) && _integerIsZero(y) },
+	 onYSpecialCase: function(x, y) { return x; }
+	});
+
+
+    // mulitply: scheme-number scheme-number -> scheme-number
+    var multiply = function(x, y) {
+        var prod;
+        if (typeof(x) === 'number' && typeof(y) === 'number') {
+	    prod = x * y;
+	    if (isOverflow(prod)) {
+		return (makeBignum(x)).multiply(makeBignum(y));
+            } else {
+                return prod;
+            }
+        }
+        if (x instanceof FloatPoint && y instanceof FloatPoint) {
+            return x.multiply(y);
+        }
+        return multiplySlow(x, y);
+    };
+    var multiplySlow = makeNumericBinop(
+	function(x, y) {
+	    var prod = x * y;
+	    if (isOverflow(prod)) {
+		return (makeBignum(x)).multiply(makeBignum(y));
+	    } else {
+		return prod;
+	    }
+	},
+	function(x, y) {
+	    return x.multiply(y);
+	},
+	{isXSpecialCase: function(x) { 
+	    return (isExactInteger(x) && 
+		    (_integerIsZero(x) || _integerIsOne(x) || _integerIsNegativeOne(x))) },
+	 onXSpecialCase: function(x, y) { 
+	     if (_integerIsZero(x))
+		 return 0;
+	     if (_integerIsOne(x))
+		 return y;
+	     if (_integerIsNegativeOne(x))
+		 return negate(y);
+	 },
+	 isYSpecialCase: function(y) { 
+	     return (isExactInteger(y) && 
+		     (_integerIsZero(y) || _integerIsOne(y) || _integerIsNegativeOne(y)))},
+	 onYSpecialCase: function(x, y) { 
+	     if (_integerIsZero(y))
+		 return 0;
+	     if (_integerIsOne(y))
+		 return x;
+	     if (_integerIsNegativeOne(y)) 
+		 return negate(x);
+	 }
+	});
+
+    
+    // divide: scheme-number scheme-number -> scheme-number
+    var divide = makeNumericBinop(
+	function(x, y) {
+	    if (_integerIsZero(y))
+		throwRuntimeError("/: division by zero", x, y);
+	    var div = x / y;
+	    if (isOverflow(div)) {
+		return (makeBignum(x)).divide(makeBignum(y));
+	    } else if (Math.floor(div) !== div) {
+		return Rational.makeInstance(x, y);
+	    } else {
+		return div;
+	    }
+	},
+	function(x, y) {
+	    return x.divide(y);
+	},
+	{ isXSpecialCase: function(x) {
+	    return (eqv(x, 0));
+	},
+	  onXSpecialCase: function(x, y) {
+	      if (eqv(y, 0)) {
+		  throwRuntimeError("/: division by zero", x, y);
+	      }
+	      return 0;
+	  },
+	  isYSpecialCase: function(y) { 
+	    return (eqv(y, 0)); },
+	  onYSpecialCase: function(x, y) {
+	      throwRuntimeError("/: division by zero", x, y);
+	  }
+	});
+    
+    
+    // equals: scheme-number scheme-number -> boolean
+    var equals = makeNumericBinop(
+	function(x, y) {
+	    return x === y;
+	},
+	function(x, y) {
+	    return x.equals(y);
+	});
+
+
+    // eqv: scheme-number scheme-number -> boolean
+    var eqv = function(x, y) {
+	if (x === y)
+	    return true;
+	if (typeof(x) === 'number' && typeof(y) === 'number')
+	    return x === y;
+	if (x === NEGATIVE_ZERO || y === NEGATIVE_ZERO)
+	    return x === y;
+	if (x instanceof Complex || y instanceof Complex) {
+	    return (eqv(realPart(x), realPart(y)) &&
+		    eqv(imaginaryPart(x), imaginaryPart(y)));
+	}
+	var ex = isExact(x), ey = isExact(y);
+	return (((ex && ey) || (!ex && !ey)) && equals(x, y));
+    };
+
+    // approxEqual: scheme-number scheme-number scheme-number -> boolean
+    var approxEquals = function(x, y, delta) {
+	return lessThan(abs(subtract(x, y)),
+                        delta);
+    };
+
+    // greaterThanOrEqual: scheme-number scheme-number -> boolean
+    var greaterThanOrEqual = makeNumericBinop(
+	function(x, y) {
+	    return x >= y;
+	},
+	function(x, y) {
+	    if (!(isReal(x) && isReal(y)))
+		throwRuntimeError(
+		    ">=: couldn't be applied to complex number", x, y);
+	    return x.greaterThanOrEqual(y);
+	});
+
+
+    // lessThanOrEqual: scheme-number scheme-number -> boolean
+    var lessThanOrEqual = makeNumericBinop(
+	function(x, y){
+
+	    return x <= y;
+	},
+	function(x, y) {
+	    if (!(isReal(x) && isReal(y)))
+		throwRuntimeError("<=: couldn't be applied to complex number", x, y);
+	    return x.lessThanOrEqual(y);
+	});
+
+
+    // greaterThan: scheme-number scheme-number -> boolean
+    var greaterThan = makeNumericBinop(
+	function(x, y){
+	    return x > y;
+	},
+	function(x, y) {
+	    if (!(isReal(x) && isReal(y)))
+		throwRuntimeError(">: couldn't be applied to complex number", x, y);
+	    return x.greaterThan(y);
+	});
+
+
+    // lessThan: scheme-number scheme-number -> boolean
+    var lessThan = makeNumericBinop(
+	function(x, y){
+
+	    return x < y;
+	},
+	function(x, y) {
+	    if (!(isReal(x) && isReal(y)))
+		throwRuntimeError("<: couldn't be applied to complex number", x, y);
+	    return x.lessThan(y);
+	});
+
+
+
+    // expt: scheme-number scheme-number -> scheme-number
+    var expt = (function() {
+	var _expt = makeNumericBinop(
+	    function(x, y){
+		var pow = Math.pow(x, y);
+		if (isOverflow(pow)) {
+		    return (makeBignum(x)).expt(makeBignum(y));
+		} else {
+		    return pow;
+		}
+	    },
+	    function(x, y) {
+		if (equals(y, 0)) {
+		    return add(y, 1);
+		} else {
+		    return x.expt(y);
+		}
+	    });
+	return function(x, y) {
+	    if (equals(y, 0)) 
+		return add(y, 1);
+	    if (isReal(y) && lessThan(y, 0)) {
+		return _expt(divide(1, x), negate(y));
+	    }
+	    return _expt(x, y);
+	};
+    })();
+
+
+    // exp: scheme-number -> scheme-number
+    var exp = function(n) {
+	if ( eqv(n, 0) ) {
+		return 1;
+	}
+	if (typeof(n) === 'number') {
+	    return FloatPoint.makeInstance(Math.exp(n));
+	}
+	return n.exp();
+    };
+
+
+    // modulo: scheme-number scheme-number -> scheme-number
+    var modulo = function(m, n) {
+	if (! isInteger(m)) {
+	    throwRuntimeError('modulo: the first argument '
+			      + m + " is not an integer.", m, n);
+	}
+	if (! isInteger(n)) {
+	    throwRuntimeError('modulo: the second argument '
+			      + n + " is not an integer.", m, n);
+	}
+	var result;
+	if (typeof(m) === 'number') {
+	    result = m % n;
+	    if (n < 0) {
+		if (result <= 0)
+		    return result;
+		else
+		    return result + n;
+	    } else {
+		if (result < 0)
+		    return result + n;
+		else
+		    return result;
+	    }
+	}
+	result = _integerModulo(floor(m), floor(n));
+	// The sign of the result should match the sign of n.
+	if (lessThan(n, 0)) {
+	    if (lessThanOrEqual(result, 0)) {
+		return result;
+	    }
+	    return add(result, n);
+
+	} else {
+	    if (lessThan(result, 0)) {
+		return add(result, n);
+	    }
+	    return result;
+	}
+    };
+
+
+
+    // numerator: scheme-number -> scheme-number
+    var numerator = function(n) {
+	if (typeof(n) === 'number')
+	    return n;
+	return n.numerator();
+    };
+
+
+    // denominator: scheme-number -> scheme-number
+    var denominator = function(n) {
+	if (typeof(n) === 'number')
+	    return 1;
+	return n.denominator();
+    };
+
+    // sqrt: scheme-number -> scheme-number
+    var sqrt = function(n) {
+	if (typeof(n) === 'number') {
+	    if (n >= 0) {
+		var result = Math.sqrt(n);
+		if (Math.floor(result) === result) {
+		    return result;
+		} else {
+		    return FloatPoint.makeInstance(result);
+		}
+	    } else {
+		return (Complex.makeInstance(0, sqrt(-n)));
+	    }
+	}
+	return n.sqrt();
+    };
+
+    // abs: scheme-number -> scheme-number
+    var abs = function(n) {
+	if (typeof(n) === 'number') {
+	    return Math.abs(n);
+	}
+	return n.abs();
+    };
+
+    // floor: scheme-number -> scheme-number
+    var floor = function(n) {
+	if (typeof(n) === 'number')
+	    return n;
+	return n.floor();
+    };
+
+    // ceiling: scheme-number -> scheme-number
+    var ceiling = function(n) {
+	if (typeof(n) === 'number')
+	    return n;
+	return n.ceiling();
+    };
+
+    // conjugate: scheme-number -> scheme-number
+    var conjugate = function(n) {
+	if (typeof(n) === 'number')
+	    return n;
+	return n.conjugate();
+    };
+
+    // magnitude: scheme-number -> scheme-number
+    var magnitude = function(n) {
+	if (typeof(n) === 'number')
+	    return Math.abs(n);
+	return n.magnitude();
+    };
+
+
+    // log: scheme-number -> scheme-number
+    var log = function(n) {
+	if ( eqv(n, 1) ) {
+		return 0;
+	}
+	if (typeof(n) === 'number') {
+	    return FloatPoint.makeInstance(Math.log(n));
+	}
+	return n.log();
+    };
+
+    // angle: scheme-number -> scheme-number
+    var angle = function(n) {
+	if (typeof(n) === 'number') {
+	    if (n > 0)
+		return 0;
+	    else
+		return FloatPoint.pi;
+	}
+	return n.angle();
+    };
+
+    // tan: scheme-number -> scheme-number
+    var tan = function(n) {
+	if (eqv(n, 0)) { return 0; }
+	if (typeof(n) === 'number') {
+	    return FloatPoint.makeInstance(Math.tan(n));
+	}
+	return n.tan();
+    };
+
+    // atan: scheme-number -> scheme-number
+    var atan = function(n) {
+	if (eqv(n, 0)) { return 0; }
+	if (typeof(n) === 'number') {
+	    return FloatPoint.makeInstance(Math.atan(n));
+	}
+	return n.atan();
+    };
+
+    // cos: scheme-number -> scheme-number
+    var cos = function(n) {
+	if (eqv(n, 0)) { return 1; }
+	if (typeof(n) === 'number') {
+	    return FloatPoint.makeInstance(Math.cos(n));
+	}
+	return n.cos();
+    };
+
+    // sin: scheme-number -> scheme-number
+    var sin = function(n) {
+	if (eqv(n, 0)) { return 0; }
+	if (typeof(n) === 'number') {
+	    return FloatPoint.makeInstance(Math.sin(n));
+	}
+	return n.sin();
+    };
+
+    // acos: scheme-number -> scheme-number
+    var acos = function(n) {
+	if (eqv(n, 1)) { return 0; }
+	if (typeof(n) === 'number') {
+	    return FloatPoint.makeInstance(Math.acos(n));
+	}
+	return n.acos();
+    };
+
+    // asin: scheme-number -> scheme-number
+    var asin = function(n) {
+        if (eqv(n, 0)) { return 0; }
+	if (typeof(n) === 'number') {
+	    return FloatPoint.makeInstance(Math.asin(n));
+	}
+	return n.asin();
+    };
+
+    // imaginaryPart: scheme-number -> scheme-number
+    var imaginaryPart = function(n) {
+	if (typeof(n) === 'number') {
+	    return 0;
+	}
+	return n.imaginaryPart();
+    };
+
+    // realPart: scheme-number -> scheme-number
+    var realPart = function(n) {
+	if (typeof(n) === 'number') {
+	    return n;
+	}
+	return n.realPart();
+    };
+
+    // round: scheme-number -> scheme-number
+    var round = function(n) {
+	if (typeof(n) === 'number') {
+	    return n;
+	}
+	return n.round();
+    };
+
+
+
+    // sqr: scheme-number -> scheme-number
+    var sqr = function(x) {
+	return multiply(x, x);
+    };
+
+
+    // integerSqrt: scheme-number -> scheme-number
+    var integerSqrt = function(x) {
+	if (! isInteger(x)) {
+	    throwRuntimeError('integer-sqrt: the argument ' + x.toString() +
+			      " is not an integer.", x);
+	}
+	if (typeof (x) === 'number') {
+	    if(x < 0) {
+	        return Complex.makeInstance(0,
+					    Math.floor(Math.sqrt(-x)))
+	    } else {
+		return Math.floor(Math.sqrt(x));
+	    }
+	}
+	return x.integerSqrt();
+    };
+
+
+    // gcd: scheme-number [scheme-number ...] -> scheme-number
+    var gcd = function(first, rest) {
+	if (! isInteger(first)) {
+	    throwRuntimeError('gcd: the argument ' + first.toString() +
+			      " is not an integer.", first);
+	}
+	var a = abs(first), t, b;
+	for(var i = 0; i < rest.length; i++) {
+	    b = abs(rest[i]);	
+	    if (! isInteger(b)) {
+		throwRuntimeError('gcd: the argument ' + b.toString() +
+				  " is not an integer.", b);
+	    }
+	    while (! _integerIsZero(b)) {
+		t = a;
+		a = b;
+		b = _integerModulo(t, b);
+	    }
+	}
+	return a;
+    };
+
+    // lcm: scheme-number [scheme-number ...] -> scheme-number
+    var lcm = function(first, rest) {
+	if (! isInteger(first)) {
+	    throwRuntimeError('lcm: the argument ' + first.toString() +
+			      " is not an integer.", first);
+	}
+	var result = abs(first);
+	if (_integerIsZero(result)) { return 0; }
+	for (var i = 0; i < rest.length; i++) {
+	    if (! isInteger(rest[i])) {
+		throwRuntimeError('lcm: the argument ' + rest[i].toString() +
+				  " is not an integer.", rest[i]);
+	    }
+	    var divisor = _integerGcd(result, rest[i]);
+	    if (_integerIsZero(divisor)) {
+		return 0;
+	    }
+	    result = divide(multiply(result, rest[i]), divisor);
+	}
+	return result;
+    };
+    
+
+    var quotient = function(x, y) {
+ 	if (! isInteger(x)) {
+	    throwRuntimeError('quotient: the first argument ' + x.toString() +
+			      " is not an integer.", x);
+	}
+	if (! isInteger(y)) {
+	    throwRuntimeError('quotient: the second argument ' + y.toString() +
+			      " is not an integer.", y);
+	}
+	return _integerQuotient(x, y);
+    };
+
+    
+    var remainder = function(x, y) {
+	if (! isInteger(x)) {
+	    throwRuntimeError('remainder: the first argument ' + x.toString() +
+			      " is not an integer.", x);
+	}
+	if (! isInteger(y)) {
+	    throwRuntimeError('remainder: the second argument ' + y.toString() +
+			      " is not an integer.", y);
+	}
+	return _integerRemainder(x, y);
+    };
+
+
+    // Implementation of the hyperbolic functions
+    // http://en.wikipedia.org/wiki/Hyperbolic_cosine
+    var cosh = function(x) {
+	if (eqv(x, 0)) {
+	    return FloatPoint.makeInstance(1.0);
+	}
+	return divide(add(exp(x), exp(negate(x))),
+		      2);
+    };
+	
+    var sinh = function(x) {
+	return divide(subtract(exp(x), exp(negate(x))),
+		      2);
+    };
+
+
+        
+    var makeComplexPolar = function(r, theta) {
+	// special case: if theta is zero, just return
+	// the scalar.
+	if (eqv(theta, 0)) {
+	    return r;
+	}
+	return Complex.makeInstance(multiply(r, cos(theta)),
+				    multiply(r, sin(theta)));
+    };
+
+
+
+    //////////////////////////////////////////////////////////////////////
+
+    // Helpers
+
+
+    // IsFinite: scheme-number -> boolean
+    // Returns true if the scheme number is finite or not.
+    var isSchemeNumberFinite = function(n) {
+	if (typeof(n) === 'number') {
+	    return isFinite(n);
+	} else {
+	    return n.isFinite();
+	}
+    };
+
+    // isOverflow: javascript-number -> boolean
+    // Returns true if we consider the number an overflow.
+    var MIN_FIXNUM = -(9e15);
+    var MAX_FIXNUM = (9e15);
+    var isOverflow = function(n) {
+	return (n < MIN_FIXNUM ||  MAX_FIXNUM < n);
+    };
+
+
+    // negate: scheme-number -> scheme-number
+    // multiplies a number times -1.
+    var negate = function(n) {
+	if (typeof(n) === 'number') {
+	    return -n;
+	}
+	return n.negate();
+    };
+
+
+    // halve: scheme-number -> scheme-number
+    // Divide a number by 2.
+    var halve = function(n) {
+	return divide(n, 2);
+    };
+
+
+    // timesI: scheme-number scheme-number
+    // multiplies a number times i.
+    var timesI = function(x) {
+	return multiply(x, plusI);
+    };
+
+
+    // fastExpt: computes n^k by squaring.
+    // n^k = (n^2)^(k/2)
+    // Assumes k is non-negative integer.
+    var fastExpt = function(n, k) {
+	var acc = 1;
+	while (true) {
+	    if (_integerIsZero(k)) {
+		return acc;
+	    }
+	    if (equals(modulo(k, 2), 0)) {
+		n = multiply(n, n);
+		k = divide(k, 2);
+	    } else {
+		acc = multiply(acc, n);
+		k = subtract(k, 1);
+	    }
+	}
+    };
+
+
+
+    //////////////////////////////////////////////////////////////////////
+    //////////////////////////////////////////////////////////////////////
+    //////////////////////////////////////////////////////////////////////
+    //////////////////////////////////////////////////////////////////////
+    //////////////////////////////////////////////////////////////////////
+
+
+    // Integer operations
+    // Integers are either represented as fixnums or as BigIntegers.
+
+    // makeIntegerBinop: (fixnum fixnum -> X) (BigInteger BigInteger -> X) -> X
+    // Helper to collect the common logic for coersing integer fixnums or bignums to a
+    // common type before doing an operation.
+    var makeIntegerBinop = function(onFixnums, onBignums, options) {
+	options = options || {};
+	return (function(m, n) {
+	    if (m instanceof Rational) {
+		m = numerator(m);
+	    } else if (m instanceof Complex) {
+		m = realPart(m);
+	    }
+
+	    if (n instanceof Rational) {
+		n = numerator(n);
+	    }else if (n instanceof Complex) {
+		n = realPart(n);
+	    }
+
+	    if (typeof(m) === 'number' && typeof(n) === 'number') {
+		var result = onFixnums(m, n);
+		if (! isOverflow(result) ||
+		    (options.ignoreOverflow)) {
+		    return result;
+		}
+	    }
+	    if (m instanceof FloatPoint || n instanceof FloatPoint) {
+		if (options.doNotCoerseToFloating) {
+		    return onFixnums(toFixnum(m), toFixnum(n));
+		}
+		else {
+		    return FloatPoint.makeInstance(
+			onFixnums(toFixnum(m), toFixnum(n)));
+		}
+	    }
+	    if (typeof(m) === 'number') {
+		m = makeBignum(m);
+	    }
+	    if (typeof(n) === 'number') {
+		n = makeBignum(n);
+	    }
+	    return onBignums(m, n);
+	});
+    };
+
+
+    var makeIntegerUnOp = function(onFixnums, onBignums, options) {
+	options = options || {};
+	return (function(m) {
+	    if (m instanceof Rational) {
+		m = numerator(m);
+	    } else if (m instanceof Complex) {
+		m = realPart(m);
+	    }
+
+	    if (typeof(m) === 'number') {
+		var result = onFixnums(m);
+		if (! isOverflow(result) ||
+		    (options.ignoreOverflow)) {
+		    return result;
+		}
+	    }
+	    if (m instanceof FloatPoint) {
+		return onFixnums(toFixnum(m));
+	    }
+	    if (typeof(m) === 'number') {
+		m = makeBignum(m);
+	    }
+	    return onBignums(m);
+	});
+    };
+
+
+
+    // _integerModulo: integer-scheme-number integer-scheme-number -> integer-scheme-number
+    var _integerModulo = makeIntegerBinop(
+	function(m, n) {
+	    return m % n;
+	},
+	function(m, n) {
+	    return bnMod.call(m, n);
+	});
+
+
+    // _integerGcd: integer-scheme-number integer-scheme-number -> integer-scheme-number
+    var _integerGcd = makeIntegerBinop(
+	function(a, b) {
+	    var t;
+	    while (b !== 0) {
+		t = a;
+		a = b;
+		b = t % b;
+	    }
+	    return a;
+	},
+	function(m, n) {
+	    return bnGCD.call(m, n);
+	});
+
+
+    // _integerIsZero: integer-scheme-number -> boolean
+    // Returns true if the number is zero.
+    var _integerIsZero = makeIntegerUnOp(
+	function(n){
+	    return n === 0;
+	},
+	function(n) {
+	    return bnEquals.call(n, BigInteger.ZERO);
+	}
+    );
+
+
+    // _integerIsOne: integer-scheme-number -> boolean
+    var _integerIsOne = makeIntegerUnOp(
+	function(n) {
+	    return n === 1;
+	},
+	function(n) {
+	    return bnEquals.call(n, BigInteger.ONE);
+	});
+    
+
+ 
+    // _integerIsNegativeOne: integer-scheme-number -> boolean
+    var _integerIsNegativeOne = makeIntegerUnOp(
+	function(n) {
+	    return n === -1;
+	},
+	function(n) {
+	    return bnEquals.call(n, BigInteger.NEGATIVE_ONE);
+	});
+    
+
+
+    // _integerAdd: integer-scheme-number integer-scheme-number -> integer-scheme-number
+    var _integerAdd = makeIntegerBinop(
+	function(m, n) {
+	    return m + n;
+	},
+	function(m, n) {
+	    return bnAdd.call(m, n);
+	});
+
+    // _integerSubtract: integer-scheme-number integer-scheme-number -> integer-scheme-number
+    var _integerSubtract = makeIntegerBinop(
+	function(m, n) {
+	    return m - n;
+	},
+	function(m, n) {
+	    return bnSubtract.call(m, n);
+	});
+
+    // _integerMultiply: integer-scheme-number integer-scheme-number -> integer-scheme-number
+    var _integerMultiply = makeIntegerBinop(
+	function(m, n) {
+	    return m * n;
+	},
+	function(m, n) {
+	    return bnMultiply.call(m, n);
+	});
+
+    //_integerQuotient: integer-scheme-number integer-scheme-number -> integer-scheme-number
+    var _integerQuotient = makeIntegerBinop(
+	function(m, n) {
+	    return ((m - (m % n))/ n);
+	},
+	function(m, n) {
+            return bnDivide.call(m, n);
+	});
+
+    var _integerRemainder = makeIntegerBinop(
+	function(m, n) {
+	    return m % n;
+	},
+	function(m, n) {
+	    return bnRemainder.call(m, n);
+	});
+
+
+    // _integerDivideToFixnum: integer-scheme-number integer-scheme-number -> fixnum
+    var _integerDivideToFixnum = makeIntegerBinop(
+	function(m, n) {
+	    return m / n;
+	},
+	function(m, n) {
+	    return toFixnum(m) / toFixnum(n);
+	},
+	{ignoreOverflow: true,
+	 doNotCoerseToFloating: true});
+
+
+    // _integerEquals: integer-scheme-number integer-scheme-number -> boolean
+    var _integerEquals = makeIntegerBinop(
+	function(m, n) {
+	    return m === n;
+	},
+	function(m, n) {
+	    return bnEquals.call(m, n);
+	},
+	{doNotCoerseToFloating: true});
+
+    // _integerGreaterThan: integer-scheme-number integer-scheme-number -> boolean
+    var _integerGreaterThan = makeIntegerBinop(
+	function(m, n) {
+	    return m > n;
+	},
+	function(m, n) {
+	    return bnCompareTo.call(m, n) > 0;
+	},
+	{doNotCoerseToFloating: true});
+
+    // _integerLessThan: integer-scheme-number integer-scheme-number -> boolean
+    var _integerLessThan = makeIntegerBinop(
+	function(m, n) {
+	    return m < n;
+	},
+	function(m, n) {
+	    return bnCompareTo.call(m, n) < 0;
+	},
+	{doNotCoerseToFloating: true});
+
+    // _integerGreaterThanOrEqual: integer-scheme-number integer-scheme-number -> boolean
+    var _integerGreaterThanOrEqual = makeIntegerBinop(
+	function(m, n) {
+	    return m >= n;
+	},
+	function(m, n) {
+	    return bnCompareTo.call(m, n) >= 0;
+	},
+	{doNotCoerseToFloating: true});
+
+    // _integerLessThanOrEqual: integer-scheme-number integer-scheme-number -> boolean
+    var _integerLessThanOrEqual = makeIntegerBinop(
+	function(m, n) {
+	    return m <= n;
+	},
+	function(m, n) {
+	    return bnCompareTo.call(m, n) <= 0;
+	},
+	{doNotCoerseToFloating: true});
+
+
+
+    //////////////////////////////////////////////////////////////////////
+    // The boxed number types are expected to implement the following
+    // interface.
+    //
+    // toString: -> string
+
+    // level: number
+
+    // liftTo: scheme-number -> scheme-number
+
+    // isFinite: -> boolean
+
+    // isInteger: -> boolean
+    // Produce true if this number can be coersed into an integer.
+
+    // isRational: -> boolean
+    // Produce true if the number is rational.
+
+    // isReal: -> boolean
+    // Produce true if the number is real.
+
+    // isExact: -> boolean
+    // Produce true if the number is exact
+
+    // toExact: -> scheme-number
+    // Produce an exact number.
+
+    // toFixnum: -> javascript-number
+    // Produce a javascript number.
+
+    // greaterThan: scheme-number -> boolean
+    // Compare against instance of the same type.
+
+    // greaterThanOrEqual: scheme-number -> boolean
+    // Compare against instance of the same type.
+
+    // lessThan: scheme-number -> boolean
+    // Compare against instance of the same type.
+
+    // lessThanOrEqual: scheme-number -> boolean
+    // Compare against instance of the same type.
+
+    // add: scheme-number -> scheme-number
+    // Add with an instance of the same type.
+
+    // subtract: scheme-number -> scheme-number
+    // Subtract with an instance of the same type.
+
+    // multiply: scheme-number -> scheme-number
+    // Multiply with an instance of the same type.
+
+    // divide: scheme-number -> scheme-number
+    // Divide with an instance of the same type.
+
+    // numerator: -> scheme-number
+    // Return the numerator.
+
+    // denominator: -> scheme-number
+    // Return the denominator.
+
+    // integerSqrt: -> scheme-number
+    // Produce the integer square root.
+
+    // sqrt: -> scheme-number
+    // Produce the square root.
+
+    // abs: -> scheme-number
+    // Produce the absolute value.
+
+    // floor: -> scheme-number
+    // Produce the floor.
+
+    // ceiling: -> scheme-number
+    // Produce the ceiling.
+
+    // conjugate: -> scheme-number
+    // Produce the conjugate.
+
+    // magnitude: -> scheme-number
+    // Produce the magnitude.
+
+    // log: -> scheme-number
+    // Produce the log.
+
+    // angle: -> scheme-number
+    // Produce the angle.
+
+    // atan: -> scheme-number
+    // Produce the arc tangent.
+
+    // cos: -> scheme-number
+    // Produce the cosine.
+
+    // sin: -> scheme-number
+    // Produce the sine.
+
+    // expt: scheme-number -> scheme-number
+    // Produce the power to the input.
+
+    // exp: -> scheme-number
+    // Produce e raised to the given power.
+
+    // acos: -> scheme-number
+    // Produce the arc cosine.
+
+    // asin: -> scheme-number
+    // Produce the arc sine.
+
+    // imaginaryPart: -> scheme-number
+    // Produce the imaginary part
+
+    // realPart: -> scheme-number
+    // Produce the real part.
+
+    // round: -> scheme-number
+    // Round to the nearest integer.
+
+    // equals: scheme-number -> boolean
+    // Produce true if the given number of the same type is equal.
+
+
+
+    //////////////////////////////////////////////////////////////////////
+
+    // Rationals
+
+
+    var Rational = function(n, d) {
+	this.n = n;
+	this.d = d;
+    };
+
+
+    Rational.prototype.toString = function() {
+	if (_integerIsOne(this.d)) {
+	    return this.n.toString() + "";
+	} else {
+	    return this.n.toString() + "/" + this.d.toString();
+	}
+    };
+
+
+    Rational.prototype.level = 1;
+
+
+    Rational.prototype.liftTo = function(target) {
+	if (target.level === 2)
+	    return new FloatPoint(
+		_integerDivideToFixnum(this.n, this.d));
+	if (target.level === 3)
+	    return new Complex(this, 0);
+	return throwRuntimeError("invalid level of Number", this, target);
+    };
+
+    Rational.prototype.isFinite = function() {
+	return true;
+    };
+
+    Rational.prototype.equals = function(other) {
+	return (other instanceof Rational &&
+		_integerEquals(this.n, other.n) &&
+		_integerEquals(this.d, other.d));
+    };
+
+
+
+    Rational.prototype.isInteger = function() {
+	return _integerIsOne(this.d);
+    };
+
+    Rational.prototype.isRational = function() {
+        return true;
+    };
+
+    Rational.prototype.isReal = function() {
+	return true;
+    };
+
+
+    Rational.prototype.add = function(other) {
+	return Rational.makeInstance(_integerAdd(_integerMultiply(this.n, other.d),
+						 _integerMultiply(this.d, other.n)),
+				     _integerMultiply(this.d, other.d));
+    };
+
+    Rational.prototype.subtract = function(other) {
+	return Rational.makeInstance(_integerSubtract(_integerMultiply(this.n, other.d),
+						      _integerMultiply(this.d, other.n)),
+				     _integerMultiply(this.d, other.d));
+    };
+
+    Rational.prototype.negate = function() { 
+	return Rational.makeInstance(-this.n, this.d) 
+    };
+
+    Rational.prototype.multiply = function(other) {
+	return Rational.makeInstance(_integerMultiply(this.n, other.n),
+				     _integerMultiply(this.d, other.d));
+    };
+
+    Rational.prototype.divide = function(other) {
+	if (_integerIsZero(this.d) || _integerIsZero(other.n)) {
+	    throwRuntimeError("/: division by zero", this, other);
+	}
+	return Rational.makeInstance(_integerMultiply(this.n, other.d),
+				     _integerMultiply(this.d, other.n));
+    };
+
+
+    Rational.prototype.toExact = function() {
+	return this;
+    };
+
+    Rational.prototype.toInexact = function() {
+	return FloatPoint.makeInstance(this.toFixnum());
+    };
+
+
+    Rational.prototype.isExact = function() {
+        return true;
+    };
+
+    Rational.prototype.isInexact = function() {
+        return false;
+    };
+
+
+    Rational.prototype.toFixnum = function() {
+	return _integerDivideToFixnum(this.n, this.d);
+    };
+
+    Rational.prototype.numerator = function() {
+	return this.n;
+    };
+
+    Rational.prototype.denominator = function() {
+	return this.d;
+    };
+
+    Rational.prototype.greaterThan = function(other) {
+	return _integerGreaterThan(_integerMultiply(this.n, other.d),
+				   _integerMultiply(this.d, other.n));
+    };
+
+    Rational.prototype.greaterThanOrEqual = function(other) {
+	return _integerGreaterThanOrEqual(_integerMultiply(this.n, other.d),
+					  _integerMultiply(this.d, other.n));
+    };
+
+    Rational.prototype.lessThan = function(other) {
+	return _integerLessThan(_integerMultiply(this.n, other.d),
+				_integerMultiply(this.d, other.n));
+    };
+
+    Rational.prototype.lessThanOrEqual = function(other) {
+	return _integerLessThanOrEqual(_integerMultiply(this.n, other.d),
+				       _integerMultiply(this.d, other.n));
+    };
+
+    Rational.prototype.integerSqrt = function() {
+	var result = sqrt(this);
+	if (isRational(result)) {
+	    return toExact(floor(result));
+	} else if (isReal(result)) {
+	    return toExact(floor(result));
+	} else {
+	    return Complex.makeInstance(toExact(floor(realPart(result))),
+					toExact(floor(imaginaryPart(result))));
+	}
+    };
+
+
+    Rational.prototype.sqrt = function() {
+	if (_integerGreaterThanOrEqual(this.n,  0)) {
+	    var newN = sqrt(this.n);
+	    var newD = sqrt(this.d);
+	    if (equals(floor(newN), newN) &&
+		equals(floor(newD), newD)) {
+		return Rational.makeInstance(newN, newD);
+	    } else {
+		return FloatPoint.makeInstance(_integerDivideToFixnum(newN, newD));
+	    }
+	} else {
+	    var newN = sqrt(negate(this.n));
+	    var newD = sqrt(this.d);
+	    if (equals(floor(newN), newN) &&
+		equals(floor(newD), newD)) {
+		return Complex.makeInstance(
+		    0,
+		    Rational.makeInstance(newN, newD));
+	    } else {
+		return Complex.makeInstance(
+		    0,
+		    FloatPoint.makeInstance(_integerDivideToFixnum(newN, newD)));
+	    }
+	}
+    };
+
+    Rational.prototype.abs = function() {
+	return Rational.makeInstance(abs(this.n),
+				     this.d);
+    };
+
+
+    Rational.prototype.floor = function() {
+	var quotient = _integerQuotient(this.n, this.d);
+	if (_integerLessThan(this.n, 0)) {
+	    return subtract(quotient, 1);
+	} else {
+	    return quotient;
+	}
+    };
+
+
+    Rational.prototype.ceiling = function() {
+	var quotient = _integerQuotient(this.n, this.d);
+	if (_integerLessThan(this.n, 0)) {
+	    return quotient;
+	} else {
+	    return add(quotient, 1);
+	}
+    };
+
+    Rational.prototype.conjugate = function() {
+	return this;
+    };
+
+    Rational.prototype.magnitude = Rational.prototype.abs;
+
+    Rational.prototype.log = function(){
+	return FloatPoint.makeInstance(Math.log(this.n / this.d));
+    };
+
+    Rational.prototype.angle = function(){
+	if (_integerIsZero(this.n))
+	    return 0;
+	if (_integerGreaterThan(this.n, 0))
+	    return 0;
+	else
+	    return FloatPoint.pi;
+    };
+
+    Rational.prototype.tan = function(){
+	return FloatPoint.makeInstance(Math.tan(_integerDivideToFixnum(this.n, this.d)));
+    };
+
+    Rational.prototype.atan = function(){
+	return FloatPoint.makeInstance(Math.atan(_integerDivideToFixnum(this.n, this.d)));
+    };
+
+    Rational.prototype.cos = function(){
+	return FloatPoint.makeInstance(Math.cos(_integerDivideToFixnum(this.n, this.d)));
+    };
+
+    Rational.prototype.sin = function(){
+	return FloatPoint.makeInstance(Math.sin(_integerDivideToFixnum(this.n, this.d)));
+    };
+
+    Rational.prototype.expt = function(a){
+	if (isExactInteger(a) && greaterThanOrEqual(a, 0)) {
+	    return fastExpt(this, a);
+	}
+	return FloatPoint.makeInstance(Math.pow(_integerDivideToFixnum(this.n, this.d),
+						_integerDivideToFixnum(a.n, a.d)));
+    };
+
+    Rational.prototype.exp = function(){
+	return FloatPoint.makeInstance(Math.exp(_integerDivideToFixnum(this.n, this.d)));
+    };
+
+    Rational.prototype.acos = function(){
+	return FloatPoint.makeInstance(Math.acos(_integerDivideToFixnum(this.n, this.d)));
+    };
+
+    Rational.prototype.asin = function(){
+	return FloatPoint.makeInstance(Math.asin(_integerDivideToFixnum(this.n, this.d)));
+    };
+
+    Rational.prototype.imaginaryPart = function(){
+	return 0;
+    };
+
+    Rational.prototype.realPart = function(){
+	return this;
+    };
+
+
+    Rational.prototype.round = function() {
+	// FIXME: not correct when values are bignums
+	if (equals(this.d, 2)) {
+	    // Round to even if it's a n/2
+	    var v = _integerDivideToFixnum(this.n, this.d);
+	    var fl = Math.floor(v);
+	    var ce = Math.ceil(v);
+	    if (_integerIsZero(fl % 2)) {
+		return fl;
+	    }
+	    else {
+		return ce;
+	    }
+	} else {
+	    return Math.round(this.n / this.d);
+	}
+    };
+
+
+    Rational.makeInstance = function(n, d) {
+	if (n === undefined)
+	    throwRuntimeError("n undefined", n, d);
+
+	if (d === undefined) { d = 1; }
+
+	if (_integerLessThan(d, 0)) {
+	    n = negate(n);
+	    d = negate(d);
+	}
+
+	var divisor = _integerGcd(abs(n), abs(d));
+	n = _integerQuotient(n, divisor);
+	d = _integerQuotient(d, divisor);
+
+	// Optimization: if we can get around construction the rational
+	// in favor of just returning n, do it:
+	if (_integerIsOne(d) || _integerIsZero(n)) {
+	    return n;
+	}
+
+	return new Rational(n, d);
+    };
+
+
+
+    // Floating Point numbers
+    var FloatPoint = function(n) {
+	this.n = n;
+    };
+    FloatPoint = FloatPoint;
+
+
+    var NaN = new FloatPoint(Number.NaN);
+    var inf = new FloatPoint(Number.POSITIVE_INFINITY);
+    var neginf = new FloatPoint(Number.NEGATIVE_INFINITY);
+
+    // We use these two constants to represent the floating-point coersion
+    // of bignums that can't be represented with fidelity.
+    var TOO_POSITIVE_TO_REPRESENT = new FloatPoint(Number.POSITIVE_INFINITY);
+    var TOO_NEGATIVE_TO_REPRESENT = new FloatPoint(Number.NEGATIVE_INFINITY);
+
+    // Negative zero is a distinguished value representing -0.0.
+    // There should only be one instance for -0.0.
+    var NEGATIVE_ZERO = new FloatPoint(-0.0);
+    var INEXACT_ZERO = new FloatPoint(0.0);
+
+    FloatPoint.pi = new FloatPoint(Math.PI);
+    FloatPoint.e = new FloatPoint(Math.E);
+    FloatPoint.nan = NaN;
+    FloatPoint.inf = inf;
+    FloatPoint.neginf = neginf;
+
+    FloatPoint.makeInstance = function(n) {
+	if (isNaN(n)) {
+	    return FloatPoint.nan;
+	} else if (n === Number.POSITIVE_INFINITY) {
+	    return FloatPoint.inf;
+	} else if (n === Number.NEGATIVE_INFINITY) {
+	    return FloatPoint.neginf;
+	} else if (n === 0) {
+	    if ((1/n) === -Infinity) {
+		return NEGATIVE_ZERO;
+	    } else {
+		return INEXACT_ZERO;
+	    }
+	}
+	return new FloatPoint(n);
+    };
+
+
+    FloatPoint.prototype.isExact = function() {
+	return false;
+    };
+
+    FloatPoint.prototype.isInexact = function() {
+	return true;
+    };
+
+
+    FloatPoint.prototype.isFinite = function() {
+	return (isFinite(this.n) ||
+		this === TOO_POSITIVE_TO_REPRESENT ||
+		this === TOO_NEGATIVE_TO_REPRESENT);
+    };
+
+
+    FloatPoint.prototype.toExact = function() {
+	// The precision of ieee is about 16 decimal digits, which we use here.
+	if (! isFinite(this.n) || isNaN(this.n)) {
+	    throwRuntimeError("toExact: no exact representation for " + this, this);
+	}
+
+	var stringRep = this.n.toString();
+	var match = stringRep.match(/^(.*)\.(.*)$/);
+	if (match) {
+	    var intPart = parseInt(match[1]);
+	    var fracPart = parseInt(match[2]);
+	    var tenToDecimalPlaces = Math.pow(10, match[2].length);
+	    return Rational.makeInstance(Math.round(this.n * tenToDecimalPlaces),
+					 tenToDecimalPlaces);
+	}
+	else {
+	    return this.n;
+	}
+    };
+
+    FloatPoint.prototype.toInexact = function() {
+	return this;
+    };
+
+    FloatPoint.prototype.isInexact = function() {
+	return true;
+    };
+
+
+    FloatPoint.prototype.level = 2;
+
+
+    FloatPoint.prototype.liftTo = function(target) {
+	if (target.level === 3)
+	    return new Complex(this, 0);
+	return throwRuntimeError("invalid level of Number", this, target);
+    };
+
+    FloatPoint.prototype.toString = function() {
+	if (isNaN(this.n))
+	    return "+nan.0";
+	if (this.n === Number.POSITIVE_INFINITY)
+	    return "+inf.0";
+	if (this.n === Number.NEGATIVE_INFINITY)
+	    return "-inf.0";
+	if (this === NEGATIVE_ZERO)
+	    return "-0.0";
+	var partialResult = this.n.toString();
+	if (! partialResult.match('\\.')) {
+	    return partialResult + ".0";
+	} else {
+	    return partialResult;
+	}
+    };
+
+
+    FloatPoint.prototype.equals = function(other, aUnionFind) {
+	return ((other instanceof FloatPoint) &&
+		((this.n === other.n)));
+    };
+
+
+
+    FloatPoint.prototype.isRational = function() {
+        return this.isFinite();
+    };
+
+    FloatPoint.prototype.isInteger = function() {
+	return this.isFinite() && this.n === Math.floor(this.n);
+    };
+
+    FloatPoint.prototype.isReal = function() {
+	return true;
+    };
+
+
+    // sign: Number -> {-1, 0, 1}
+    var sign = function(n) {
+	if (lessThan(n, 0)) {
+	    return -1;
+	} else if (greaterThan(n, 0)) {
+	    return 1;
+	} else if (n === NEGATIVE_ZERO) {
+	    return -1;
+	} else {
+	    return 0;
+	}
+    };
+
+
+    FloatPoint.prototype.add = function(other) {
+	if (this.isFinite() && other.isFinite()) {
+	    return FloatPoint.makeInstance(this.n + other.n);
+	} else {
+	    if (isNaN(this.n) || isNaN(other.n)) {
+		return NaN;
+	    } else if (this.isFinite() && ! other.isFinite()) {
+		return other;
+	    } else if (!this.isFinite() && other.isFinite()) {
+		return this;
+	    } else {
+		return ((sign(this) * sign(other) === 1) ?
+			this : NaN);
+	    };
+	}
+    };
+
+    FloatPoint.prototype.subtract = function(other) {
+	if (this.isFinite() && other.isFinite()) {
+	    return FloatPoint.makeInstance(this.n - other.n);
+	} else if (isNaN(this.n) || isNaN(other.n)) {
+	    return NaN;
+	} else if (! this.isFinite() && ! other.isFinite()) {
+	    if (sign(this) === sign(other)) {
+		return NaN;
+	    } else {
+		return this;
+	    }
+	} else if (this.isFinite()) {
+	    return multiply(other, -1);
+	} else {  // other.isFinite()
+	    return this;
+	}
+    };
+
+
+    FloatPoint.prototype.negate = function() {
+	return FloatPoint.makeInstance(-this.n);
+    };
+
+    FloatPoint.prototype.multiply = function(other) {
+	return FloatPoint.makeInstance(this.n * other.n);
+    };
+
+    FloatPoint.prototype.divide = function(other) {
+        return FloatPoint.makeInstance(this.n / other.n);
+    };
+
+
+    FloatPoint.prototype.toFixnum = function() {
+	return this.n;
+    };
+
+    FloatPoint.prototype.numerator = function() {
+	var stringRep = this.n.toString();
+	var match = stringRep.match(/^(.*)\.(.*)$/);
+	if (match) {
+	    var afterDecimal = parseInt(match[2]);
+	    var factorToInt = Math.pow(10, match[2].length);
+	    var extraFactor = _integerGcd(factorToInt, afterDecimal);
+	    var multFactor = factorToInt / extraFactor;
+	    return FloatPoint.makeInstance( Math.round(this.n * multFactor) );
+	} else {
+	    return this;
+	}
+    };
+
+    FloatPoint.prototype.denominator = function() {
+	var stringRep = this.n.toString();
+	var match = stringRep.match(/^(.*)\.(.*)$/);
+	if (match) {
+	    var afterDecimal = parseInt(match[2]);
+	    var factorToInt = Math.pow(10, match[2].length);
+	    var extraFactor = _integerGcd(factorToInt, afterDecimal);
+	    return FloatPoint.makeInstance( Math.round(factorToInt/extraFactor) );
+	} else {
+	    return FloatPoint.makeInstance(1);
+	}
+    };
+
+
+    FloatPoint.prototype.floor = function() {
+	return FloatPoint.makeInstance(Math.floor(this.n));
+    };
+
+    FloatPoint.prototype.ceiling = function() {
+	return FloatPoint.makeInstance(Math.ceil(this.n));
+    };
+
+
+    FloatPoint.prototype.greaterThan = function(other) {
+	return this.n > other.n;
+    };
+
+    FloatPoint.prototype.greaterThanOrEqual = function(other) {
+	return this.n >= other.n;
+    };
+
+    FloatPoint.prototype.lessThan = function(other) {
+	return this.n < other.n;
+    };
+
+    FloatPoint.prototype.lessThanOrEqual = function(other) {
+	return this.n <= other.n;
+    };
+
+
+    FloatPoint.prototype.integerSqrt = function() {
+	if (this === NEGATIVE_ZERO) { return this; }
+	if (isInteger(this)) {
+	    if(this.n >= 0) {
+	        return FloatPoint.makeInstance(Math.floor(Math.sqrt(this.n)));
+	    } else {
+	        return Complex.makeInstance(
+		    INEXACT_ZERO,
+		    FloatPoint.makeInstance(Math.floor(Math.sqrt(-this.n))));
+	    }
+	} else {
+	    throwRuntimeError("integerSqrt: can only be applied to an integer", this);
+	}
+    };
+
+    FloatPoint.prototype.sqrt = function() {
+	if (this.n < 0) {
+	    var result = Complex.makeInstance(
+		0,
+		FloatPoint.makeInstance(Math.sqrt(-this.n)));
+	    return result;
+	} else {
+	    return FloatPoint.makeInstance(Math.sqrt(this.n));
+	}
+    };
+
+    FloatPoint.prototype.abs = function() {
+	return FloatPoint.makeInstance(Math.abs(this.n));
+    };
+
+
+
+    FloatPoint.prototype.log = function(){
+	if (this.n < 0)
+	    return (new Complex(this, 0)).log();
+	else
+	    return FloatPoint.makeInstance(Math.log(this.n));
+    };
+
+    FloatPoint.prototype.angle = function(){
+	if (0 === this.n)
+	    return 0;
+	if (this.n > 0)
+	    return 0;
+	else
+	    return FloatPoint.pi;
+    };
+
+    FloatPoint.prototype.tan = function(){
+	return FloatPoint.makeInstance(Math.tan(this.n));
+    };
+
+    FloatPoint.prototype.atan = function(){
+	return FloatPoint.makeInstance(Math.atan(this.n));
+    };
+
+    FloatPoint.prototype.cos = function(){
+	return FloatPoint.makeInstance(Math.cos(this.n));
+    };
+
+    FloatPoint.prototype.sin = function(){
+	return FloatPoint.makeInstance(Math.sin(this.n));
+    };
+
+    FloatPoint.prototype.expt = function(a){
+	if (this.n === 1) {
+	    if (a.isFinite()) {
+		return this;
+	    } else if (isNaN(a.n)){
+		return this;
+	    } else {
+		return this;
+	    }
+	} else {
+	    return FloatPoint.makeInstance(Math.pow(this.n, a.n));
+	}
+    };
+
+    FloatPoint.prototype.exp = function(){
+	return FloatPoint.makeInstance(Math.exp(this.n));
+    };
+
+    FloatPoint.prototype.acos = function(){
+	return FloatPoint.makeInstance(Math.acos(this.n));
+    };
+
+    FloatPoint.prototype.asin = function(){
+	return FloatPoint.makeInstance(Math.asin(this.n));
+    };
+
+    FloatPoint.prototype.imaginaryPart = function(){
+	return 0;
+    };
+
+    FloatPoint.prototype.realPart = function(){
+	return this;
+    };
+
+
+    FloatPoint.prototype.round = function(){
+	if (isFinite(this.n)) {
+	    if (this === NEGATIVE_ZERO) {
+		return this;
+	    }
+	    if (Math.abs(Math.floor(this.n) - this.n) === 0.5) {
+		if (Math.floor(this.n) % 2 === 0)
+		    return FloatPoint.makeInstance(Math.floor(this.n));
+		return FloatPoint.makeInstance(Math.ceil(this.n));
+	    } else {
+		return FloatPoint.makeInstance(Math.round(this.n));
+	    }
+	} else {
+	    return this;
+	}
+    };
+
+
+    FloatPoint.prototype.conjugate = function() {
+	return this;
+    };
+
+    FloatPoint.prototype.magnitude = FloatPoint.prototype.abs;
+
+
+
+    //////////////////////////////////////////////////////////////////////
+    // Complex numbers
+    //////////////////////////////////////////////////////////////////////
+
+    var Complex = function(r, i){
+	this.r = r;
+	this.i = i;
+    };
+
+    // Constructs a complex number from two basic number r and i.  r and i can
+    // either be plt.type.Rational or plt.type.FloatPoint.
+    Complex.makeInstance = function(r, i){
+	if (i === undefined) { i = 0; }
+	if (isExact(i) && isInteger(i) && _integerIsZero(i)) {
+	    return r;
+	}
+	if (isInexact(r) || isInexact(i)) {
+	    r = toInexact(r);
+	    i = toInexact(i);
+	}
+	return new Complex(r, i);
+    };
+
+    Complex.prototype.toString = function() {
+	var realPart = this.r.toString(), imagPart = this.i.toString();
+	if (imagPart[0] === '-' || imagPart[0] === '+') {
+	    return realPart + imagPart + 'i';
+	} else {
+	    return realPart + "+" + imagPart + 'i';
+	}
+    };
+
+
+    Complex.prototype.isFinite = function() {
+	return isSchemeNumberFinite(this.r) && isSchemeNumberFinite(this.i);
+    };
+
+
+    Complex.prototype.isRational = function() {
+	return isRational(this.r) && eqv(this.i, 0);
+    };
+
+    Complex.prototype.isInteger = function() {
+	return (isInteger(this.r) &&
+		eqv(this.i, 0));
+    };
+
+    Complex.prototype.toExact = function() {
+	return Complex.makeInstance( toExact(this.r), toExact(this.i) );
+    };
+
+    Complex.prototype.toInexact = function() {
+	return Complex.makeInstance(toInexact(this.r),
+				    toInexact(this.i));
+    };
+
+
+    Complex.prototype.isExact = function() {
+        return isExact(this.r) && isExact(this.i);
+    };
+
+
+    Complex.prototype.isInexact = function() {
+	return isInexact(this.r) || isInexact(this.i);
+    };
+
+
+    Complex.prototype.level = 3;
+
+
+    Complex.prototype.liftTo = function(target){
+	throwRuntimeError("Don't know how to lift Complex number", this, target);
+    };
+
+    Complex.prototype.equals = function(other) {
+	var result = ((other instanceof Complex) &&
+		      (equals(this.r, other.r)) &&
+		      (equals(this.i, other.i)));
+	return result;
+    };
+
+
+
+    Complex.prototype.greaterThan = function(other) {
+	if (! this.isReal() || ! other.isReal()) {
+	    throwRuntimeError(">: expects argument of type real number", this, other);
+	}
+	return greaterThan(this.r, other.r);
+    };
+
+    Complex.prototype.greaterThanOrEqual = function(other) {
+	if (! this.isReal() || ! other.isReal()) {
+	    throwRuntimeError(">=: expects argument of type real number", this, other);
+	}
+	return greaterThanOrEqual(this.r, other.r);
+    };
+
+    Complex.prototype.lessThan = function(other) {
+	if (! this.isReal() || ! other.isReal()) {
+	    throwRuntimeError("<: expects argument of type real number", this, other);
+	}
+	return lessThan(this.r, other.r);
+    };
+
+    Complex.prototype.lessThanOrEqual = function(other) {
+	if (! this.isReal() || ! other.isReal()) {
+	    throwRuntimeError("<=: expects argument of type real number", this, other);
+	}
+	return lessThanOrEqual(this.r, other.r);
+    };
+
+
+    Complex.prototype.abs = function(){
+	if (!equals(this.i, 0).valueOf())
+	    throwRuntimeError("abs: expects argument of type real number", this);
+	return abs(this.r);
+    };
+
+    Complex.prototype.toFixnum = function(){
+	if (!equals(this.i, 0).valueOf())
+	    throwRuntimeError("toFixnum: expects argument of type real number", this);
+	return toFixnum(this.r);
+    };
+
+    Complex.prototype.numerator = function() {
+	if (!this.isReal())
+	    throwRuntimeError("numerator: can only be applied to real number", this);
+	return numerator(this.n);
+    };
+
+
+    Complex.prototype.denominator = function() {
+	if (!this.isReal())
+	    throwRuntimeError("floor: can only be applied to real number", this);
+	return denominator(this.n);
+    };
+
+    Complex.prototype.add = function(other){
+	return Complex.makeInstance(
+	    add(this.r, other.r),
+	    add(this.i, other.i));
+    };
+
+    Complex.prototype.subtract = function(other){
+	return Complex.makeInstance(
+	    subtract(this.r, other.r),
+	    subtract(this.i, other.i));
+    };
+
+    Complex.prototype.negate = function() {
+	return Complex.makeInstance(negate(this.r),
+				    negate(this.i));
+    };
+
+
+    Complex.prototype.multiply = function(other){
+	// If the other value is real, just do primitive division
+	if (other.isReal()) {
+	    return Complex.makeInstance(
+		multiply(this.r, other.r),
+		multiply(this.i, other.r));
+	}
+	var r = subtract(
+	    multiply(this.r, other.r),
+	    multiply(this.i, other.i));
+	var i = add(
+	    multiply(this.r, other.i),
+	    multiply(this.i, other.r));
+	return Complex.makeInstance(r, i);
+    };
+
+
+
+
+
+    Complex.prototype.divide = function(other){
+	var a, b, c, d, r, x, y;
+	// If the other value is real, just do primitive division
+	if (other.isReal()) {
+	    return Complex.makeInstance(
+		divide(this.r, other.r),
+		divide(this.i, other.r));
+	}
+
+	if (this.isInexact() || other.isInexact()) {
+	    // http://portal.acm.org/citation.cfm?id=1039814
+	    // We currently use Smith's method, though we should
+	    // probably switch over to Priest's method.
+	    a = this.r;
+	    b = this.i;
+	    c = other.r;
+	    d = other.i;
+	    if (lessThanOrEqual(abs(d), abs(c))) {
+		r = divide(d, c);
+		x = divide(add(a, multiply(b, r)),
+			   add(c, multiply(d, r)));
+		y = divide(subtract(b, multiply(a, r)),
+			   add(c, multiply(d, r)));
+	    } else {
+		r = divide(c, d);
+		x = divide(add(multiply(a, r), b),
+			   add(multiply(c, r), d));
+		y = divide(subtract(multiply(b, r), a),
+			   add(multiply(c, r), d));
+	    }
+	    return Complex.makeInstance(x, y);
+	} else {
+	    var con = conjugate(other);
+	    var up = multiply(this, con);
+
+	    // Down is guaranteed to be real by this point.
+	    var down = realPart(multiply(other, con));
+
+	    var result = Complex.makeInstance(
+		divide(realPart(up), down),
+		divide(imaginaryPart(up), down));
+	    return result;
+	}
+    };
+
+    Complex.prototype.conjugate = function(){
+	var result = Complex.makeInstance(
+	    this.r,
+	    subtract(0, this.i));
+
+	return result;
+    };
+
+    Complex.prototype.magnitude = function(){
+	var sum = add(
+	    multiply(this.r, this.r),
+	    multiply(this.i, this.i));
+	return sqrt(sum);
+    };
+
+    Complex.prototype.isReal = function(){
+	return eqv(this.i, 0);
+    };
+
+    Complex.prototype.integerSqrt = function() {
+	if (isInteger(this)) {
+	    return integerSqrt(this.r);
+	} else {
+	    throwRuntimeError("integerSqrt: can only be applied to an integer", this);
+	}
+    };
+
+    Complex.prototype.sqrt = function(){
+	if (this.isReal())
+	    return sqrt(this.r);
+	// http://en.wikipedia.org/wiki/Square_root#Square_roots_of_negative_and_complex_numbers
+	var r_plus_x = add(this.magnitude(), this.r);
+
+	var r = sqrt(halve(r_plus_x));
+
+	var i = divide(this.i, sqrt(multiply(r_plus_x, 2)));
+
+
+	return Complex.makeInstance(r, i);
+    };
+
+    Complex.prototype.log = function(){
+	var m = this.magnitude();
+	var theta = this.angle();
+	var result = add(
+	    log(m),
+	    timesI(theta));
+	return result;
+    };
+
+    Complex.prototype.angle = function(){
+	if (this.isReal()) {
+	    return angle(this.r);
+	}
+	if (equals(0, this.r)) {
+	    var tmp = halve(FloatPoint.pi);
+	    return greaterThan(this.i, 0) ?
+		tmp : negate(tmp);
+	} else {
+	    var tmp = atan(divide(abs(this.i), abs(this.r)));
+	    if (greaterThan(this.r, 0)) {
+		return greaterThan(this.i, 0) ?
+		    tmp : negate(tmp);
+	    } else {
+		return greaterThan(this.i, 0) ?
+		    subtract(FloatPoint.pi, tmp) : subtract(tmp, FloatPoint.pi);
+	    }
+	}
+    };
+
+    var plusI = Complex.makeInstance(0, 1);
+    var minusI = Complex.makeInstance(0, -1);
+
+
+    Complex.prototype.tan = function() {
+	return divide(this.sin(), this.cos());
+    };
+
+    Complex.prototype.atan = function(){
+	if (equals(this, plusI) ||
+	    equals(this, minusI)) {
+	    return neginf;
+	}
+	return multiply(
+	    plusI,
+	    multiply(
+		FloatPoint.makeInstance(0.5),
+		log(divide(
+		    add(plusI, this),
+		    add(
+			plusI,
+			subtract(0, this))))));
+    };
+
+    Complex.prototype.cos = function(){
+	if (this.isReal())
+	    return cos(this.r);
+	var iz = timesI(this);
+	var iz_negate = negate(iz);
+
+	return halve(add(exp(iz), exp(iz_negate)));
+    };
+
+    Complex.prototype.sin = function(){
+	if (this.isReal())
+	    return sin(this.r);
+	var iz = timesI(this);
+	var iz_negate = negate(iz);
+	var z2 = Complex.makeInstance(0, 2);
+	var exp_negate = subtract(exp(iz), exp(iz_negate));
+	var result = divide(exp_negate, z2);
+	return result;
+    };
+
+
+    Complex.prototype.expt = function(y){
+	if (isExactInteger(y) && greaterThanOrEqual(y, 0)) {
+	    return fastExpt(this, y);
+	}
+	var expo = multiply(y, this.log());
+	return exp(expo);
+    };
+
+    Complex.prototype.exp = function(){
+	var r = exp(this.r);
+	var cos_a = cos(this.i);
+	var sin_a = sin(this.i);
+
+	return multiply(
+	    r,
+	    add(cos_a, timesI(sin_a)));
+    };
+
+    Complex.prototype.acos = function(){
+	if (this.isReal())
+	    return acos(this.r);
+	var pi_half = halve(FloatPoint.pi);
+	var iz = timesI(this);
+	var root = sqrt(subtract(1, sqr(this)));
+	var l = timesI(log(add(iz, root)));
+	return add(pi_half, l);
+    };
+
+    Complex.prototype.asin = function(){
+	if (this.isReal())
+	    return asin(this.r);
+
+	var oneNegateThisSq =
+	    subtract(1, sqr(this));
+	var sqrtOneNegateThisSq = sqrt(oneNegateThisSq);
+	return multiply(2, atan(divide(this,
+				       add(1, sqrtOneNegateThisSq))));
+    };
+
+    Complex.prototype.ceiling = function(){
+	if (!this.isReal())
+	    throwRuntimeError("ceiling: can only be applied to real number", this);
+	return ceiling(this.r);
+    };
+
+    Complex.prototype.floor = function(){
+	if (!this.isReal())
+	    throwRuntimeError("floor: can only be applied to real number", this);
+	return floor(this.r);
+    };
+
+    Complex.prototype.imaginaryPart = function(){
+	return this.i;
+    };
+
+    Complex.prototype.realPart = function(){
+	return this.r;
+    };
+
+    Complex.prototype.round = function(){
+	if (!this.isReal())
+	    throwRuntimeError("round: can only be applied to real number", this);
+	return round(this.r);
+    };
+
+
+
+    var rationalRegexp = new RegExp("^([+-]?\\d+)/(\\d+)$");
+    var complexRegexp = new RegExp("^([+-]?[\\d\\w/\\.]*)([+-])([\\d\\w/\\.]*)i$");
+    var digitRegexp = new RegExp("^[+-]?\\d+$");
+    var flonumRegexp = new RegExp("^([+-]?\\d*)\\.(\\d*)$");
+    var scientificPattern = new RegExp("^([+-]?\\d*\\.?\\d*)[Ee](\\+?\\d+)$");
+
+    // fromString: string -> (scheme-number | false)
+    var fromString = function(x) {
+	var aMatch = x.match(rationalRegexp);
+	if (aMatch) {
+	    return Rational.makeInstance(fromString(aMatch[1]),
+					 fromString(aMatch[2]));
+	}
+
+	var cMatch = x.match(complexRegexp);
+	if (cMatch) {
+	    return Complex.makeInstance(fromString(cMatch[1] || "0"),
+					fromString(cMatch[2] + (cMatch[3] || "1")));
+	}
+
+	// Floating point tests
+	if (x === '+nan.0' || x === '-nan.0')
+	    return FloatPoint.nan;
+	if (x === '+inf.0')
+	    return FloatPoint.inf;
+	if (x === '-inf.0')
+	    return FloatPoint.neginf;
+	if (x === "-0.0") {
+	    return NEGATIVE_ZERO;
+	}
+	if (x.match(flonumRegexp) ||  x.match(scientificPattern)) {
+	    return FloatPoint.makeInstance(Number(x));
+	}
+
+	// Finally, integer tests.
+	if (x.match(digitRegexp)) {
+	    var n = Number(x);
+	    if (isOverflow(n)) {
+		return makeBignum(x);
+	    } else {
+		return n;
+	    }
+	} else {
+	    return false;
+	}
+    };
+
+
+
+
+
+    //////////////////////////////////////////////////////////////////////
+    //////////////////////////////////////////////////////////////////////
+    //////////////////////////////////////////////////////////////////////
+    //////////////////////////////////////////////////////////////////////
+    //////////////////////////////////////////////////////////////////////
+
+    // The code below comes from Tom Wu's BigInteger implementation:
+
+    // Copyright (c) 2005  Tom Wu
+    // All Rights Reserved.
+    // See "LICENSE" for details.
+
+    // Basic JavaScript BN library - subset useful for RSA encryption.
+
+    // Bits per digit
+    var dbits;
+
+    // JavaScript engine analysis
+    var canary = 0xdeadbeefcafe;
+    var j_lm = ((canary&0xffffff)==0xefcafe);
+
+    // (public) Constructor
+    function BigInteger(a,b,c) {
+	if(a != null)
+	    if("number" == typeof a) this.fromNumber(a,b,c);
+	else if(b == null && "string" != typeof a) this.fromString(a,256);
+	else this.fromString(a,b);
+    }
+
+    // return new, unset BigInteger
+    function nbi() { return new BigInteger(null); }
+
+    // am: Compute w_j += (x*this_i), propagate carries,
+    // c is initial carry, returns final carry.
+    // c < 3*dvalue, x < 2*dvalue, this_i < dvalue
+    // We need to select the fastest one that works in this environment.
+
+    // am1: use a single mult and divide to get the high bits,
+    // max digit bits should be 26 because
+    // max internal value = 2*dvalue^2-2*dvalue (< 2^53)
+    function am1(i,x,w,j,c,n) {
+	while(--n >= 0) {
+	    var v = x*this[i++]+w[j]+c;
+	    c = Math.floor(v/0x4000000);
+	    w[j++] = v&0x3ffffff;
+	}
+	return c;
+    }
+    // am2 avoids a big mult-and-extract completely.
+    // Max digit bits should be <= 30 because we do bitwise ops
+    // on values up to 2*hdvalue^2-hdvalue-1 (< 2^31)
+    function am2(i,x,w,j,c,n) {
+	var xl = x&0x7fff, xh = x>>15;
+	while(--n >= 0) {
+	    var l = this[i]&0x7fff;
+	    var h = this[i++]>>15;
+	    var m = xh*l+h*xl;
+	    l = xl*l+((m&0x7fff)<<15)+w[j]+(c&0x3fffffff);
+	    c = (l>>>30)+(m>>>15)+xh*h+(c>>>30);
+	    w[j++] = l&0x3fffffff;
+	}
+	return c;
+    }
+    // Alternately, set max digit bits to 28 since some
+    // browsers slow down when dealing with 32-bit numbers.
+    function am3(i,x,w,j,c,n) {
+	var xl = x&0x3fff, xh = x>>14;
+	while(--n >= 0) {
+	    var l = this[i]&0x3fff;
+	    var h = this[i++]>>14;
+	    var m = xh*l+h*xl;
+	    l = xl*l+((m&0x3fff)<<14)+w[j]+c;
+	    c = (l>>28)+(m>>14)+xh*h;
+	    w[j++] = l&0xfffffff;
+	}
+	return c;
+    }
+    if(j_lm && (typeof(navigator) !== 'undefined' && navigator.appName == "Microsoft Internet Explorer")) {
+	BigInteger.prototype.am = am2;
+	dbits = 30;
+    }
+    else if(j_lm && (typeof(navigator) !== 'undefined' && navigator.appName != "Netscape")) {
+	BigInteger.prototype.am = am1;
+	dbits = 26;
+    }
+    else { // Mozilla/Netscape seems to prefer am3
+	BigInteger.prototype.am = am3;
+	dbits = 28;
+    }
+
+    BigInteger.prototype.DB = dbits;
+    BigInteger.prototype.DM = ((1<<dbits)-1);
+    BigInteger.prototype.DV = (1<<dbits);
+
+    var BI_FP = 52;
+    BigInteger.prototype.FV = Math.pow(2,BI_FP);
+    BigInteger.prototype.F1 = BI_FP-dbits;
+    BigInteger.prototype.F2 = 2*dbits-BI_FP;
+
+    // Digit conversions
+    var BI_RM = "0123456789abcdefghijklmnopqrstuvwxyz";
+    var BI_RC = [];
+    var rr,vv;
+    rr = "0".charCodeAt(0);
+    for(vv = 0; vv <= 9; ++vv) BI_RC[rr++] = vv;
+    rr = "a".charCodeAt(0);
+    for(vv = 10; vv < 36; ++vv) BI_RC[rr++] = vv;
+    rr = "A".charCodeAt(0);
+    for(vv = 10; vv < 36; ++vv) BI_RC[rr++] = vv;
+
+    function int2char(n) { return BI_RM.charAt(n); }
+    function intAt(s,i) {
+	var c = BI_RC[s.charCodeAt(i)];
+	return (c==null)?-1:c;
+    }
+
+    // (protected) copy this to r
+    function bnpCopyTo(r) {
+	for(var i = this.t-1; i >= 0; --i) r[i] = this[i];
+	r.t = this.t;
+	r.s = this.s;
+    }
+
+    // (protected) set from integer value x, -DV <= x < DV
+    function bnpFromInt(x) {
+	this.t = 1;
+	this.s = (x<0)?-1:0;
+	if(x > 0) this[0] = x;
+	else if(x < -1) this[0] = x+DV;
+	else this.t = 0;
+    }
+
+    // return bigint initialized to value
+    function nbv(i) { var r = nbi(); r.fromInt(i); return r; }
+
+    // (protected) set from string and radix
+    function bnpFromString(s,b) {
+	var k;
+	if(b == 16) k = 4;
+	else if(b == 8) k = 3;
+	else if(b == 256) k = 8; // byte array
+	else if(b == 2) k = 1;
+	else if(b == 32) k = 5;
+	else if(b == 4) k = 2;
+	else { this.fromRadix(s,b); return; }
+	this.t = 0;
+	this.s = 0;
+	var i = s.length, mi = false, sh = 0;
+	while(--i >= 0) {
+	    var x = (k==8)?s[i]&0xff:intAt(s,i);
+	    if(x < 0) {
+		if(s.charAt(i) == "-") mi = true;
+		continue;
+	    }
+	    mi = false;
+	    if(sh == 0)
+		this[this.t++] = x;
+	    else if(sh+k > this.DB) {
+		this[this.t-1] |= (x&((1<<(this.DB-sh))-1))<<sh;
+		this[this.t++] = (x>>(this.DB-sh));
+	    }
+	    else
+		this[this.t-1] |= x<<sh;
+	    sh += k;
+	    if(sh >= this.DB) sh -= this.DB;
+	}
+	if(k == 8 && (s[0]&0x80) != 0) {
+	    this.s = -1;
+	    if(sh > 0) this[this.t-1] |= ((1<<(this.DB-sh))-1)<<sh;
+	}
+	this.clamp();
+	if(mi) BigInteger.ZERO.subTo(this,this);
+    }
+
+    // (protected) clamp off excess high words
+    function bnpClamp() {
+	var c = this.s&this.DM;
+	while(this.t > 0 && this[this.t-1] == c) --this.t;
+    }
+
+    // (public) return string representation in given radix
+    function bnToString(b) {
+	if(this.s < 0) return "-"+this.negate().toString(b);
+	var k;
+	if(b == 16) k = 4;
+	else if(b == 8) k = 3;
+	else if(b == 2) k = 1;
+	else if(b == 32) k = 5;
+	else if(b == 4) k = 2;
+	else return this.toRadix(b);
+	var km = (1<<k)-1, d, m = false, r = [], i = this.t;
+	var p = this.DB-(i*this.DB)%k;
+	if(i-- > 0) {
+	    if(p < this.DB && (d = this[i]>>p) > 0) { m = true; r.push(int2char(d)); }
+	    while(i >= 0) {
+		if(p < k) {
+		    d = (this[i]&((1<<p)-1))<<(k-p);
+		    d |= this[--i]>>(p+=this.DB-k);
+		}
+		else {
+		    d = (this[i]>>(p-=k))&km;
+		    if(p <= 0) { p += this.DB; --i; }
+		}
+		if(d > 0) m = true;
+		if(m) r.push(int2char(d));
+	    }
+	}
+	return m?r.join(""):"0";
+    }
+
+    // (public) -this
+    function bnNegate() { var r = nbi(); BigInteger.ZERO.subTo(this,r); return r; }
+
+    // (public) |this|
+    function bnAbs() { return (this.s<0)?this.negate():this; }
+
+    // (public) return + if this > a, - if this < a, 0 if equal
+    function bnCompareTo(a) {
+	var r = this.s-a.s;
+	if(r != 0) return r;
+	var i = this.t;
+	if ( this.s < 0 ) {
+		r = a.t - i;
+	}
+	else {
+		r = i - a.t;
+	}
+	if(r != 0) return r;
+	while(--i >= 0) if((r=this[i]-a[i]) != 0) return r;
+	return 0;
+    }
+
+    // returns bit length of the integer x
+    function nbits(x) {
+	var r = 1, t;
+	if((t=x>>>16) != 0) { x = t; r += 16; }
+	if((t=x>>8) != 0) { x = t; r += 8; }
+	if((t=x>>4) != 0) { x = t; r += 4; }
+	if((t=x>>2) != 0) { x = t; r += 2; }
+	if((t=x>>1) != 0) { x = t; r += 1; }
+	return r;
+    }
+
+    // (public) return the number of bits in "this"
+    function bnBitLength() {
+	if(this.t <= 0) return 0;
+	return this.DB*(this.t-1)+nbits(this[this.t-1]^(this.s&this.DM));
+    }
+
+    // (protected) r = this << n*DB
+    function bnpDLShiftTo(n,r) {
+	var i;
+	for(i = this.t-1; i >= 0; --i) r[i+n] = this[i];
+	for(i = n-1; i >= 0; --i) r[i] = 0;
+	r.t = this.t+n;
+	r.s = this.s;
+    }
+
+    // (protected) r = this >> n*DB
+    function bnpDRShiftTo(n,r) {
+	for(var i = n; i < this.t; ++i) r[i-n] = this[i];
+	r.t = Math.max(this.t-n,0);
+	r.s = this.s;
+    }
+
+    // (protected) r = this << n
+    function bnpLShiftTo(n,r) {
+	var bs = n%this.DB;
+	var cbs = this.DB-bs;
+	var bm = (1<<cbs)-1;
+	var ds = Math.floor(n/this.DB), c = (this.s<<bs)&this.DM, i;
+	for(i = this.t-1; i >= 0; --i) {
+	    r[i+ds+1] = (this[i]>>cbs)|c;
+	    c = (this[i]&bm)<<bs;
+	}
+	for(i = ds-1; i >= 0; --i) r[i] = 0;
+	r[ds] = c;
+	r.t = this.t+ds+1;
+	r.s = this.s;
+	r.clamp();
+    }
+
+    // (protected) r = this >> n
+    function bnpRShiftTo(n,r) {
+	r.s = this.s;
+	var ds = Math.floor(n/this.DB);
+	if(ds >= this.t) { r.t = 0; return; }
+	var bs = n%this.DB;
+	var cbs = this.DB-bs;
+	var bm = (1<<bs)-1;
+	r[0] = this[ds]>>bs;
+	for(var i = ds+1; i < this.t; ++i) {
+	    r[i-ds-1] |= (this[i]&bm)<<cbs;
+	    r[i-ds] = this[i]>>bs;
+	}
+	if(bs > 0) r[this.t-ds-1] |= (this.s&bm)<<cbs;
+	r.t = this.t-ds;
+	r.clamp();
+    }
+
+    // (protected) r = this - a
+    function bnpSubTo(a,r) {
+	var i = 0, c = 0, m = Math.min(a.t,this.t);
+	while(i < m) {
+	    c += this[i]-a[i];
+	    r[i++] = c&this.DM;
+	    c >>= this.DB;
+	}
+	if(a.t < this.t) {
+	    c -= a.s;
+	    while(i < this.t) {
+		c += this[i];
+		r[i++] = c&this.DM;
+		c >>= this.DB;
+	    }
+	    c += this.s;
+	}
+	else {
+	    c += this.s;
+	    while(i < a.t) {
+		c -= a[i];
+		r[i++] = c&this.DM;
+		c >>= this.DB;
+	    }
+	    c -= a.s;
+	}
+	r.s = (c<0)?-1:0;
+	if(c < -1) r[i++] = this.DV+c;
+	else if(c > 0) r[i++] = c;
+	r.t = i;
+	r.clamp();
+    }
+
+    // (protected) r = this * a, r != this,a (HAC 14.12)
+    // "this" should be the larger one if appropriate.
+    function bnpMultiplyTo(a,r) {
+	var x = this.abs(), y = a.abs();
+	var i = x.t;
+	r.t = i+y.t;
+	while(--i >= 0) r[i] = 0;
+	for(i = 0; i < y.t; ++i) r[i+x.t] = x.am(0,y[i],r,i,0,x.t);
+	r.s = 0;
+	r.clamp();
+	if(this.s != a.s) BigInteger.ZERO.subTo(r,r);
+    }
+
+    // (protected) r = this^2, r != this (HAC 14.16)
+    function bnpSquareTo(r) {
+	var x = this.abs();
+	var i = r.t = 2*x.t;
+	while(--i >= 0) r[i] = 0;
+	for(i = 0; i < x.t-1; ++i) {
+	    var c = x.am(i,x[i],r,2*i,0,1);
+	    if((r[i+x.t]+=x.am(i+1,2*x[i],r,2*i+1,c,x.t-i-1)) >= x.DV) {
+		r[i+x.t] -= x.DV;
+		r[i+x.t+1] = 1;
+	    }
+	}
+	if(r.t > 0) r[r.t-1] += x.am(i,x[i],r,2*i,0,1);
+	r.s = 0;
+	r.clamp();
+    }
+
+
+    // (protected) divide this by m, quotient and remainder to q, r (HAC 14.20)
+    // r != q, this != m.  q or r may be null.
+    function bnpDivRemTo(m,q,r) {
+	var pm = m.abs();
+	if(pm.t <= 0) return;
+	var pt = this.abs();
+	if(pt.t < pm.t) {
+	    if(q != null) q.fromInt(0);
+	    if(r != null) this.copyTo(r);
+	    return;
+	}
+	if(r == null) r = nbi();
+	var y = nbi(), ts = this.s, ms = m.s;
+	var nsh = this.DB-nbits(pm[pm.t-1]);	// normalize modulus
+	if(nsh > 0) { pm.lShiftTo(nsh,y); pt.lShiftTo(nsh,r); }
+	else { pm.copyTo(y); pt.copyTo(r); }
+	var ys = y.t;
+	var y0 = y[ys-1];
+	if(y0 == 0) return;
+	var yt = y0*(1<<this.F1)+((ys>1)?y[ys-2]>>this.F2:0);
+	var d1 = this.FV/yt, d2 = (1<<this.F1)/yt, e = 1<<this.F2;
+	var i = r.t, j = i-ys, t = (q==null)?nbi():q;
+	y.dlShiftTo(j,t);
+	if(r.compareTo(t) >= 0) {
+	    r[r.t++] = 1;
+	    r.subTo(t,r);
+	}
+	BigInteger.ONE.dlShiftTo(ys,t);
+	t.subTo(y,y);	// "negative" y so we can replace sub with am later
+	while(y.t < ys) y[y.t++] = 0;
+	while(--j >= 0) {
+	    // Estimate quotient digit
+	    var qd = (r[--i]==y0)?this.DM:Math.floor(r[i]*d1+(r[i-1]+e)*d2);
+	    if((r[i]+=y.am(0,qd,r,j,0,ys)) < qd) {	// Try it out
+		y.dlShiftTo(j,t);
+		r.subTo(t,r);
+		while(r[i] < --qd) r.subTo(t,r);
+	    }
+	}
+	if(q != null) {
+	    r.drShiftTo(ys,q);
+	    if(ts != ms) BigInteger.ZERO.subTo(q,q);
+	}
+	r.t = ys;
+	r.clamp();
+	if(nsh > 0) r.rShiftTo(nsh,r);	// Denormalize remainder
+	if(ts < 0) BigInteger.ZERO.subTo(r,r);
+    }
+
+    // (public) this mod a
+    function bnMod(a) {
+	var r = nbi();
+	this.abs().divRemTo(a,null,r);
+	if(this.s < 0 && r.compareTo(BigInteger.ZERO) > 0) a.subTo(r,r);
+	return r;
+    }
+
+    // Modular reduction using "classic" algorithm
+    function Classic(m) { this.m = m; }
+    function cConvert(x) {
+	if(x.s < 0 || x.compareTo(this.m) >= 0) return x.mod(this.m);
+	else return x;
+    }
+    function cRevert(x) { return x; }
+    function cReduce(x) { x.divRemTo(this.m,null,x); }
+    function cMulTo(x,y,r) { x.multiplyTo(y,r); this.reduce(r); }
+    function cSqrTo(x,r) { x.squareTo(r); this.reduce(r); }
+
+    Classic.prototype.convert = cConvert;
+    Classic.prototype.revert = cRevert;
+    Classic.prototype.reduce = cReduce;
+    Classic.prototype.mulTo = cMulTo;
+    Classic.prototype.sqrTo = cSqrTo;
+
+    // (protected) return "-1/this % 2^DB"; useful for Mont. reduction
+    // justification:
+    //         xy == 1 (mod m)
+    //         xy =  1+km
+    //   xy(2-xy) = (1+km)(1-km)
+    // x[y(2-xy)] = 1-k^2m^2
+    // x[y(2-xy)] == 1 (mod m^2)
+    // if y is 1/x mod m, then y(2-xy) is 1/x mod m^2
+    // should reduce x and y(2-xy) by m^2 at each step to keep size bounded.
+    // JS multiply "overflows" differently from C/C++, so care is needed here.
+    function bnpInvDigit() {
+	if(this.t < 1) return 0;
+	var x = this[0];
+	if((x&1) == 0) return 0;
+	var y = x&3;		// y == 1/x mod 2^2
+	y = (y*(2-(x&0xf)*y))&0xf;	// y == 1/x mod 2^4
+	y = (y*(2-(x&0xff)*y))&0xff;	// y == 1/x mod 2^8
+	y = (y*(2-(((x&0xffff)*y)&0xffff)))&0xffff;	// y == 1/x mod 2^16
+	// last step - calculate inverse mod DV directly;
+	// assumes 16 < DB <= 32 and assumes ability to handle 48-bit ints
+	y = (y*(2-x*y%this.DV))%this.DV;		// y == 1/x mod 2^dbits
+	// we really want the negative inverse, and -DV < y < DV
+	return (y>0)?this.DV-y:-y;
+    }
+
+    // Montgomery reduction
+    function Montgomery(m) {
+	this.m = m;
+	this.mp = m.invDigit();
+	this.mpl = this.mp&0x7fff;
+	this.mph = this.mp>>15;
+	this.um = (1<<(m.DB-15))-1;
+	this.mt2 = 2*m.t;
+    }
+
+    // xR mod m
+    function montConvert(x) {
+	var r = nbi();
+	x.abs().dlShiftTo(this.m.t,r);
+	r.divRemTo(this.m,null,r);
+	if(x.s < 0 && r.compareTo(BigInteger.ZERO) > 0) this.m.subTo(r,r);
+	return r;
+    }
+
+    // x/R mod m
+    function montRevert(x) {
+	var r = nbi();
+	x.copyTo(r);
+	this.reduce(r);
+	return r;
+    }
+
+    // x = x/R mod m (HAC 14.32)
+    function montReduce(x) {
+	while(x.t <= this.mt2)	// pad x so am has enough room later
+	    x[x.t++] = 0;
+	for(var i = 0; i < this.m.t; ++i) {
+	    // faster way of calculating u0 = x[i]*mp mod DV
+	    var j = x[i]&0x7fff;
+	    var u0 = (j*this.mpl+(((j*this.mph+(x[i]>>15)*this.mpl)&this.um)<<15))&x.DM;
+	    // use am to combine the multiply-shift-add into one call
+	    j = i+this.m.t;
+	    x[j] += this.m.am(0,u0,x,i,0,this.m.t);
+	    // propagate carry
+	    while(x[j] >= x.DV) { x[j] -= x.DV; x[++j]++; }
+	}
+	x.clamp();
+	x.drShiftTo(this.m.t,x);
+	if(x.compareTo(this.m) >= 0) x.subTo(this.m,x);
+    }
+
+    // r = "x^2/R mod m"; x != r
+    function montSqrTo(x,r) { x.squareTo(r); this.reduce(r); }
+
+    // r = "xy/R mod m"; x,y != r
+    function montMulTo(x,y,r) { x.multiplyTo(y,r); this.reduce(r); }
+
+    Montgomery.prototype.convert = montConvert;
+    Montgomery.prototype.revert = montRevert;
+    Montgomery.prototype.reduce = montReduce;
+    Montgomery.prototype.mulTo = montMulTo;
+    Montgomery.prototype.sqrTo = montSqrTo;
+
+    // (protected) true iff this is even
+    function bnpIsEven() { return ((this.t>0)?(this[0]&1):this.s) == 0; }
+
+    // (protected) this^e, e < 2^32, doing sqr and mul with "r" (HAC 14.79)
+    function bnpExp(e,z) {
+	    if(e > 0xffffffff || e < 1) return BigInteger.ONE;
+	    var r = nbi(), r2 = nbi(), g = z.convert(this), i = nbits(e)-1;
+	    g.copyTo(r);
+	    while(--i >= 0) {
+	        z.sqrTo(r,r2);
+	        if((e&(1<<i)) > 0) z.mulTo(r2,g,r);
+	        else { var t = r; r = r2; r2 = t; }
+	    }
+	    return z.revert(r);
+    }
+
+    // (public) this^e % m, 0 <= e < 2^32
+    function bnModPowInt(e,m) {
+	var z;
+	if(e < 256 || m.isEven()) z = new Classic(m); else z = new Montgomery(m);
+	return this.exp(e,z);
+    }
+
+    // protected
+    BigInteger.prototype.copyTo = bnpCopyTo;
+    BigInteger.prototype.fromInt = bnpFromInt;
+    BigInteger.prototype.fromString = bnpFromString;
+    BigInteger.prototype.clamp = bnpClamp;
+    BigInteger.prototype.dlShiftTo = bnpDLShiftTo;
+    BigInteger.prototype.drShiftTo = bnpDRShiftTo;
+    BigInteger.prototype.lShiftTo = bnpLShiftTo;
+    BigInteger.prototype.rShiftTo = bnpRShiftTo;
+    BigInteger.prototype.subTo = bnpSubTo;
+    BigInteger.prototype.multiplyTo = bnpMultiplyTo;
+    BigInteger.prototype.squareTo = bnpSquareTo;
+    BigInteger.prototype.divRemTo = bnpDivRemTo;
+    BigInteger.prototype.invDigit = bnpInvDigit;
+    BigInteger.prototype.isEven = bnpIsEven;
+    BigInteger.prototype.exp = bnpExp;
+
+    // public
+    BigInteger.prototype.toString = bnToString;
+    BigInteger.prototype.negate = bnNegate;
+    BigInteger.prototype.abs = bnAbs;
+    BigInteger.prototype.compareTo = bnCompareTo;
+    BigInteger.prototype.bitLength = bnBitLength;
+    BigInteger.prototype.mod = bnMod;
+    BigInteger.prototype.modPowInt = bnModPowInt;
+
+    // "constants"
+    BigInteger.ZERO = nbv(0);
+    BigInteger.ONE = nbv(1);
+
+    // Copyright (c) 2005-2009  Tom Wu
+    // All Rights Reserved.
+    // See "LICENSE" for details.
+
+    // Extended JavaScript BN functions, required for RSA private ops.
+
+    // Version 1.1: new BigInteger("0", 10) returns "proper" zero
+
+    // (public)
+    function bnClone() { var r = nbi(); this.copyTo(r); return r; }
+
+    // (public) return value as integer
+    function bnIntValue() {
+	if(this.s < 0) {
+	    if(this.t == 1) return this[0]-this.DV;
+	    else if(this.t == 0) return -1;
+	}
+	else if(this.t == 1) return this[0];
+	else if(this.t == 0) return 0;
+	// assumes 16 < DB < 32
+	return ((this[1]&((1<<(32-this.DB))-1))<<this.DB)|this[0];
+    }
+
+    // (public) return value as byte
+    function bnByteValue() { return (this.t==0)?this.s:(this[0]<<24)>>24; }
+
+    // (public) return value as short (assumes DB>=16)
+    function bnShortValue() { return (this.t==0)?this.s:(this[0]<<16)>>16; }
+
+    // (protected) return x s.t. r^x < DV
+    function bnpChunkSize(r) { return Math.floor(Math.LN2*this.DB/Math.log(r)); }
+
+    // (public) 0 if this == 0, 1 if this > 0
+    function bnSigNum() {
+	if(this.s < 0) return -1;
+	else if(this.t <= 0 || (this.t == 1 && this[0] <= 0)) return 0;
+	else return 1;
+    }
+
+    // (protected) convert to radix string
+    function bnpToRadix(b) {
+	if(b == null) b = 10;
+	if(this.signum() == 0 || b < 2 || b > 36) return "0";
+	var cs = this.chunkSize(b);
+	var a = Math.pow(b,cs);
+	var d = nbv(a), y = nbi(), z = nbi(), r = "";
+	this.divRemTo(d,y,z);
+	while(y.signum() > 0) {
+	    r = (a+z.intValue()).toString(b).substr(1) + r;
+	    y.divRemTo(d,y,z);
+	}
+	return z.intValue().toString(b) + r;
+    }
+
+    // (protected) convert from radix string
+    function bnpFromRadix(s,b) {
+	this.fromInt(0);
+	if(b == null) b = 10;
+	var cs = this.chunkSize(b);
+	var d = Math.pow(b,cs), mi = false, j = 0, w = 0;
+	for(var i = 0; i < s.length; ++i) {
+	    var x = intAt(s,i);
+	    if(x < 0) {
+		if(s.charAt(i) == "-" && this.signum() == 0) mi = true;
+		continue;
+	    }
+	    w = b*w+x;
+	    if(++j >= cs) {
+		this.dMultiply(d);
+		this.dAddOffset(w,0);
+		j = 0;
+		w = 0;
+	    }
+	}
+	if(j > 0) {
+	    this.dMultiply(Math.pow(b,j));
+	    this.dAddOffset(w,0);
+	}
+	if(mi) BigInteger.ZERO.subTo(this,this);
+    }
+
+    // (protected) alternate constructor
+    function bnpFromNumber(a,b,c) {
+	if("number" == typeof b) {
+	    // new BigInteger(int,int,RNG)
+	    if(a < 2) this.fromInt(1);
+	    else {
+		this.fromNumber(a,c);
+		if(!this.testBit(a-1))	// force MSB set
+		    this.bitwiseTo(BigInteger.ONE.shiftLeft(a-1),op_or,this);
+		if(this.isEven()) this.dAddOffset(1,0); // force odd
+		while(!this.isProbablePrime(b)) {
+		    this.dAddOffset(2,0);
+		    if(this.bitLength() > a) this.subTo(BigInteger.ONE.shiftLeft(a-1),this);
+		}
+	    }
+	}
+	else {
+	    // new BigInteger(int,RNG)
+	    var x = [], t = a&7;
+	    x.length = (a>>3)+1;
+	    b.nextBytes(x);
+	    if(t > 0) x[0] &= ((1<<t)-1); else x[0] = 0;
+	    this.fromString(x,256);
+	}
+    }
+
+    // (public) convert to bigendian byte array
+    function bnToByteArray() {
+	var i = this.t, r = [];
+	r[0] = this.s;
+	var p = this.DB-(i*this.DB)%8, d, k = 0;
+	if(i-- > 0) {
+	    if(p < this.DB && (d = this[i]>>p) != (this.s&this.DM)>>p)
+		r[k++] = d|(this.s<<(this.DB-p));
+	    while(i >= 0) {
+		if(p < 8) {
+		    d = (this[i]&((1<<p)-1))<<(8-p);
+		    d |= this[--i]>>(p+=this.DB-8);
+		}
+		else {
+		    d = (this[i]>>(p-=8))&0xff;
+		    if(p <= 0) { p += this.DB; --i; }
+		}
+		if((d&0x80) != 0) d |= -256;
+		if(k == 0 && (this.s&0x80) != (d&0x80)) ++k;
+		if(k > 0 || d != this.s) r[k++] = d;
+	    }
+	}
+	return r;
+    }
+
+    function bnEquals(a) { return(this.compareTo(a)==0); }
+    function bnMin(a) { return(this.compareTo(a)<0)?this:a; }
+    function bnMax(a) { return(this.compareTo(a)>0)?this:a; }
+
+    // (protected) r = this op a (bitwise)
+    function bnpBitwiseTo(a,op,r) {
+	var i, f, m = Math.min(a.t,this.t);
+	for(i = 0; i < m; ++i) r[i] = op(this[i],a[i]);
+	if(a.t < this.t) {
+	    f = a.s&this.DM;
+	    for(i = m; i < this.t; ++i) r[i] = op(this[i],f);
+	    r.t = this.t;
+	}
+	else {
+	    f = this.s&this.DM;
+	    for(i = m; i < a.t; ++i) r[i] = op(f,a[i]);
+	    r.t = a.t;
+	}
+	r.s = op(this.s,a.s);
+	r.clamp();
+    }
+
+    // (public) this & a
+    function op_and(x,y) { return x&y; }
+    function bnAnd(a) { var r = nbi(); this.bitwiseTo(a,op_and,r); return r; }
+
+    // (public) this | a
+    function op_or(x,y) { return x|y; }
+    function bnOr(a) { var r = nbi(); this.bitwiseTo(a,op_or,r); return r; }
+
+    // (public) this ^ a
+    function op_xor(x,y) { return x^y; }
+    function bnXor(a) { var r = nbi(); this.bitwiseTo(a,op_xor,r); return r; }
+
+    // (public) this & ~a
+    function op_andnot(x,y) { return x&~y; }
+    function bnAndNot(a) { var r = nbi(); this.bitwiseTo(a,op_andnot,r); return r; }
+
+    // (public) ~this
+    function bnNot() {
+	var r = nbi();
+	for(var i = 0; i < this.t; ++i) r[i] = this.DM&~this[i];
+	r.t = this.t;
+	r.s = ~this.s;
+	return r;
+    }
+
+    // (public) this << n
+    function bnShiftLeft(n) {
+	var r = nbi();
+	if(n < 0) this.rShiftTo(-n,r); else this.lShiftTo(n,r);
+	return r;
+    }
+
+    // (public) this >> n
+    function bnShiftRight(n) {
+	var r = nbi();
+	if(n < 0) this.lShiftTo(-n,r); else this.rShiftTo(n,r);
+	return r;
+    }
+
+    // return index of lowest 1-bit in x, x < 2^31
+    function lbit(x) {
+	if(x == 0) return -1;
+	var r = 0;
+	if((x&0xffff) == 0) { x >>= 16; r += 16; }
+	if((x&0xff) == 0) { x >>= 8; r += 8; }
+	if((x&0xf) == 0) { x >>= 4; r += 4; }
+	if((x&3) == 0) { x >>= 2; r += 2; }
+	if((x&1) == 0) ++r;
+	return r;
+    }
+
+    // (public) returns index of lowest 1-bit (or -1 if none)
+    function bnGetLowestSetBit() {
+	for(var i = 0; i < this.t; ++i)
+	    if(this[i] != 0) return i*this.DB+lbit(this[i]);
+	if(this.s < 0) return this.t*this.DB;
+	return -1;
+    }
+
+    // return number of 1 bits in x
+    function cbit(x) {
+	var r = 0;
+	while(x != 0) { x &= x-1; ++r; }
+	return r;
+    }
+
+    // (public) return number of set bits
+    function bnBitCount() {
+	var r = 0, x = this.s&this.DM;
+	for(var i = 0; i < this.t; ++i) r += cbit(this[i]^x);
+	return r;
+    }
+
+    // (public) true iff nth bit is set
+    function bnTestBit(n) {
+	var j = Math.floor(n/this.DB);
+	if(j >= this.t) return(this.s!=0);
+	return((this[j]&(1<<(n%this.DB)))!=0);
+    }
+
+    // (protected) this op (1<<n)
+    function bnpChangeBit(n,op) {
+	var r = BigInteger.ONE.shiftLeft(n);
+	this.bitwiseTo(r,op,r);
+	return r;
+    }
+
+    // (public) this | (1<<n)
+    function bnSetBit(n) { return this.changeBit(n,op_or); }
+
+    // (public) this & ~(1<<n)
+    function bnClearBit(n) { return this.changeBit(n,op_andnot); }
+
+    // (public) this ^ (1<<n)
+    function bnFlipBit(n) { return this.changeBit(n,op_xor); }
+
+    // (protected) r = this + a
+    function bnpAddTo(a,r) {
+	var i = 0, c = 0, m = Math.min(a.t,this.t);
+	while(i < m) {
+	    c += this[i]+a[i];
+	    r[i++] = c&this.DM;
+	    c >>= this.DB;
+	}
+	if(a.t < this.t) {
+	    c += a.s;
+	    while(i < this.t) {
+		c += this[i];
+		r[i++] = c&this.DM;
+		c >>= this.DB;
+	    }
+	    c += this.s;
+	}
+	else {
+	    c += this.s;
+	    while(i < a.t) {
+		c += a[i];
+		r[i++] = c&this.DM;
+		c >>= this.DB;
+	    }
+	    c += a.s;
+	}
+	r.s = (c<0)?-1:0;
+	if(c > 0) r[i++] = c;
+	else if(c < -1) r[i++] = this.DV+c;
+	r.t = i;
+	r.clamp();
+    }
+
+    // (public) this + a
+    function bnAdd(a) { var r = nbi(); this.addTo(a,r); return r; }
+
+    // (public) this - a
+    function bnSubtract(a) { var r = nbi(); this.subTo(a,r); return r; }
+
+    // (public) this * a
+    function bnMultiply(a) { var r = nbi(); this.multiplyTo(a,r); return r; }
+
+    // (public) this / a
+    function bnDivide(a) { var r = nbi(); this.divRemTo(a,r,null); return r; }
+
+    // (public) this % a
+    function bnRemainder(a) { var r = nbi(); this.divRemTo(a,null,r); return r; }
+
+    // (public) [this/a,this%a]
+    function bnDivideAndRemainder(a) {
+	var q = nbi(), r = nbi();
+	this.divRemTo(a,q,r);
+	return [q,r];
+    }
+
+    // (protected) this *= n, this >= 0, 1 < n < DV
+    function bnpDMultiply(n) {
+	this[this.t] = this.am(0,n-1,this,0,0,this.t);
+	++this.t;
+	this.clamp();
+    }
+
+    // (protected) this += n << w words, this >= 0
+    function bnpDAddOffset(n,w) {
+	if(n == 0) return;
+	while(this.t <= w) this[this.t++] = 0;
+	this[w] += n;
+	while(this[w] >= this.DV) {
+	    this[w] -= this.DV;
+	    if(++w >= this.t) this[this.t++] = 0;
+	    ++this[w];
+	}
+    }
+
+    // A "null" reducer
+    function NullExp() {}
+    function nNop(x) { return x; }
+    function nMulTo(x,y,r) { x.multiplyTo(y,r); }
+    function nSqrTo(x,r) { x.squareTo(r); }
+
+    NullExp.prototype.convert = nNop;
+    NullExp.prototype.revert = nNop;
+    NullExp.prototype.mulTo = nMulTo;
+    NullExp.prototype.sqrTo = nSqrTo;
+
+    // (public) this^e
+    function bnPow(e) { return this.exp(e,new NullExp()); }
+
+    // (protected) r = lower n words of "this * a", a.t <= n
+    // "this" should be the larger one if appropriate.
+    function bnpMultiplyLowerTo(a,n,r) {
+	var i = Math.min(this.t+a.t,n);
+	r.s = 0; // assumes a,this >= 0
+	r.t = i;
+	while(i > 0) r[--i] = 0;
+	var j;
+	for(j = r.t-this.t; i < j; ++i) r[i+this.t] = this.am(0,a[i],r,i,0,this.t);
+	for(j = Math.min(a.t,n); i < j; ++i) this.am(0,a[i],r,i,0,n-i);
+	r.clamp();
+    }
+
+    // (protected) r = "this * a" without lower n words, n > 0
+    // "this" should be the larger one if appropriate.
+    function bnpMultiplyUpperTo(a,n,r) {
+	--n;
+	var i = r.t = this.t+a.t-n;
+	r.s = 0; // assumes a,this >= 0
+	while(--i >= 0) r[i] = 0;
+	for(i = Math.max(n-this.t,0); i < a.t; ++i)
+	    r[this.t+i-n] = this.am(n-i,a[i],r,0,0,this.t+i-n);
+	r.clamp();
+	r.drShiftTo(1,r);
+    }
+
+    // Barrett modular reduction
+    function Barrett(m) {
+	// setup Barrett
+	this.r2 = nbi();
+	this.q3 = nbi();
+	BigInteger.ONE.dlShiftTo(2*m.t,this.r2);
+	this.mu = this.r2.divide(m);
+	this.m = m;
+    }
+
+    function barrettConvert(x) {
+	if(x.s < 0 || x.t > 2*this.m.t) return x.mod(this.m);
+	else if(x.compareTo(this.m) < 0) return x;
+	else { var r = nbi(); x.copyTo(r); this.reduce(r); return r; }
+    }
+
+    function barrettRevert(x) { return x; }
+
+    // x = x mod m (HAC 14.42)
+    function barrettReduce(x) {
+	x.drShiftTo(this.m.t-1,this.r2);
+	if(x.t > this.m.t+1) { x.t = this.m.t+1; x.clamp(); }
+	this.mu.multiplyUpperTo(this.r2,this.m.t+1,this.q3);
+	this.m.multiplyLowerTo(this.q3,this.m.t+1,this.r2);
+	while(x.compareTo(this.r2) < 0) x.dAddOffset(1,this.m.t+1);
+	x.subTo(this.r2,x);
+	while(x.compareTo(this.m) >= 0) x.subTo(this.m,x);
+    }
+
+    // r = x^2 mod m; x != r
+    function barrettSqrTo(x,r) { x.squareTo(r); this.reduce(r); }
+
+    // r = x*y mod m; x,y != r
+    function barrettMulTo(x,y,r) { x.multiplyTo(y,r); this.reduce(r); }
+
+    Barrett.prototype.convert = barrettConvert;
+    Barrett.prototype.revert = barrettRevert;
+    Barrett.prototype.reduce = barrettReduce;
+    Barrett.prototype.mulTo = barrettMulTo;
+    Barrett.prototype.sqrTo = barrettSqrTo;
+
+    // (public) this^e % m (HAC 14.85)
+    function bnModPow(e,m) {
+	var i = e.bitLength(), k, r = nbv(1), z;
+	if(i <= 0) return r;
+	else if(i < 18) k = 1;
+	else if(i < 48) k = 3;
+	else if(i < 144) k = 4;
+	else if(i < 768) k = 5;
+	else k = 6;
+	if(i < 8)
+	    z = new Classic(m);
+	else if(m.isEven())
+	    z = new Barrett(m);
+	else
+	    z = new Montgomery(m);
+
+	// precomputation
+	var g = [], n = 3, k1 = k-1, km = (1<<k)-1;
+	g[1] = z.convert(this);
+	if(k > 1) {
+	    var g2 = nbi();
+	    z.sqrTo(g[1],g2);
+	    while(n <= km) {
+		g[n] = nbi();
+		z.mulTo(g2,g[n-2],g[n]);
+		n += 2;
+	    }
+	}
+
+	var j = e.t-1, w, is1 = true, r2 = nbi(), t;
+	i = nbits(e[j])-1;
+	while(j >= 0) {
+	    if(i >= k1) w = (e[j]>>(i-k1))&km;
+	    else {
+		w = (e[j]&((1<<(i+1))-1))<<(k1-i);
+		if(j > 0) w |= e[j-1]>>(this.DB+i-k1);
+	    }
+
+	    n = k;
+	    while((w&1) == 0) { w >>= 1; --n; }
+	    if((i -= n) < 0) { i += this.DB; --j; }
+	    if(is1) {	// ret == 1, don't bother squaring or multiplying it
+		g[w].copyTo(r);
+		is1 = false;
+	    }
+	    else {
+		while(n > 1) { z.sqrTo(r,r2); z.sqrTo(r2,r); n -= 2; }
+		if(n > 0) z.sqrTo(r,r2); else { t = r; r = r2; r2 = t; }
+		z.mulTo(r2,g[w],r);
+	    }
+
+	    while(j >= 0 && (e[j]&(1<<i)) == 0) {
+		z.sqrTo(r,r2); t = r; r = r2; r2 = t;
+		if(--i < 0) { i = this.DB-1; --j; }
+	    }
+	}
+	return z.revert(r);
+    }
+
+    // (public) gcd(this,a) (HAC 14.54)
+    function bnGCD(a) {
+	var x = (this.s<0)?this.negate():this.clone();
+	var y = (a.s<0)?a.negate():a.clone();
+	if(x.compareTo(y) < 0) { var t = x; x = y; y = t; }
+	var i = x.getLowestSetBit(), g = y.getLowestSetBit();
+	if(g < 0) return x;
+	if(i < g) g = i;
+	if(g > 0) {
+	    x.rShiftTo(g,x);
+	    y.rShiftTo(g,y);
+	}
+	while(x.signum() > 0) {
+	    if((i = x.getLowestSetBit()) > 0) x.rShiftTo(i,x);
+	    if((i = y.getLowestSetBit()) > 0) y.rShiftTo(i,y);
+	    if(x.compareTo(y) >= 0) {
+		x.subTo(y,x);
+		x.rShiftTo(1,x);
+	    }
+	    else {
+		y.subTo(x,y);
+		y.rShiftTo(1,y);
+	    }
+	}
+	if(g > 0) y.lShiftTo(g,y);
+	return y;
+    }
+
+    // (protected) this % n, n < 2^26
+    function bnpModInt(n) {
+	if(n <= 0) return 0;
+	var d = this.DV%n, r = (this.s<0)?n-1:0;
+	if(this.t > 0)
+	    if(d == 0) r = this[0]%n;
+	else for(var i = this.t-1; i >= 0; --i) r = (d*r+this[i])%n;
+	return r;
+    }
+
+    // (public) 1/this % m (HAC 14.61)
+    function bnModInverse(m) {
+	var ac = m.isEven();
+	if((this.isEven() && ac) || m.signum() == 0) return BigInteger.ZERO;
+	var u = m.clone(), v = this.clone();
+	var a = nbv(1), b = nbv(0), c = nbv(0), d = nbv(1);
+	while(u.signum() != 0) {
+	    while(u.isEven()) {
+		u.rShiftTo(1,u);
+		if(ac) {
+		    if(!a.isEven() || !b.isEven()) { a.addTo(this,a); b.subTo(m,b); }
+		    a.rShiftTo(1,a);
+		}
+		else if(!b.isEven()) b.subTo(m,b);
+		b.rShiftTo(1,b);
+	    }
+	    while(v.isEven()) {
+		v.rShiftTo(1,v);
+		if(ac) {
+		    if(!c.isEven() || !d.isEven()) { c.addTo(this,c); d.subTo(m,d); }
+		    c.rShiftTo(1,c);
+		}
+		else if(!d.isEven()) d.subTo(m,d);
+		d.rShiftTo(1,d);
+	    }
+	    if(u.compareTo(v) >= 0) {
+		u.subTo(v,u);
+		if(ac) a.subTo(c,a);
+		b.subTo(d,b);
+	    }
+	    else {
+		v.subTo(u,v);
+		if(ac) c.subTo(a,c);
+		d.subTo(b,d);
+	    }
+	}
+	if(v.compareTo(BigInteger.ONE) != 0) return BigInteger.ZERO;
+	if(d.compareTo(m) >= 0) return d.subtract(m);
+	if(d.signum() < 0) d.addTo(m,d); else return d;
+	if(d.signum() < 0) return d.add(m); else return d;
+    }
+
+    var lowprimes = [2,3,5,7,11,13,17,19,23,29,31,37,41,43,47,53,59,61,67,71,73,79,83,89,97,101,103,107,109,113,127,131,137,139,149,151,157,163,167,173,179,181,191,193,197,199,211,223,227,229,233,239,241,251,257,263,269,271,277,281,283,293,307,311,313,317,331,337,347,349,353,359,367,373,379,383,389,397,401,409,419,421,431,433,439,443,449,457,461,463,467,479,487,491,499,503,509];
+    var lplim = (1<<26)/lowprimes[lowprimes.length-1];
+
+    // (public) test primality with certainty >= 1-.5^t
+    function bnIsProbablePrime(t) {
+	var i, x = this.abs();
+	if(x.t == 1 && x[0] <= lowprimes[lowprimes.length-1]) {
+	    for(i = 0; i < lowprimes.length; ++i)
+		if(x[0] == lowprimes[i]) return true;
+	    return false;
+	}
+	if(x.isEven()) return false;
+	i = 1;
+	while(i < lowprimes.length) {
+	    var m = lowprimes[i], j = i+1;
+	    while(j < lowprimes.length && m < lplim) m *= lowprimes[j++];
+	    m = x.modInt(m);
+	    while(i < j) if(m%lowprimes[i++] == 0) return false;
+	}
+	return x.millerRabin(t);
+    }
+
+    // (protected) true if probably prime (HAC 4.24, Miller-Rabin)
+    function bnpMillerRabin(t) {
+	var n1 = this.subtract(BigInteger.ONE);
+	var k = n1.getLowestSetBit();
+	if(k <= 0) return false;
+	var r = n1.shiftRight(k);
+	t = (t+1)>>1;
+	if(t > lowprimes.length) t = lowprimes.length;
+	var a = nbi();
+	for(var i = 0; i < t; ++i) {
+	    a.fromInt(lowprimes[i]);
+	    var y = a.modPow(r,this);
+	    if(y.compareTo(BigInteger.ONE) != 0 && y.compareTo(n1) != 0) {
+		var j = 1;
+		while(j++ < k && y.compareTo(n1) != 0) {
+		    y = y.modPowInt(2,this);
+		    if(y.compareTo(BigInteger.ONE) == 0) return false;
+		}
+		if(y.compareTo(n1) != 0) return false;
+	    }
+	}
+	return true;
+    }
+    
+    
+
+    // protected
+    BigInteger.prototype.chunkSize = bnpChunkSize;
+    BigInteger.prototype.toRadix = bnpToRadix;
+    BigInteger.prototype.fromRadix = bnpFromRadix;
+    BigInteger.prototype.fromNumber = bnpFromNumber;
+    BigInteger.prototype.bitwiseTo = bnpBitwiseTo;
+    BigInteger.prototype.changeBit = bnpChangeBit;
+    BigInteger.prototype.addTo = bnpAddTo;
+    BigInteger.prototype.dMultiply = bnpDMultiply;
+    BigInteger.prototype.dAddOffset = bnpDAddOffset;
+    BigInteger.prototype.multiplyLowerTo = bnpMultiplyLowerTo;
+    BigInteger.prototype.multiplyUpperTo = bnpMultiplyUpperTo;
+    BigInteger.prototype.modInt = bnpModInt;
+    BigInteger.prototype.millerRabin = bnpMillerRabin;
+
+    // public
+    BigInteger.prototype.clone = bnClone;
+    BigInteger.prototype.intValue = bnIntValue;
+    BigInteger.prototype.byteValue = bnByteValue;
+    BigInteger.prototype.shortValue = bnShortValue;
+    BigInteger.prototype.signum = bnSigNum;
+    BigInteger.prototype.toByteArray = bnToByteArray;
+    BigInteger.prototype.equals = bnEquals;
+    BigInteger.prototype.min = bnMin;
+    BigInteger.prototype.max = bnMax;
+    BigInteger.prototype.and = bnAnd;
+    BigInteger.prototype.or = bnOr;
+    BigInteger.prototype.xor = bnXor;
+    BigInteger.prototype.andNot = bnAndNot;
+    BigInteger.prototype.not = bnNot;
+    BigInteger.prototype.shiftLeft = bnShiftLeft;
+    BigInteger.prototype.shiftRight = bnShiftRight;
+    BigInteger.prototype.getLowestSetBit = bnGetLowestSetBit;
+    BigInteger.prototype.bitCount = bnBitCount;
+    BigInteger.prototype.testBit = bnTestBit;
+    BigInteger.prototype.setBit = bnSetBit;
+    BigInteger.prototype.clearBit = bnClearBit;
+    BigInteger.prototype.flipBit = bnFlipBit;
+    BigInteger.prototype.add = bnAdd;
+    BigInteger.prototype.subtract = bnSubtract;
+    BigInteger.prototype.multiply = bnMultiply;
+    BigInteger.prototype.divide = bnDivide;
+    BigInteger.prototype.remainder = bnRemainder;
+    BigInteger.prototype.divideAndRemainder = bnDivideAndRemainder;
+    BigInteger.prototype.modPow = bnModPow;
+    BigInteger.prototype.modInverse = bnModInverse;
+    BigInteger.prototype.pow = bnPow;
+    BigInteger.prototype.gcd = bnGCD;
+    BigInteger.prototype.isProbablePrime = bnIsProbablePrime;
+
+    // BigInteger interfaces not implemented in jsbn:
+
+    // BigInteger(int signum, byte[] magnitude)
+    // double doubleValue()
+    // float floatValue()
+    // int hashCode()
+    // long longValue()
+    // static BigInteger valueOf(long val)
+
+
+
+    //////////////////////////////////////////////////////////////////////
+    //////////////////////////////////////////////////////////////////////
+    //////////////////////////////////////////////////////////////////////
+    //////////////////////////////////////////////////////////////////////
+    //////////////////////////////////////////////////////////////////////
+    // END OF copy-and-paste of jsbn.
+
+
+
+    BigInteger.NEGATIVE_ONE = BigInteger.ONE.negate();
+
+
+    // Other methods we need to add for compatibilty with js-numbers numeric tower.
+
+    // add is implemented above.
+    // subtract is implemented above.
+    // multiply is implemented above.
+    // equals is implemented above.
+    // abs is implemented above.
+    // negate is defined above.
+
+    // makeBignum: string -> BigInteger
+    var makeBignum = function(s) {
+	if (typeof(s) === 'number') { s = s + ''; }
+	s = expandExponent(s);
+	return new BigInteger(s, 10);
+    };
+
+    var zerostring = function(n) {
+	var buf = [];
+	for (var i = 0; i < n; i++) {
+	    buf.push('0');
+	}
+	return buf.join('');
+    };
+
+
+    BigInteger.prototype.level = 0;
+    BigInteger.prototype.liftTo = function(target) {
+	if (target.level === 1) {
+	    return new Rational(this, 1);
+	}
+	if (target.level === 2) {
+	    var fixrep = this.toFixnum();
+	    if (fixrep === Number.POSITIVE_INFINITY)
+		return TOO_POSITIVE_TO_REPRESENT;
+	    if (fixrep === Number.NEGATIVE_INFINITY)
+		return TOO_NEGATIVE_TO_REPRESENT;
+	    return new FloatPoint(fixrep);
+	}
+	if (target.level === 3) {
+	    return new Complex(this, 0);
+	}
+	return throwRuntimeError("invalid level for BigInteger lift", this, target);
+    };
+
+    BigInteger.prototype.isFinite = function() {
+	return true;
+    };
+
+    BigInteger.prototype.isInteger = function() {
+	return true;
+    };
+
+    BigInteger.prototype.isRational = function() {
+	return true;
+    };
+
+    BigInteger.prototype.isReal = function() {
+	return true;
+    };
+
+    BigInteger.prototype.isExact = function() {
+	return true;
+    };
+
+    BigInteger.prototype.isInexact = function() {
+	return false;
+    };
+
+    BigInteger.prototype.toExact = function() {
+	return this;
+    };
+
+    BigInteger.prototype.toInexact = function() {
+	return FloatPoint.makeInstance(this.toFixnum());
+    };
+
+    BigInteger.prototype.toFixnum = function() {
+	var result = 0, str = this.toString(), i;
+	if (str[0] === '-') {
+	    for (i=1; i < str.length; i++) {
+		result = result * 10 + Number(str[i]);
+	    }
+	    return -result;
+	} else {
+	    for (i=0; i < str.length; i++) {
+		result = result * 10 + Number(str[i]);
+	    }
+	    return result;
+	}
+    };
+
+
+    BigInteger.prototype.greaterThan = function(other) {
+	return this.compareTo(other) > 0;
+    };
+
+    BigInteger.prototype.greaterThanOrEqual = function(other) {
+	return this.compareTo(other) >= 0;
+    };
+
+    BigInteger.prototype.lessThan = function(other) {
+	return this.compareTo(other) < 0;
+    };
+
+    BigInteger.prototype.lessThanOrEqual = function(other) {
+	return this.compareTo(other) <= 0;
+    };
+
+    // divide: scheme-number -> scheme-number
+    // WARNING NOTE: we override the old version of divide.
+    BigInteger.prototype.divide = function(other) {
+	var quotientAndRemainder = bnDivideAndRemainder.call(this, other);
+	if (quotientAndRemainder[1].compareTo(BigInteger.ZERO) === 0) {
+	    return quotientAndRemainder[0];
+	} else {
+	    var result = add(quotientAndRemainder[0],
+			     Rational.makeInstance(quotientAndRemainder[1], other));
+	    return result;
+	}
+    };
+
+    BigInteger.prototype.numerator = function() {
+	return this;
+    };
+
+    BigInteger.prototype.denominator = function() {
+	return 1;
+    };
+
+
+    (function() {
+	// Classic implementation of Newton-Ralphson square-root search,
+	// adapted for integer-sqrt.
+	// http://en.wikipedia.org/wiki/Newton's_method#Square_root_of_a_number
+	    var searchIter = function(n, guess) {
+		while(!(lessThanOrEqual(sqr(guess),n) &&
+			lessThan(n,sqr(add(guess, 1))))) {
+		    guess = floor(divide(add(guess,
+					     floor(divide(n, guess))),
+					 2));
+		}
+		return guess;
+	    };
+
+	    // integerSqrt: -> scheme-number
+	    BigInteger.prototype.integerSqrt = function() {
+		var n;
+		if(sign(this) >= 0) {
+		    return searchIter(this, this);
+		} else {
+		    n = this.negate();
+		    return Complex.makeInstance(0, searchIter(n, n));
+		}
+	    };
+    })();
+
+
+    (function() {	
+	// Get an approximation using integerSqrt, and then start another
+	// Newton-Ralphson search if necessary.
+	BigInteger.prototype.sqrt = function() {
+	    var approx = this.integerSqrt(), fix;
+	    if (eqv(sqr(approx), this)) {
+		return approx;
+	    }
+	    fix = toFixnum(this);
+	    if (isFinite(fix)) {
+		if (fix >= 0) {
+		    return FloatPoint.makeInstance(Math.sqrt(fix));
+		} else {
+		    return Complex.makeInstance(
+			0,
+			FloatPoint.makeInstance(Math.sqrt(-fix)));
+		}
+	    } else {
+		return approx;
+	    }
+	};
+    })();
+
+
+
+
+    
+    // sqrt: -> scheme-number
+    // http://en.wikipedia.org/wiki/Newton's_method#Square_root_of_a_number
+    // Produce the square root.
+
+    // floor: -> scheme-number
+    // Produce the floor.
+    BigInteger.prototype.floor = function() {
+        return this;
+    }
+
+    // ceiling: -> scheme-number
+    // Produce the ceiling.
+    BigInteger.prototype.ceiling = function() {
+        return this;
+    }
+
+    // conjugate: -> scheme-number
+    // Produce the conjugate.
+
+    // magnitude: -> scheme-number
+    // Produce the magnitude.
+
+    // log: -> scheme-number
+    // Produce the log.
+
+    // angle: -> scheme-number
+    // Produce the angle.
+
+    // atan: -> scheme-number
+    // Produce the arc tangent.
+
+    // cos: -> scheme-number
+    // Produce the cosine.
+
+    // sin: -> scheme-number
+    // Produce the sine.
+
+
+    // expt: scheme-number -> scheme-number
+    // Produce the power to the input.
+    BigInteger.prototype.expt = function(n) {
+	return bnPow.call(this, n);
+    };
+
+
+
+    // exp: -> scheme-number
+    // Produce e raised to the given power.
+
+    // acos: -> scheme-number
+    // Produce the arc cosine.
+
+    // asin: -> scheme-number
+    // Produce the arc sine.
+
+    BigInteger.prototype.imaginaryPart = function() {
+	    return 0;
+    }
+    BigInteger.prototype.realPart = function() {
+	    return this;
+    }
+
+    // round: -> scheme-number
+    // Round to the nearest integer.
+
+
+
+
+
+    //////////////////////////////////////////////////////////////////////
+    // toRepeatingDecimal: jsnum jsnum {limit: number}? -> [string, string, string]
+    //
+    // Given the numerator and denominator parts of a rational,
+    // produces the repeating-decimal representation, where the first
+    // part are the digits before the decimal, the second are the
+    // non-repeating digits after the decimal, and the third are the
+    // remaining repeating decimals.
+    // 
+    // An optional limit on the decimal expansion can be provided, in which
+    // case the search cuts off if we go past the limit.
+    // If this happens, the third argument returned becomes '...' to indicate
+    // that the search was prematurely cut off.
+    var toRepeatingDecimal = (function() {
+	var getResidue = function(r, d, limit) {
+	    var digits = [];
+	    var seenRemainders = {};
+	    seenRemainders[r] = true;
+	    while(true) {	
+		if (limit-- <= 0) {
+		    return [digits.join(''), '...']
+		}
+
+		var nextDigit = quotient(
+		    multiply(r, 10), d);
+		var nextRemainder = remainder(
+		    multiply(r, 10),
+		    d);
+		digits.push(nextDigit.toString());
+		if (seenRemainders[nextRemainder]) {
+		    r = nextRemainder;
+		    break;
+		} else {
+		    seenRemainders[nextRemainder] = true;
+		    r = nextRemainder;
+		}
+	    }
+	    
+	    var firstRepeatingRemainder = r;
+	    var repeatingDigits = [];
+	    while (true) {
+		var nextDigit = quotient(multiply(r, 10), d);
+		var nextRemainder = remainder(
+		    multiply(r, 10),
+		    d);
+		repeatingDigits.push(nextDigit.toString());
+		if (equals(nextRemainder, firstRepeatingRemainder)) {
+		    break;
+		} else {
+		    r = nextRemainder;
+		}
+	    };
+
+	    var digitString = digits.join('');
+	    var repeatingDigitString = repeatingDigits.join('');
+
+	    while (digitString.length >= repeatingDigitString.length &&
+		   (digitString.substring(
+		       digitString.length - repeatingDigitString.length)
+		    === repeatingDigitString)) {
+		digitString = digitString.substring(
+		    0, digitString.length - repeatingDigitString.length);
+	    }
+
+	    return [digitString, repeatingDigitString];
+
+	};
+
+	return function(n, d, options) {
+	    // default limit on decimal expansion; can be overridden
+	    var limit = 512;
+	    if (options && typeof(options.limit) !== 'undefined') {
+		limit = options.limit;
+	    }
+	    if (! isInteger(n)) {
+		throwRuntimeError('toRepeatingDecimal: n ' + n.toString() +
+				  " is not an integer.");
+	    }
+	    if (! isInteger(d)) {
+		throwRuntimeError('toRepeatingDecimal: d ' + d.toString() +
+				  " is not an integer.");
+	    }
+	    if (equals(d, 0)) {
+		throwRuntimeError('toRepeatingDecimal: d equals 0');
+	    }
+	    if (lessThan(d, 0)) {
+		throwRuntimeError('toRepeatingDecimal: d < 0');
+	    }
+ 	    var sign = (lessThan(n, 0) ? "-" : "");
+ 	    n = abs(n);
+ 	    var beforeDecimalPoint = sign + quotient(n, d);
+ 	    var afterDecimals = getResidue(remainder(n, d), d, limit);
+ 	    return [beforeDecimalPoint].concat(afterDecimals);
+	};
+    })();
+    //////////////////////////////////////////////////////////////////////
+
+
+
+
+    // External interface of js-numbers:
+
+    Numbers['fromFixnum'] = fromFixnum;
+    Numbers['fromString'] = fromString;
+    Numbers['makeBignum'] = makeBignum;
+    Numbers['makeRational'] = Rational.makeInstance;
+    Numbers['makeFloat'] = FloatPoint.makeInstance;
+    Numbers['makeComplex'] = Complex.makeInstance;
+    Numbers['makeComplexPolar'] = makeComplexPolar;
+
+    Numbers['pi'] = FloatPoint.pi;
+    Numbers['e'] = FloatPoint.e;
+    Numbers['nan'] = FloatPoint.nan;
+    Numbers['negative_inf'] = FloatPoint.neginf;
+    Numbers['inf'] = FloatPoint.inf;
+    Numbers['negative_one'] = -1;   // Rational.NEGATIVE_ONE;
+    Numbers['zero'] = 0;            // Rational.ZERO;
+    Numbers['one'] = 1;             // Rational.ONE;
+    Numbers['i'] = plusI;
+    Numbers['negative_i'] = minusI;
+    Numbers['negative_zero'] = NEGATIVE_ZERO;
+
+    Numbers['onThrowRuntimeError'] = onThrowRuntimeError;
+    Numbers['isSchemeNumber'] = isSchemeNumber;
+    Numbers['isRational'] = isRational;
+    Numbers['isReal'] = isReal;
+    Numbers['isExact'] = isExact;
+    Numbers['isInexact'] = isInexact;
+    Numbers['isInteger'] = isInteger;
+
+    Numbers['toFixnum'] = toFixnum;
+    Numbers['toExact'] = toExact;
+    Numbers['toInexact'] = toInexact;
+    Numbers['add'] = add;
+    Numbers['subtract'] = subtract;
+    Numbers['multiply'] = multiply;
+    Numbers['divide'] = divide;
+    Numbers['equals'] = equals;
+    Numbers['eqv'] = eqv;
+    Numbers['approxEquals'] = approxEquals;
+    Numbers['greaterThanOrEqual'] = greaterThanOrEqual;
+    Numbers['lessThanOrEqual'] = lessThanOrEqual;
+    Numbers['greaterThan'] = greaterThan;
+    Numbers['lessThan'] = lessThan;
+    Numbers['expt'] = expt;
+    Numbers['exp'] = exp;
+    Numbers['modulo'] = modulo;
+    Numbers['numerator'] = numerator;
+    Numbers['denominator'] = denominator;
+    Numbers['integerSqrt'] = integerSqrt;
+    Numbers['sqrt'] = sqrt;
+    Numbers['abs'] = abs;
+    Numbers['quotient'] = quotient;
+    Numbers['remainder'] = remainder;
+    Numbers['floor'] = floor;
+    Numbers['ceiling'] = ceiling;
+    Numbers['conjugate'] = conjugate;
+    Numbers['magnitude'] = magnitude;
+    Numbers['log'] = log;
+    Numbers['angle'] = angle;
+    Numbers['tan'] = tan;
+    Numbers['atan'] = atan;
+    Numbers['cos'] = cos;
+    Numbers['sin'] = sin;
+    Numbers['tan'] = tan;
+    Numbers['acos'] = acos;
+    Numbers['asin'] = asin;
+    Numbers['cosh'] = cosh;
+    Numbers['sinh'] = sinh;
+    Numbers['imaginaryPart'] = imaginaryPart;
+    Numbers['realPart'] = realPart;
+    Numbers['round'] = round;
+    Numbers['sqr'] = sqr;
+    Numbers['gcd'] = gcd;
+    Numbers['lcm'] = lcm;
+
+    Numbers['toRepeatingDecimal'] = toRepeatingDecimal;
+
+
+
+    // The following exposes the class representations for easier
+    // integration with other projects.
+    Numbers['BigInteger'] = BigInteger;
+    Numbers['Rational'] = Rational;
+    Numbers['FloatPoint'] = FloatPoint;
+    Numbers['Complex'] = Complex;   
+
+    Numbers['MIN_FIXNUM'] = MIN_FIXNUM;
+    Numbers['MAX_FIXNUM'] = MAX_FIXNUM;
+
+})();
+/**
+ *
+ *  Originally grabbed from:
+ *  Base64 encode / decode
+ *  http://www.webtoolkit.info/
+ *
+ *  dyoo: modified to work with arrays of bytes rather than assume
+ *  the bytes are strings.
+ * 
+ *  Provides a Base64 object with two methods:
+ *  Base64.encode: [arrayof int] -> string
+ *  Base64.decode: string -> [arrayof int]
+ **/
+var Base64 = (function() {
+    'use strict';
+
+    // private property
+    var _keyStr = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=";
+
+    var Base64 = {        
+        // public method for encoding
+        encode : function (inputBytes) {
+	    var output = [];
+	    var chr1, chr2, chr3, enc1, enc2, enc3, enc4;
+	    var i = 0;
+	    while (i < inputBytes.length) {
+                
+	        chr1 = inputBytes[i++];
+	        chr2 = inputBytes[i++];
+	        chr3 = inputBytes[i++];
+                
+	        enc1 = chr1 >> 2;
+	        enc2 = ((chr1 & 3) << 4) | (chr2 >> 4);
+	        enc3 = ((chr2 & 15) << 2) | (chr3 >> 6);
+	        enc4 = chr3 & 63;
+                
+	        if (isNaN(chr2)) {
+		    enc3 = enc4 = 64;
+	        } else if (isNaN(chr3)) {
+		    enc4 = 64;
+	        }
+	        output.push(_keyStr.charAt(enc1));
+                output.push(_keyStr.charAt(enc2));
+		output.push(_keyStr.charAt(enc3));
+                output.push(_keyStr.charAt(enc4));
+	    }
+	    return output.join('');
+        },
+        
+        // public method for decoding
+        decode : function (inputString) {
+	    var outputBytes = [];
+	    var chr1, chr2, chr3;
+	    var enc1, enc2, enc3, enc4;
+	    var i = 0;
+            
+	    inputString = inputString.replace(/[^A-Za-z0-9\+\/\=]/g, "");
+            
+	    while (i < inputString.length) {
+	        enc1 = _keyStr.indexOf(inputString.charAt(i++));
+	        enc2 = _keyStr.indexOf(inputString.charAt(i++));
+	        enc3 = _keyStr.indexOf(inputString.charAt(i++));
+	        enc4 = _keyStr.indexOf(inputString.charAt(i++));
+                
+	        chr1 = (enc1 << 2) | (enc2 >> 4);
+	        chr2 = ((enc2 & 15) << 4) | (enc3 >> 2);
+	        chr3 = ((enc3 & 3) << 6) | enc4;
+                
+	        outputBytes.push(chr1);
+                
+	        if (enc3 !== 64) {
+		    outputBytes.push(chr2);
+	        }
+	        if (enc4 !== 64) {
+		    outputBytes.push(chr3);
+	        }
+	    }
+	    return outputBytes;
+        }
+    };
+    return Base64;
+}());/*jslint vars: true, plusplus: true, maxerr: 50, indent: 4 */
+
+// Basic library functions.  This will include a few simple functions,
+// but be augmented with several namespaces for the other libraries in
+// the base library.
+if (!(this.plt)) { this.plt = {}; }
+(function (plt) {
+    'use strict';
+    var baselib = {};
+    plt.baselib = baselib;
+
+
+
+    // Simple object inheritance.
+    var heir = function (parentPrototype) {
+        var F = function () {};
+        F.prototype = parentPrototype;
+        return new F();
+    };
+
+
+
+    var hasOwnProperty = {}.hasOwnProperty;
+
+    // clone: object -> object
+    // Copies an object.  The new object should respond like the old
+    // object, including to things like instanceof.
+    var clone = function (obj) {
+        var property;
+        var C = function () {};
+        C.prototype = obj;
+        var c = new C();
+        for (property in obj) {
+            if (hasOwnProperty.call(obj, property)) {
+                c[property] = obj[property];
+            }
+        }
+        return c;
+    };
+
+
+    // Consumes a class and creates a predicate that recognizes subclasses.
+    var makeClassPredicate = function (aClass) {
+        return function (x) { return x instanceof aClass; };
+    };
+
+
+
+    // Helper to deal with the argument-passing of primitives.  Call f
+    // with arguments bound from MACHINE.e, assuming
+    // MACHINE.a has been initialized with the number of
+    // arguments on the stack.  vs provides optional values for the
+    // arguments that go beyond those of the mandatoryArgCount.
+    var withArguments = function (MACHINE, mandatoryArgCount, vs, f) {
+        var args = [], i;
+        for (i = 0; i < MACHINE.a; i++) {
+            if (i < mandatoryArgCount) {
+                args.push(MACHINE.e[MACHINE.e.length - 1 - i]);
+            } else {
+                if (i < MACHINE.a) {
+                    args.push(MACHINE.e[MACHINE.e.length - 1 - i]);
+                } else {
+                    args.push(vs[mandatoryArgCount - i]);
+                }
+            }
+        }
+        return f.apply(null, args);
+    };
+
+
+
+    baselib.heir = heir;
+    baselib.clone = clone;
+    baselib.makeClassPredicate = makeClassPredicate;
+    baselib.withArguments = withArguments;
+
+
+}(this.plt));
+/*jslint unparam: true, vars: true, white: true, newcap: true, nomen: true, plusplus: true, maxerr: 50, indent: 4 */
+
+/*global window*/
+
+// Dictionaries.  We need this due to JS weirdness, since object
+// literals have issues with regards to magic properties like
+// __proto__.  This is taken from Effective JavaScript, Item 45.
+(function (baselib) {
+    'use strict';
+
+    var hasOwnProperty = {}.hasOwnProperty;
+    
+    baselib.Dict = function(elements) {
+        this.elements = elements || {};
+        this.hasSpecialProto = false;
+        this.specialProto = undefined;
+    };
+
+    baselib.Dict.prototype.has = function(key) {
+        if (key === '__proto__') {
+            return this.hasSpecialProto;
+        }
+        return hasOwnProperty.call(this.elements, key);
+    };
+
+    baselib.Dict.prototype.get = function(key) {
+        if (key === '__proto__') { 
+            return this.specialProto;
+        } else if (hasOwnProperty.call(this.elements, key)) {
+            return this.elements[key];
+        } else {
+            return undefined;
+        }
+    };
+
+    baselib.Dict.prototype.set = function(key, val) {
+        if (key === '__proto__') {
+            this.hasSpecialProto = true;
+            this.specialProto = val;
+        } else {
+            this.elements[key] = val;
+        }
+    };
+
+    baselib.Dict.prototype.remove = function(key) {
+        if (key === '__proto__') {
+            this.hasSpecialProto = false;
+            this.specialProto = undefined;
+        } else {
+            delete this.elements[key];
+        }
+    };
+}(window.plt.baselib));/*jslint unparam: true, sub: true, vars: true, white: true, plusplus: true, maxerr: 50, indent: 4 */
+
+// Frame structures.
+(function(baselib) {
+    'use strict';
+    var exports = {};
+    baselib.frames = exports;
+
+
+
+    // A generic frame just holds marks.
+    var Frame = function() {
+	// The set of continuation marks.
+	// this.marks = [];
+	// When we're in the middle of computing with-cont-mark, we
+	// stash the key in here temporarily.
+	// this.pendingContinuationMarkKey = undefined;
+	// this.pendingApplyValuesProc = undefined;
+	// this.pendingBegin0Count = undefined;
+	// this.pendingBegin0Values = undefined;
+    };
+    Frame.prototype.getMarks = function() {
+        if (this.marks === void(0)) { this.marks = []; }
+        return this.marks;
+    };
+
+
+    // Frames must support marks and the temporary variables necessary to
+    // support with-continuation-mark and with-values.
+
+    // Specialized frames support more features:
+
+    // A CallFrame represents a call stack frame, and includes the return address
+    // as well as the function being called.
+    var CallFrame = function(label, proc) {
+	this.label = label;
+	this.p = proc;
+    };
+    CallFrame.prototype = baselib.heir(Frame.prototype);
+
+
+
+    // A prompt frame includes a return address, as well as a prompt
+    // tag for supporting delimited continuations.  To support abort,
+    // we also keep the size of the environment, and the handler
+    // to call if an abort happens.
+    //
+    // If handler is null, handler will be a default closure that
+    // accepts any number of values and returns.
+    var PromptFrame = function(label, tag, envLength, handler) {
+	this.label = label;
+	this.tag = tag; // ContinuationPromptTag
+        this.envLength = envLength;
+        this.handler = handler;
+    };
+    PromptFrame.prototype = baselib.heir(Frame.prototype);
+
+
+
+
+
+
+
+    //////////////////////////////////////////////////////////////////////
+    exports.Frame = Frame;
+    exports.CallFrame = CallFrame;
+    exports.PromptFrame = PromptFrame;
+
+
+
+}(this.plt.baselib));
+/*jslint unparam: true, sub: true, vars: true, white: true, plusplus: true, maxerr: 50, indent: 4 */
+
+// Frame structures.
+(function(baselib) {
+    var exports = {};
+    baselib.loadscript = exports;
+
+    //////////////////////////////////////////////////////////////////////
+    /* Lesser General Public License for more details.
+     *
+     * You should have received a copy of the GNU Lesser General Public
+     * License along with this library; if not, write to the Free Software
+     * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+     *
+     * Contact information:
+     *   Dao Gottwald  <dao at design-noir.de>
+     *
+     * @version  1.6
+     * @url      http://design-noir.de/webdev/JS/loadScript/
+     */
+
+    var loadScript = function(url, callback, onError) {
+        var f = arguments.callee;
+        if (!("queue" in f))
+            f.queue = {};
+        var queue = f.queue;
+        if (url in queue) { // script is already in the document
+            if (callback) {
+                if (queue[url]) // still loading
+                    queue[url].push(callback);
+                else // loaded
+                    callback();
+            }
+            return;
+        }
+        queue[url] = callback ? [callback] : [];
+        var script = document.createElement("script");
+        script.type = "text/javascript";
+        script.onload = script.onreadystatechange = function() {
+            if (script.readyState && script.readyState != "loaded" && script.readyState != "complete")
+                return;
+            script.onreadystatechange = script.onload = null;
+            document.getElementsByTagName("head")[0].removeChild(script);
+            var work = queue[url];
+            delete(queue[url]);
+            while (work.length)
+                work.shift()();
+        };
+        script.onerror = function() {
+            script.onreadystatechange = script.onload = null;
+            document.getElementsByTagName("head")[0].removeChild(script);
+            onError();
+        };
+        script.src = url;
+        document.getElementsByTagName("head")[0].appendChild(script);
+    };
+
+    //////////////////////////////////////////////////////////////////////
+    exports.loadScript = loadScript;
+}(this.plt.baselib));
+/*jslint devel: false, browser: true, vars: true, plusplus: true, maxerr: 500, indent: 4 */
+(function (baselib) {
+    "use strict";
+
+    // Union/find for circular equality testing.
+
+    var UnionFind = function () {
+        // this.parenMap holds the arrows from an arbitrary pointer
+        // to its parent.
+        this.parentMap = baselib.hashes.makeLowLevelEqHash();
+    };
+
+    // find: ptr -> UnionFindNode
+    // Returns the representative for this ptr.
+    UnionFind.prototype.find = function (ptr) {
+        var parent = (this.parentMap.containsKey(ptr) ? 
+                      this.parentMap.get(ptr) : ptr);
+        if (parent === ptr) {
+            return parent;
+        } else {
+            var rep = this.find(parent);
+            // Path compression:
+            this.parentMap.put(ptr, rep);
+            return rep;
+        }
+    };
+
+    // merge: ptr ptr -> void
+    // Merge the representative nodes for ptr1 and ptr2.
+    UnionFind.prototype.merge = function (ptr1, ptr2) {
+        this.parentMap.put(this.find(ptr1), this.find(ptr2));
+    };
+
+
+
+    baselib.UnionFind = UnionFind;
+
+}(this.plt.baselib));/*jslint vars: true, white: true, maxerr: 50, indent: 4 */
+
+
+// Equality function
+/*global jsnums*/
+(function (baselib, jsnums) {
+    'use strict';
+    var exports = {};
+    baselib.equality = exports;
+
+
+
+    var eqv = function (x, y) {
+        if (x === y) { return true; }
+
+        if (baselib.numbers.isNumber(x) && baselib.numbers.isNumber(y)) {
+            return jsnums.eqv(x, y);
+        } else if (baselib.chars.isChar(x) && baselib.chars.isChar(y)) {
+            return x.val === y.val;
+        } else {
+            return false;
+        }
+    };
+
+
+
+
+    // equals: X Y -> boolean
+    // Returns true if the objects are equivalent; otherwise, returns false.
+    var equals = function (x, y, aUnionFind) {
+        if (x === y) { return true; }
+
+        if (baselib.numbers.isNumber(x) && baselib.numbers.isNumber(y)) {
+            return baselib.numbers.eqv(x, y);
+        }
+
+        if (baselib.strings.isString(x) && baselib.strings.isString(y)) {
+            return x.toString() === y.toString();
+        }
+
+        if (x === void(0) || x === null) {
+            return (y === void(0) || y === null);
+        }
+
+        if (typeof (x) === 'object' && typeof (y) === 'object' &&
+            x.equals && y.equals) {
+            if (aUnionFind === void(0)) {
+                aUnionFind = new baselib.UnionFind();
+            }
+
+            if (aUnionFind.find(x) === aUnionFind.find(y)) {
+                return true;
+            }
+            else {
+                aUnionFind.merge(x, y); 
+                return x.equals(y, aUnionFind);
+            }
+        }
+        return false;
+    };
+
+    exports.eqv = eqv;
+    exports.equals = equals;
+
+}(this.plt.baselib, jsnums));/*jslint browser: true, undef: false, unparam: true, sub: true, vars: true, white: true, plusplus: true, maxerr: 50, indent: 4 */
+
+// Formatting library.
+// Produces string and DOM representations of values.
+//
+/*global $*/
+(function(baselib, $) {
+    'use strict';
+    var exports = {};
+    baselib.format = exports;
+
+
+    var replaceUnprintableStringChars = function(s) {
+        var ret = [], i;
+        for (i = 0; i < s.length; i++) {
+            var val = s.charCodeAt(i);
+            switch(val) {
+            case 7: ret.push('\\a'); break;
+            case 8: ret.push('\\b'); break;
+            case 9: ret.push('\\t'); break;
+            case 10: ret.push('\\n'); break;
+            case 11: ret.push('\\v'); break;
+            case 12: ret.push('\\f'); break;
+            case 13: ret.push('\\r'); break;
+            case 34: ret.push('\\"'); break;
+            case 92: ret.push('\\\\'); break;
+            default: if (val >= 32 && val <= 126) {
+                ret.push( s.charAt(i) );
+            }
+                else {
+                    var numStr = val.toString(16).toUpperCase();
+                    while (numStr.length < 4) {
+                        numStr = '0' + numStr;
+                    }
+                    ret.push('\\u' + numStr);
+                }
+                break;
+            }
+        }
+        return ret.join('');
+    };
+
+    var escapeString = function(s) {
+        return '"' + replaceUnprintableStringChars(s) + '"';
+    };
+
+
+    // toWrittenString: Any Hashtable -> String
+    var toWrittenString = function(x, cache) {
+        if (! cache) { 
+            cache = baselib.hashes.makeLowLevelEqHash();
+        }
+        if (x === null) {
+            return "null";
+        }
+        if (x === true) { return "true"; }
+        if (x === false) { return "false"; }
+        if (typeof(x) === 'object') {
+            if (cache.containsKey(x)) {
+                return "...";
+            }
+        }
+        if (x === void(0)) {
+            return "#<undefined>";
+        }
+        if (typeof(x) === 'string') {
+            return escapeString(x.toString());
+        }
+
+        if (baselib.functions.isProcedure(x)) {
+            return '#<function:' + x.displayName + '>';
+        }
+
+        if (typeof(x) !== 'object' && typeof(x) !== 'function') {
+            return x.toString();
+        }
+
+        var returnVal;
+        if (x.toWrittenString) {
+            returnVal = x.toWrittenString(cache);
+        } else if (x.toDisplayedString) {
+            returnVal = x.toDisplayedString(cache);
+        } else {
+            returnVal = x.toString();
+        }
+        return returnVal;
+    };
+
+
+
+    // toDisplayedString: Any Hashtable -> String
+    var toDisplayedString = function(x, cache) {
+        if (! cache) {
+            cache = baselib.hashes.makeLowLevelEqHash();
+        }
+        if (x === null) {
+            return "null";
+        }
+        if (x === true) { return "true"; }
+        if (x === false) { return "false"; }
+        if (typeof(x) === 'object') {
+            if (cache.containsKey(x)) {
+                return "...";
+            }
+        }
+        if (x === void(0) || x === null) {
+            return "#<undefined>";
+        }
+        if (typeof(x) === 'string') {
+            return x;
+        }
+
+        if (baselib.functions.isProcedure(x)) {
+            return '#<function:' + x.displayName + '>';
+        }
+
+        if (typeof(x) !== 'object' && typeof(x) !== 'function') {
+            return x.toString();
+        }
+
+        var returnVal;
+        if (x.toDisplayedString) {
+            returnVal = x.toDisplayedString(cache);
+        } else if (x.toWrittenString) {
+            returnVal = x.toWrittenString(cache);
+        } else {
+            returnVal = x.toString();
+        }
+        return returnVal;
+    };
+
+
+
+    var formatRegexp1 = new RegExp('~[sSaA]', 'g');
+    var formatRegexp2 = new RegExp("~[sSaAnevE%~]", "g");
+    
+    // format: string [X ...] string -> string
+    // String formatting.  If an exception occurs, throws
+    // a plain Error whose message describes the formatting error.
+    var format = function(formatStr, args, functionName) {
+        var throwFormatError = function() {
+            functionName = functionName || 'format';
+            var matches = formatStr.match(formatRegexp1);
+            var expectedNumberOfArgs = (matches === null ? 0 : matches.length);
+            var errorStrBuffer = [functionName + ': format string requires ' + expectedNumberOfArgs
+                                  + ' arguments, given ' + args.length + '; arguments were:',
+                                  toWrittenString(formatStr)];
+            var i;
+            for (i = 0; i < args.length; i++) {
+                errorStrBuffer.push( toWrittenString(args[i]) );
+            }
+
+            throw new Error(errorStrBuffer.join(' '));
+        };
+
+
+        var buffer = args.slice(0);
+        var onTemplate = function(s) {
+            if (s === "~~") {
+                return "~";
+            } else if (s === '~n' || s === '~%') {
+                return "\n";
+            } else if (s === '~s' || s === "~S") {
+                if (buffer.length === 0) {
+                    throwFormatError();
+                }
+                return toWrittenString(buffer.shift());
+            } else if (s === '~e' || s === "~E") {
+                // FIXME: we don't yet have support for the error-print
+                // handler, and currently treat ~e just like ~s.
+                if (buffer.length === 0) {
+                    throwFormatError();
+                }
+                return toWrittenString(buffer.shift()); 
+            }
+            else if (s === '~v') {
+                if (buffer.length === 0) {
+                    throwFormatError();
+                }
+                // fprintf must do something more interesting here by
+                // printing the dom representation directly...
+                return toWrittenString(buffer.shift());
+            } else if (s === '~a' || s === "~A") {
+                if (buffer.length === 0) {
+                    throwFormatError();
+                }
+                return toDisplayedString(buffer.shift());
+            } else {
+                throw new Error(functionName + 
+                                ': string.replace matched invalid regexp');
+            }
+        };
+        var result = formatStr.replace(formatRegexp2, onTemplate);
+        if (buffer.length > 0) {
+            throwFormatError();
+        }
+        return result;
+    };
+    
+
+
+    var hasOwnProperty = {}.hasOwnProperty;
+
+    var ToDomNodeParameters = function(params) {
+        if (! params) { params = {}; }
+        var k;
+        for (k in params) {
+            if (hasOwnProperty.call(params, k)) {
+                this[k] = params[k];
+            }
+        }
+        if (this.cache === void(0)) {
+            this.cache = baselib.hashes.makeLowLevelEqHash();
+        }
+        if (this.cycles === void(0)) {
+            this.cycles = baselib.hashes.makeLowLevelEqHash();
+        }
+        if (this.depth === void(0)) {
+            this.depth = 0;
+        }
+        if (this.objectCounter === void(0)) {
+            this.objectCounter = 0;
+        }
+    };
+
+
+    ToDomNodeParameters.prototype.incrementDepth = function() {
+        return new ToDomNodeParameters({ mode : this.mode,
+                                         depth: this.depth + 1,
+                                         cache: this.cache,
+                                         cycles: this.cycles,
+                                         objectCounter: this.objectCounter });
+    };
+    
+
+    // getMode: -> (U "print" "display" "write" "constructor")
+    ToDomNodeParameters.prototype.getMode = function() {
+        if (this.mode) { 
+            return this.mode; 
+        }
+        return 'print';
+    };
+
+    ToDomNodeParameters.prototype.getDepth = function(x) {
+        return this.depth;
+    };
+
+    ToDomNodeParameters.prototype.containsKey = function(x) {
+        return this.cache.containsKey(x);
+    };
+
+    ToDomNodeParameters.prototype.seesOldCycle = function(x) {
+        return this.cycles.containsKey(x);
+    };
+
+    ToDomNodeParameters.prototype.get = function(x) {
+        return this.cache.get(x);
+    };
+
+    ToDomNodeParameters.prototype.remove = function(x) {
+        return this.cache.remove(x);
+    };
+
+    ToDomNodeParameters.prototype.put = function(x, v) {
+        return this.cache.put(x, v);
+    };
+
+    ToDomNodeParameters.prototype.recur = function(x) {
+        return toDomNode(x, this.incrementDepth());
+    };
+
+
+
+    // rationalToDomNode: rational -> dom-node
+    var rationalToDomNode = function(n) {
+        var repeatingDecimalNode = document.createElement("span");
+        var chunks = baselib.numbers.toRepeatingDecimal(baselib.numbers.numerator(n),
+                                                        baselib.numbers.denominator(n),
+                                                        {limit: 25});
+        repeatingDecimalNode.appendChild($('<span/>').text(chunks[0] + '.').get(0));
+        repeatingDecimalNode.appendChild($('<span/>').text(chunks[1]).get(0));
+        if (chunks[2] === '...') {
+            repeatingDecimalNode.appendChild(
+                $('<span/>').text(chunks[2]).get(0));
+        } else if (chunks[2] !== '0') {
+            var overlineSpan = document.createElement("span");
+            overlineSpan.style.textDecoration = 'overline';
+            overlineSpan.appendChild(document.createTextNode(chunks[2]));
+            repeatingDecimalNode.appendChild(overlineSpan);
+        }
+
+
+        var fractionalNode = document.createElement("span");
+        var numeratorNode = document.createElement("sup");
+        numeratorNode.appendChild(document.createTextNode(String(baselib.numbers.numerator(n))));
+        var denominatorNode = document.createElement("sub");
+        denominatorNode.appendChild(document.createTextNode(String(baselib.numbers.denominator(n))));
+        fractionalNode.appendChild(numeratorNode);
+        fractionalNode.appendChild($('<span/>').text('/').get(0));
+        fractionalNode.appendChild(denominatorNode);
+
+        
+        var numberNode = document.createElement("span");
+        numberNode.className = "wescheme-number Rational";
+        numberNode.appendChild(repeatingDecimalNode);
+        numberNode.appendChild(fractionalNode);
+        fractionalNode.style['display'] = 'none';
+
+        var showingRepeating = true;
+
+        numberNode.onclick = function(e) {
+            showingRepeating = !showingRepeating;
+            repeatingDecimalNode.style['display'] = 
+                (showingRepeating ? 'inline' : 'none');
+            fractionalNode.style['display'] = 
+                (!showingRepeating ? 'inline' : 'none');
+        };
+        numberNode.style['cursor'] = 'pointer';
+        return numberNode;
+    };
+
+
+    // numberToDomNode: jsnum -> dom
+    // Given a jsnum, produces a dom-node representation.
+    var numberToDomNode = function(n, params) {
+        var node;
+        if (baselib.numbers.isExact(n)) {
+            if (baselib.numbers.isInteger(n)) {
+                node = document.createElement("span");
+                node.className = "wescheme-number Integer";
+                node.appendChild(document.createTextNode(n.toString()));
+                return node;
+            } else if (baselib.numbers.isRational(n)) {
+                return rationalToDomNode(n);
+            } else if (baselib.numbers.isComplex(n)) {
+                node = document.createElement("span");
+                node.className = "wescheme-number Complex";
+                node.appendChild(document.createTextNode(n.toString()));
+                return node;
+            } else {
+                node = document.createElement("span");
+                node.className = "wescheme-number";
+                node.appendChild(document.createTextNode(n.toString()));
+                return node;
+            }
+        } else {
+            node = document.createElement("span");
+            node.className = "wescheme-number";
+            node.appendChild(document.createTextNode(n.toString()));
+            return node;
+        }
+    };
+
+
+    var coerseToParams = function(params) {
+        if (params === 'write') {
+            params = new ToDomNodeParameters({'mode' : 'write'});
+        } else if (params === 'print') {
+            params = new ToDomNodeParameters({'mode' : 'print'});
+        } else if (params === 'display') {
+            params = new ToDomNodeParameters({'mode' : 'display'});
+        } else if (params === 'constructor') {
+            params = new ToDomNodeParameters({'mode' : 'constructor'});
+        } else {
+            params = params || new ToDomNodeParameters({'mode' : 'display'});
+        } 
+        return params;
+    };
+
+
+    // toDomNode: scheme-value -> dom-node
+    var toDomNode = function(x, params) {
+        var node, retval;
+        params = coerseToParams(params);
+
+        if (x === null) {
+            node = document.createElement("span");
+            node.appendChild(document.createTextNode("#<null>"));
+            $(node).addClass("null");
+            return node;
+        }
+
+        if (x === void(0)) {
+            node = document.createElement("span");
+            node.appendChild(document.createTextNode("#<undefined>"));
+            $(node).addClass("undefined");
+            return node;
+        }
+
+        if (baselib.numbers.isSchemeNumber(x)) {
+            node = numberToDomNode(x, params);
+            $(node).addClass("number");
+            return node;
+        }
+
+        if (typeof(x) === 'string') {
+            var wrapper = document.createElement("span");
+            wrapper.style.whiteSpace = "pre";
+            if (params.getMode() === 'write' || params.getMode() === 'print' || params.getMode() === 'constructor') {
+                node = document.createTextNode(toWrittenString(x));
+            } else {
+                node = document.createTextNode(toDisplayedString(x));
+            }
+            wrapper.appendChild(node);
+            $(wrapper).addClass("wescheme-string");
+            return wrapper;
+        }
+
+        if (x === true || x === false) {
+            node = document.createElement("span");
+            node.appendChild(document.createTextNode(x ? "true" : "false"));
+            $(node).addClass("wescheme-boolean");
+            return node;
+        }
+
+        if (baselib.functions.isProcedure(x)) {
+            node = document.createElement("span");
+            node.appendChild(document.createTextNode('#<function:' + x.displayName + '>'));
+            $(node).addClass("procedure");
+            return node;
+        }
+
+        if (typeof(x) !== 'object') {
+            node = document.createElement("span");
+            node.appendChild(document.createTextNode(x.toString()));
+            return node;
+        }
+
+        if (x.nodeType) {
+            return x;
+        }
+
+
+
+        // Otherwise, we know the value is an object.
+        
+        // If we're along a print path with a loop, we need to stop
+        // and return the key.
+        if (params.seesOldCycle(x)) {
+            node = document.createElement("span");
+            node.appendChild(document.createTextNode("#" + params.cycles.get(x) + "#"));
+            $(node).addClass("cycle");
+            return node;
+        }
+
+        // If we see a fresh cycle, register it.
+        if (params.containsKey(x)) {
+            $('<span/>').text('#' + params.objectCounter +'=')
+                    .prependTo(params.get(x));
+
+            params.cycles.put(x, params.objectCounter);
+            params.objectCounter++;
+
+            node = document.createElement("span");
+            node.appendChild(document.createTextNode("#" + params.cycles.get(x) + "#"));
+            $(node).addClass("cycle");
+            return node;
+        }
+
+        node = document.createElement("span");
+        params.put(x, node);
+        if (x.toDomNode) {
+            node.appendChild(x.toDomNode(params));
+        } else if (params.getMode() === 'write' && x.toWrittenString) {
+            node.appendChild(document.createTextNode(
+                x.toWrittenString(params)));
+        } else if (params.getMode() === 'display' && x.toDisplayedString) {
+            node.appendChild(document.createTextNode(
+                x.toDisplayedString(params)));
+        } else {
+            node.appendChild(document.createTextNode(x.toString()));
+        }
+        params.remove(x);
+        return node;
+    };
+
+
+
+    //////////////////////////////////////////////////////////////////////
+
+
+    exports.ToDomNodeParameters = ToDomNodeParameters;
+
+    exports.format = format;
+    exports.toWrittenString = toWrittenString;
+    exports.toDisplayedString = toDisplayedString;
+    exports.toDomNode = toDomNode;
+
+    exports.escapeString = escapeString;
+}(this.plt.baselib, jQuery));
+/*jslint vars: true, maxerr: 50, indent: 4 */
+
+
+// Other miscellaneous constants
+(function (baselib) {
+    'use strict';
+    var exports = {};
+    baselib.constants = exports;
+
+
+    var VoidValue = function () {};
+    VoidValue.prototype.toString = function () {
+        return "#<void>";
+    };
+
+    var VOID_VALUE = new VoidValue();
+
+
+    var EofValue = function () {};
+    EofValue.prototype.toString = function () {
+        return "#<eof>";
+    };
+
+    var EOF_VALUE = new EofValue();
+
+
+    exports.VOID_VALUE = VOID_VALUE;
+    exports.EOF_VALUE = EOF_VALUE;
+}(this.plt.baselib));/*jslint vars: true, maxerr: 50, indent: 4 */
+
+// Numbers.
+/*global jsnums*/
+(function (baselib, jsnums) {
+    'use strict';
+    var exports = {};
+    baselib.numbers = exports;
+
+
+
+    // Set the numeric tower to raise errors through our mechanism.
+    jsnums.onThrowRuntimeError = function(msg, x, y) {
+        if (msg === '/: division by zero') {
+            baselib.exceptions.raiseDivisionByZeroError(plt.runtime.currentMachine, msg);
+        } else {
+            baselib.exceptions.raiseContractError(plt.runtime.currentMachine, msg);
+        }
+    };
+
+
+    var isNumber = jsnums.isSchemeNumber;
+    var isReal = jsnums.isReal;
+    var isRational = jsnums.isRational;
+    var isComplex = isNumber;
+    var isInteger = jsnums.isInteger;
+
+
+    var isNatural = function (x) {
+        return (jsnums.isExact(x) && isInteger(x) 
+                && jsnums.greaterThanOrEqual(x, 0));
+    };
+
+    var isNonNegativeReal = function (x) {
+        return isReal(x) && jsnums.greaterThanOrEqual(x, 0);
+    };
+
+    var isByte = function (x) {
+        return (isNatural(x) && 
+                jsnums.lessThan(x, 256));
+    };
+
+
+    // sign: number -> number
+    var sign = function (x) {
+        if (jsnums.isInexact(x)) {
+            if (jsnums.greaterThan(x, 0)) {
+                return jsnums.makeFloat(1);
+            } else if (jsnums.lessThan(x, 0)) {
+                return jsnums.makeFloat(-1);
+            } else {
+                return jsnums.makeFloat(0);
+            }
+        } else {
+            if (jsnums.greaterThan(x, 0)) {
+                return 1;
+            } else if (jsnums.lessThan(x, 0)) {
+                return -1;
+            } else {
+                return 0;
+            }
+        }
+    };
+
+
+
+
+    //////////////////////////////////////////////////////////////////////
+    // Exports
+
+
+    var hasOwnProperty = {}.hasOwnProperty;
+
+    // We first re-export everything in jsnums.
+    var prop;
+    for (prop in jsnums) {
+        if (hasOwnProperty.call(jsnums,prop)) {
+            exports[prop] = jsnums[prop];
+        }
+    }
+
+    exports.isNumber = jsnums.isSchemeNumber;
+    exports.isReal = isReal;
+    exports.isRational = isRational;
+    exports.isComplex = isComplex;
+    exports.isInteger = isInteger;
+    exports.isNatural = isNatural;
+    exports.isByte = isByte;
+    exports.isNonNegativeReal = isNonNegativeReal;
+
+    exports.sign = sign;
+
+
+}(this.plt.baselib, jsnums));/*global $*/
+/*jslint browser: true, unparam: true, vars: true, plusplus: true, maxerr: 50, indent: 4 */
+
+
+// list structures (pairs, empty)
+(function (baselib, $) {
+    'use strict';
+    var exports = {};
+    baselib.lists = exports;
+
+
+    var Empty = function () {
+    };
+    Empty.EMPTY = new Empty();
+    var EMPTY = Empty.EMPTY;
+
+
+
+    Empty.prototype.equals = function (other, aUnionFind) {
+        return other instanceof Empty;
+    };
+
+    Empty.prototype.hashCode = function(depth) {
+        return baselib.hashes.getEqualHashCode("empty");
+    };
+
+
+    Empty.prototype.reverse = function () {
+        return this;
+    };
+
+    Empty.prototype.toWrittenString = function (cache) { return "empty"; };
+    Empty.prototype.toDisplayedString = function (cache) { return "empty"; };
+    Empty.prototype.toString = function (cache) { return "()"; };
+
+    Empty.prototype.toDomNode = function(params) {
+        if (params.getMode() === "display") {
+            return $("<span/>").text("()").get(0);
+        } else if (params.getMode() === "write") {
+            return $("<span/>").text("()").get(0);
+        } else if (params.getMode() === "print") {
+            if (params.getDepth() === 0) {
+                return $("<span/>").text("'()").get(0);
+            } else {
+                return $("<span/>").text("()").get(0);
+            }
+        } else if (params.getMode() === "constructor") {
+            return $("<span/>").text("(list)").get(0);
+        } else {
+            return $("<span/>").text("()").get(0);
+        }
+    };
+
+    // Empty.append: (listof X) -> (listof X)
+    Empty.prototype.append = function (b) {
+        return b;
+    };
+
+
+
+    //////////////////////////////////////////////////////////////////////
+
+    // Cons Pairs
+
+    var Cons = function (first, rest) {
+        this.first = first;
+        this.rest = rest;
+    };
+
+    var makePair = function (first, rest) {
+        return new Cons(first, rest);
+    };
+
+    Cons.prototype.reverse = function () {
+        var lst = this;
+        var ret = EMPTY;
+        while (lst !== EMPTY) {
+            ret = makePair(lst.first, ret);
+            lst = lst.rest;
+        }
+        return ret;
+    };
+
+    // FIXME: can we reduce the recursion on this?
+    Cons.prototype.equals = function (other, aUnionFind) {
+        if (!(other instanceof Cons)) {
+            return false;
+        }
+        return (baselib.equality.equals(this.first, other.first, aUnionFind) &&
+                baselib.equality.equals(this.rest, other.rest, aUnionFind));
+    };
+
+    Cons.prototype.hashCode = function(depth) {
+        var k = baselib.hashes.getEqualHashCode("Cons");
+        k += baselib.hashes.getEqualHashCode(this.first, depth);
+        k = baselib.hashes.hashMix(k);
+        k += baselib.hashes.getEqualHashCode(this.rest, depth);
+        k = baselib.hashes.hashMix(k);
+        return k;
+    };
+
+
+
+    // Cons.append: (listof X) -> (listof X)
+    Cons.prototype.append = function (b) {
+        if (b === EMPTY) {
+            return this;
+        }
+        var ret = b;
+        var lst = this.reverse();
+        while (lst !== EMPTY) {
+            ret = makePair(lst.first, ret);
+            lst = lst.rest;
+        }
+        return ret;
+    };
+
+
+    Cons.prototype.toWrittenString = function (cache) {
+        cache.put(this, true);
+        var texts = [];
+        var p = this;
+        while (p instanceof Cons) {
+            texts.push(baselib.format.toWrittenString(p.first, cache));
+            p = p.rest;
+            if (typeof (p) === 'object' && cache.containsKey(p)) {
+                break;
+            }
+        }
+        if (p !== EMPTY) {
+            texts.push('.');
+            texts.push(baselib.format.toWrittenString(p, cache));
+        }
+        return "(" + texts.join(" ") + ")";
+    };
+
+    Cons.prototype.toString = Cons.prototype.toWrittenString;
+
+    Cons.prototype.toDisplayedString = function (cache) {
+        cache.put(this, true);
+        var texts = [];
+        var p = this;
+        while (p instanceof Cons) {
+            texts.push(baselib.format.toDisplayedString(p.first, cache));
+            p = p.rest;
+            if (typeof (p) === 'object' && cache.containsKey(p)) {
+                break;
+            }
+        }
+        if (p !== EMPTY) {
+            texts.push('.');
+            texts.push(baselib.format.toDisplayedString(p, cache));
+        }
+        return "(" + texts.join(" ") + ")";
+    };
+
+
+
+    Cons.prototype.toDomNode = function (params) {
+        var node;
+
+        var subelts = [], dottedPair = false, i;
+        var p = this;
+        while (p instanceof Cons) {
+            subelts.push(params.recur(p.first));
+            p = p.rest;
+            if (typeof (p) === 'object' && params.containsKey(p)) {
+                break;
+            }
+        }
+        if (p !== EMPTY) {
+            dottedPair = true;
+            subelts.push(params.recur(p));
+        }
+
+        if (params.getMode() === 'constructor') {
+            if (dottedPair) {
+                node = subelts[subelts.length - 1];
+                for (i = subelts.length - 2; i >= 0; i--) {
+                    node = $('<span/>')
+                        .append($('<span/>').text("(").addClass('lParen'))
+                        .append($('<span/>').text("cons"))
+                        .append(" ")
+                        .append(subelts[i])
+                        .append(" ")
+                        .append(node)
+                        .append($('<span/>').text(")").addClass('rParen'))
+                        .get(0);
+                }
+                return node;
+            } else {
+                node = $("<span/>").addClass("wescheme-cons");
+                node.append($('<span/>').text("(").addClass('lParen'));
+                node.append($('<span/>').text("list"));
+                node.append(" ");
+                node.append(subelts[0]);
+                for (i = 1; i < subelts.length; i++) {
+                    node.append(" ");
+                    node.append(subelts[i]);
+                }
+                node.append($('<span/>').text(')').addClass('rParen'));
+                return node.get(0);
+            }
+        }
+
+        node = $('<span/>').addClass("wescheme-cons");
+        if (params.getMode() === 'print') {
+            node.append($("<span/>").text("'"));
+        }
+        node.append($('<span/>').text('(').addClass('lParen'))
+        node.append(subelts[0]);
+        if (subelts.length > 1) {
+            for (i = 1; i < subelts.length - 1; i++) {
+                node.append(" ");
+                node.append(subelts[i]);
+            }
+            if (dottedPair) {
+                node.append(" ");
+                node.append(".");
+            }
+            node.append(" ");
+            node.append(subelts[subelts.length - 1]);
+        }
+        node.append($('<span/>').text(")").addClass('rParen'));
+        return node.get(0);
+    };
+
+
+    var isPair = function (x) { return x instanceof Cons; };
+    var isEmpty = function (x) { return x === EMPTY; };
+
+
+
+    var makeList = function () {
+        var result = EMPTY, i;
+        for (i = arguments.length - 1; i >= 0; i--) {
+            result = makePair(arguments[i], result);
+        }
+        return result;
+    };
+
+
+    var arrayToList = function (arr) {
+        var result = EMPTY, i;
+        for (i = arr.length -1; i >= 0; i--) {
+            result = makePair(arr[i], result);
+        }
+        return result;
+    };
+
+
+    // Coerse a list back into a JavaScript array.
+    var listToArray = function (lst) {
+        var result = [];
+        while (lst !== EMPTY) {
+            result.push(lst.first);
+            lst = lst.rest;
+        }
+        return result;
+    };
+
+
+    // isList: Any -> Boolean
+    // Returns true if x is a list (a chain of pairs terminated by EMPTY).
+    var isList = function (x) {
+        var tortoise, hare;
+        tortoise = hare = x;
+        if (hare === EMPTY) { 
+            return true; 
+        }
+        if (!(hare instanceof Cons)) { return false; }
+        while (true) {
+            // Loop invariant: at the beginning of the loop, both tortoise
+            // and hare should be pointing to a cons cell.
+            tortoise = tortoise.rest; 
+            hare = hare.rest;
+            if (hare instanceof Cons) { 
+                // optimization to get amortized linear time isList:
+                if (hare._isList !== void(0)) { 
+                    tortoise._isList = hare._isList; return hare._isList; 
+                }
+                hare = hare.rest; 
+                // optimization to get amortized linear time isList:
+                if (hare instanceof Cons && hare._isList !== void(0)) { 
+                    tortoise._isList = hare._isList; return hare._isList; 
+                }
+            }
+            if (hare === EMPTY) { 
+                // optimization to get amortized linear time isList:
+                tortoise._isList = true;
+                return true; 
+            }
+            if (tortoise === hare) {
+                tortoise._isList = false;
+                return false; 
+            }
+            if (!(hare instanceof Cons)) { 
+                tortoise._isList = false;
+                return false; 
+            }
+        }
+    };
+
+
+
+    var reverse = function (lst) {
+        var rev = EMPTY;
+        while (lst !== EMPTY) {
+            rev = makePair(lst.first, rev);
+            lst = lst.rest;
+        }
+        return rev;
+    };
+
+
+    var length = function (lst) {
+        var len = 0;
+        while (lst !== EMPTY) {
+            len++;
+            lst = lst.rest;
+        }
+        return len;
+    };
+
+
+    var listRef = function (lst, n) {
+        var i;
+        for (i = 0; i < n; i++) {
+            lst = lst.rest;
+        }
+        return lst.first;
+    };
+
+
+
+    //////////////////////////////////////////////////////////////////////
+
+    exports.EMPTY = EMPTY;
+    exports.Empty = Empty;
+    exports.Cons = Cons;
+    exports.isPair = isPair;
+    exports.isList = isList;
+    exports.isEmpty = isEmpty;
+    exports.makePair = makePair;
+    exports.makeList = makeList;
+    exports.reverse = reverse;
+    exports.length = length;
+    exports.listRef = listRef;
+    exports.listToArray = listToArray;
+    exports.arrayToList = arrayToList;
+
+}(this.plt.baselib, jQuery));
+// vectors
+/*jslint devel: false, browser: true, vars: true, plusplus: true, maxerr: 500, indent: 4 */
+(function (baselib, $) {
+    "use strict";
+    var exports = {};
+    baselib.vectors = exports;
+
+
+
+    var Vector = function (initialElements) {
+        this.elts = initialElements;
+        this.mutable = true;
+    };
+
+    Vector.makeInstance = function (elts) {
+        return new Vector(elts);
+    };
+
+    Vector.prototype.length = function () {
+        return this.elts.length;
+    };
+
+    Vector.prototype.ref = function (k) {
+        return this.elts[k];
+    };
+
+    Vector.prototype.set = function (k, v) {
+        this.elts[k] = v;
+    };
+
+    Vector.prototype.equals = function (other, aUnionFind) {
+        var i;
+        if (other instanceof Vector) {
+            if (other.length() !== this.length()) {
+                return false;
+            }
+            for (i = 0; i <  this.length(); i++) {
+                if (!(baselib.equality.equals(this.elts[i], other.elts[i], aUnionFind))) {
+                    return false;
+                }
+            }
+            return true;
+        } else {
+            return false;
+        }
+    };
+
+    Vector.prototype.hashCode = function(depth) {
+        var k = baselib.hashes.getEqualHashCode("Vector");
+        var i;
+        k = baselib.hashes.hashMix(k);
+        for (i = 0; i < this.elts.length; i++) {
+            k += baselib.hashes.getEqualHashCode(this.elts[i], depth);
+            k = baselib.hashes.hashMix(k);
+        }
+        return k;
+    };
+
+    Vector.prototype.toList = function () {
+        var ret = baselib.lists.EMPTY, i;
+        for (i = this.length() - 1; i >= 0; i--) {
+            ret = baselib.lists.makePair(this.elts[i], ret);           
+        }       
+        return ret;
+    };
+
+    Vector.prototype.toWrittenString = function (cache) {
+        var texts = [], i;
+        cache.put(this, true);
+        for (i = 0; i < this.length(); i++) {
+            texts.push(baselib.format.toWrittenString(this.ref(i), cache));
+        }
+        return "#(" + texts.join(" ") + ")";
+    };
+
+    Vector.prototype.toDisplayedString = function (cache) {
+        var texts = [], i;
+        cache.put(this, true);
+        for (i = 0; i < this.length(); i++) {
+            texts.push(baselib.format.toDisplayedString(this.ref(i), cache));
+        }
+        return "#(" + texts.join(" ") + ")";
+    };
+
+    Vector.prototype.toDomNode = function (params) {
+        var node = $('<span/>'), i;
+        if (params.getMode() === 'constructor') {
+            node.append($('<span/>').text('(').addClass('lParen'));
+            node.append($('<span/>').text('vector'));
+            for (i = 0; i < this.length(); i++) {
+                node.append(" ");
+                node.append(params.recur(this.ref(i)));
+            }
+            node.append($('<span/>').text(')').addClass('rParen'));
+        } else {
+            node.append($('<span/>').text('#(').addClass('lParen'));
+            for (i = 0; i < this.length(); i++) {
+                node.append(params.recur(this.ref(i)));
+                if (i !== this.length() - 1) {
+                    node.append(" ");
+                }
+            }
+            node.append($('<span/>').text(')').addClass('rParen'));
+        }
+        return node.get(0);
+    };
+
+
+    var isVector = function (x) { return x instanceof Vector; };
+
+    // makeVector: x ... -> vector
+    var makeVector = Vector.makeInstance;
+
+    var makeVectorImmutable = function (elts) {
+        var v = Vector.makeInstance(elts);
+        v.mutable = false;
+        return v;
+    };
+
+
+
+    //////////////////////////////////////////////////////////////////////
+
+    exports.Vector = Vector;
+    exports.isVector = isVector;
+    exports.makeVector = makeVector;
+    exports.makeVectorImmutable = makeVectorImmutable;
+
+
+}(this.plt.baselib, jQuery));
+// Single characters
+(function(baselib, $) {
+    var exports = {};
+    baselib.chars = exports;
+
+
+    // Chars
+    // Char: string -> Char
+    var Char = function(val){
+        this.val = val;
+    };
+    // The characters less than 256 must be eq?, according to the
+    // documentation:
+    // http://docs.racket-lang.org/reference/characters.html
+    var _CharCache = {};
+    for (var i = 0; i < 256; i++) {
+        _CharCache[String.fromCharCode(i)] = new Char(String.fromCharCode(i));
+    }
+    
+    // makeInstance: 1-character string -> Char  
+    Char.makeInstance = function(val){
+        if (_CharCache[val]) {
+	    return _CharCache[val];
+        }
+        return new Char(val);
+    };
+
+    Char.prototype.toString = function(cache) {
+	var code = this.val.charCodeAt(0);
+	var returnVal;
+	switch (code) {
+	case 0: returnVal = '#\\nul'; break;
+	case 8: returnVal = '#\\backspace'; break;
+	case 9: returnVal = '#\\tab'; break;
+	case 10: returnVal = '#\\newline'; break;
+	case 11: returnVal = '#\\vtab'; break;
+	case 12: returnVal = '#\\page'; break;
+	case 13: returnVal = '#\\return'; break;
+	case 20: returnVal = '#\\space'; break;
+	case 127: returnVal = '#\\rubout'; break;
+	default: if (code >= 32 && code <= 126) {
+	    returnVal = ("#\\" + this.val);
+	}
+	    else {
+		var numStr = code.toString(16).toUpperCase();
+		while (numStr.length < 4) {
+		    numStr = '0' + numStr;
+		}
+		returnVal = ('#\\u' + numStr);
+	    }
+	    break;
+	}
+	return returnVal;
+    };
+
+    Char.prototype.toWrittenString = Char.prototype.toString;
+
+    Char.prototype.toDisplayedString = function (cache) {
+        return this.val;
+    };
+
+    Char.prototype.toDomNode = function(params) {
+        return $('<span/>')
+            .text(this.toString())
+            .addClass('wescheme-character')
+            .get(0);
+    };
+
+    Char.prototype.getValue = function() {
+        return this.val;
+    };
+
+    Char.prototype.equals = function(other, aUnionFind){
+        return other instanceof Char && this.val == other.val;
+    };
+
+    Char.prototype.hashCode = function(depth) {
+        var k = baselib.hashes.getEqualHashCode('Char');
+        k += this.val.charCodeAt(0);
+        k = baselib.hashes.hashMix(k);
+        return k;
+    };
+
+
+    exports.Char = Char;
+    exports.makeChar = Char.makeInstance;
+    exports.isChar = plt.baselib.makeClassPredicate(Char);
+
+
+})(this['plt'].baselib, jQuery);
+/*jslint devel: false, browser: true, unparam: true, vars: true, plusplus: true, maxerr: 500, indent: 4 */
+// Structure types
+(function (baselib,$) {
+    "use strict";
+    var exports = {};
+    baselib.symbols = exports;
+
+
+    //////////////////////////////////////////////////////////////////////
+    
+    // Symbols
+
+    //////////////////////////////////////////////////////////////////////
+    var Symbol = function (val) {
+        this.val = val;
+    };
+
+    var symbolCache = new baselib.Dict();
+
+    // makeSymbol: string -> Symbol.
+    // Interns a symbol.
+    var makeSymbol = function (val) {
+        // To ensure that we can eq? symbols with equal values.
+        if (!(symbolCache.has(val))) {
+            symbolCache.set(val, new Symbol(val));
+        }
+        return symbolCache.get(val);
+    };
+    
+    Symbol.prototype.equals = function (other, aUnionFind) {
+        return other instanceof Symbol &&
+            this.val === other.val;
+    };
+
+    Symbol.prototype.hashCode = function(depth) {
+        var k = baselib.hashes.getEqualHashCode("Symbol");
+        k = baselib.hashes.hashMix(k);
+        k += baselib.hashes.getEqualHashCode(this.val);
+        k = baselib.hashes.hashMix(k);
+        return k;
+    };
+    
+
+    Symbol.prototype.toString = function (cache) {
+        return this.val;
+    };
+
+    Symbol.prototype.toWrittenString = function (cache) {
+        return this.val;
+    };
+
+    Symbol.prototype.toDisplayedString = function (cache) {
+        return this.val;
+    };
+
+    Symbol.prototype.toDomNode = function(params) {
+        if (params.getMode() === 'write') {
+            return $("<span/>").text(this.val).addClass('wescheme-symbol').get(0);
+        }
+        if (params.getMode() === 'display') {
+            return $("<span/>").text(this.val).addClass('wescheme-symbol').get(0);
+        }
+        if (params.getMode() === 'print') {
+            if (params.getDepth() === 0) {
+                return $("<span/>").text("'" + this.val).addClass('wescheme-symbol').get(0);
+            } else {
+                return $("<span/>").text(this.val).addClass('wescheme-symbol').get(0);
+            }
+        }
+        if (params.getMode() === 'constructor') {
+            return $("<span/>").text("'" + this.val).addClass('wescheme-symbol').get(0);
+        }
+
+        return $("<span/>").text(this.val).addClass('wescheme-symbol').get(0);
+    };
+    
+
+
+    var isSymbol = function (x) { return x instanceof Symbol; };
+
+
+
+
+    //////////////////////////////////////////////////////////////////////
+
+    exports.Symbol = Symbol;
+    exports.makeSymbol = makeSymbol;
+    exports.isSymbol = isSymbol;
+
+}(this.plt.baselib, jQuery));
+// Hardcoded parameters.
+(function(baselib) {
+    'use strict';
+    var exports = {};
+    baselib.paramz = exports;
+
+    // The parameter keys here must be uninterned symbols, so we explicitly
+    // call the symbol constructor here.
+    var exceptionHandlerKey = new baselib.symbols.Symbol("exnh");
+    var parameterizationKey = new baselib.symbols.Symbol("paramz");
+    var breakEnabledKey = new baselib.symbols.Symbol("break-on?");
+
+    exports.exceptionHandlerKey = exceptionHandlerKey;
+    exports.parameterizationKey = parameterizationKey;
+    exports.breakEnabledKey = breakEnabledKey;
+    
+})(this['plt'].baselib);
+/*jslint browser: false, unparam: true, vars: true, white: true, nomen: true, plusplus: true, maxerr: 50, indent: 4 */
+
+
+// Strings
+
+// Strings are either mutable or immutable.  immutable strings are represented
+// as regular JavaScript strings.  Mutable ones are represented as instances
+// of the Str class.
+
+(function (baselib) {
+    'use strict';
+    var exports = {};
+
+    baselib.strings = exports;
+
+
+    // chars: arrayof string
+    // Precondition: each string must only be 1 character long or bad things
+    // happen.
+    var Str = function (chars) {
+	this.chars = chars;
+	this.length = chars.length;
+	this.mutable = true;
+    };
+
+    Str.makeInstance = function (chars) {
+	return new Str(chars);
+    };
+
+    Str.fromString = function (s) {
+	return Str.makeInstance(s.split(""));
+    };
+
+    Str.prototype.toString = function () {
+	return this.chars.join("");
+    };
+
+    var replaceUnprintableStringChars = function (s) {
+	var ret = [], i;
+	for (i = 0; i < s.length; i++) {
+	    var val = s.charCodeAt(i);
+	    switch(val) {
+	    case 7: ret.push('\\a'); break;
+	    case 8: ret.push('\\b'); break;
+	    case 9: ret.push('\\t'); break;
+	    case 10: ret.push('\\n'); break;
+	    case 11: ret.push('\\v'); break;
+	    case 12: ret.push('\\f'); break;
+	    case 13: ret.push('\\r'); break;
+	    case 34: ret.push('\\"'); break;
+	    case 92: ret.push('\\\\'); break;
+	    default: 
+                if (val >= 32 && val <= 126) {
+		    ret.push( s.charAt(i) );
+	        }
+		else {
+		    var numStr = val.toString(16).toUpperCase();
+		    while (numStr.length < 4) {
+			numStr = '0' + numStr;
+		    }
+		    ret.push('\\u' + numStr);
+		}
+		break;
+	    }
+	}
+	return ret.join('');
+    };
+
+    var escapeString = function (s) {
+        return '"' + replaceUnprintableStringChars(s) + '"';
+    };
+
+    Str.prototype.toWrittenString = function (cache) {
+        return escapeString(this.toString());
+    };
+
+    Str.prototype.toDisplayedString = Str.prototype.toString;
+
+    Str.prototype.toDomNode = function(params) {
+        return $("<span/>")
+            .text(escapeString(this.toString()))
+            .addClass('wescheme-string')
+            .get(0);
+    };
+
+
+    Str.prototype.copy = function () {
+	return Str.makeInstance(this.chars.slice(0));
+    };
+
+    Str.prototype.substring = function (start, end) {
+	if (end === null || end === void(0)) {
+	    end = this.length;
+	}
+	return Str.makeInstance( this.chars.slice(start, end) );
+    };
+
+    Str.prototype.charAt = function (index) {
+	return this.chars[index];
+    };
+
+    Str.prototype.charCodeAt = function (index) {
+	return this.chars[index].charCodeAt(0);
+    };
+
+    Str.prototype.replace = function (expr, newStr) {
+	return Str.fromString(this.toString().replace(expr, newStr) );
+    };
+
+
+    Str.prototype.equals = function (other, aUnionFind) {
+	if ( !(other instanceof Str || typeof(other) === 'string') ) {
+	    return false;
+	}
+	return this.toString() === other.toString();
+    };
+
+    Str.prototype.hashCode = function(depth) {
+        return baselib.hashes.getEqualHashCode(this.toString());
+    };
+
+
+    Str.prototype.set = function (i, c) {
+	this.chars[i] = c;
+    };
+
+    Str.prototype.toUpperCase = function () {
+	return Str.fromString(this.chars.join("").toUpperCase() );
+    };
+
+    Str.prototype.toLowerCase = function () {
+	return Str.fromString(this.chars.join("").toLowerCase() );
+    };
+
+    Str.prototype.match = function (regexpr) {
+	return this.toString().match(regexpr);
+    };
+
+
+
+    var isString = function (s) {
+	return (typeof s === 'string' || 
+                s instanceof Str);
+    };
+
+    var isMutableString = baselib.makeClassPredicate(Str);
+
+
+
+    exports.Str = Str;
+    exports.escapeString = escapeString;
+    exports.isString = isString;
+    exports.isMutableString = isMutableString;
+    exports.makeMutableString = Str.makeInstance;
+
+}(this.plt.baselib));
+/*jslint unparam: true, vars: true, white: true, plusplus: true, maxerr: 50, indent: 4 */
+
+
+
+(function(baselib) {
+    'use strict';
+    var exports = {};
+    baselib.bytes = exports;
+
+    // Bytes
+
+    var Bytes = function(bts, mutable) {
+        // bytes: arrayof [0-255]
+        this.bytes = bts;
+        this.mutable = (mutable === void(0)) ? false : mutable;
+    };
+
+    Bytes.prototype.get = function(i) {
+	return this.bytes[i];
+    };
+
+    Bytes.prototype.set = function(i, b) {
+	if (this.mutable) {
+	    this.bytes[i] = b;
+	}
+    };
+
+    Bytes.prototype.length = function() {
+	return this.bytes.length;
+    };
+
+    Bytes.prototype.copy = function(mutable) {
+	return new Bytes(this.bytes.slice(0), mutable);
+    };
+
+    Bytes.prototype.subbytes = function(start, end) {
+	if (end === null || end === void(0)) {
+	    end = this.bytes.length;
+	}
+	return new Bytes( this.bytes.slice(start, end), true );
+    };
+
+
+    Bytes.prototype.equals = function(other) {
+        if (! (other instanceof Bytes)) {
+	    return false;
+        }
+        if (this.bytes.length !== other.bytes.length) {
+	    return false;
+        }
+        var A = this.bytes;
+        var B = other.bytes;
+        var n = this.bytes.length;
+        var i;
+        for (i = 0; i < n; i++) {
+	    if (A[i] !== B[i]) {
+	        return false;
+            }
+        }
+        return true;
+    };
+
+    Bytes.prototype.hashCode = function(depth) {
+        var i;
+        var k = baselib.hashes.getEqualHashCode('Bytes');
+        for (i = 0; i < this.bytes.length; i++) {
+            k += this.bytes[i];
+            k = baselib.hashes.hashMix(k);
+        }
+        return k;
+    };
+
+
+    Bytes.prototype.toString = function(cache) {
+	var ret = [], i;
+	for (i = 0; i < this.bytes.length; i++) {
+	    ret.push(String.fromCharCode(this.bytes[i]));
+	}
+
+	return ret.join('');
+    };
+
+    Bytes.prototype.toDisplayedString = Bytes.prototype.toString;
+
+    var escapeByte = function(aByte) {
+	var ret = [];
+	var returnVal;
+	switch(aByte) {
+	case 7: returnVal = '\\a'; break;
+	case 8: returnVal = '\\b'; break;
+	case 9: returnVal = '\\t'; break;
+	case 10: returnVal = '\\n'; break;
+	case 11: returnVal = '\\v'; break;
+	case 12: returnVal = '\\f'; break;
+	case 13: returnVal = '\\r'; break;
+	case 34: returnVal = '\\"'; break;
+	case 92: returnVal = '\\\\'; break;
+	default: if (aByte >= 32 && aByte <= 126) {
+	    returnVal = String.fromCharCode(aByte);
+	}
+	    else {
+		ret.push( '\\' + aByte.toString(8) );
+	    }
+	    break;
+	}
+	return returnVal;
+    };
+
+    Bytes.prototype.toWrittenString = function() {
+	var ret = ['#"'], i;
+	for (i = 0; i < this.bytes.length; i++) {
+	    ret.push(escapeByte(this.bytes[i]));
+	}
+	ret.push('"');
+	return ret.join('');
+    };
+
+    var makeBytes = function(chars) {
+        return new Bytes(chars);
+    };
+
+    var makeBytesFromBase64 = function(byteString) {
+        return new Bytes(Base64.decode(byteString));
+    };
+
+
+    var isBytes = baselib.makeClassPredicate(Bytes);
+
+
+    exports.Bytes = Bytes;
+    exports.makeBytes = makeBytes;
+    exports.makeBytesFromBase64 = makeBytesFromBase64;
+    exports.isBytes = isBytes;
+
+
+}(this.plt.baselib));(function() {
+'use strict';/**
+ * Copyright 2010 Tim Down.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * jshashtable
+ *
+ * jshashtable is a JavaScript implementation of a hash table. It creates a single constructor function called Hashtable
+ * in the global scope.
+ *
+ * Author: Tim Down <tim@timdown.co.uk>
+ * Version: 2.1
+ * Build date: 21 March 2010
+ * Website: http://www.timdown.co.uk/jshashtable
+ */
+
+var Hashtable = (function() {
+	var FUNCTION = "function";
+
+	var arrayRemoveAt = (typeof Array.prototype.splice == FUNCTION) ?
+		function(arr, idx) {
+			arr.splice(idx, 1);
+		} :
+
+		function(arr, idx) {
+			var itemsAfterDeleted, i, len;
+			if (idx === arr.length - 1) {
+				arr.length = idx;
+			} else {
+				itemsAfterDeleted = arr.slice(idx + 1);
+				arr.length = idx;
+				for (i = 0, len = itemsAfterDeleted.length; i < len; ++i) {
+					arr[idx + i] = itemsAfterDeleted[i];
+				}
+			}
+		};
+
+	function hashObject(obj) {
+		var hashCode;
+		if (typeof obj == "string") {
+			return obj;
+		} else if (typeof obj.hashCode == FUNCTION) {
+			// Check the hashCode method really has returned a string
+			hashCode = obj.hashCode();
+			return (typeof hashCode == "string") ? hashCode : hashObject(hashCode);
+		} else if (typeof obj.toString == FUNCTION) {
+			return obj.toString();
+		} else {
+			try {
+				return String(obj);
+			} catch (ex) {
+				// For host objects (such as ActiveObjects in IE) that have no toString() method and throw an error when
+				// passed to String()
+				return Object.prototype.toString.call(obj);
+			}
+		}
+	}
+
+	function equals_fixedValueHasEquals(fixedValue, variableValue) {
+		return fixedValue.equals(variableValue);
+	}
+
+	function equals_fixedValueNoEquals(fixedValue, variableValue) {
+		return (typeof variableValue.equals == FUNCTION) ?
+			   variableValue.equals(fixedValue) : (fixedValue === variableValue);
+	}
+
+	function createKeyValCheck(kvStr) {
+		return function(kv) {
+			if (kv === null) {
+				throw new Error("null is not a valid " + kvStr);
+			} else if (typeof kv == "undefined") {
+				throw new Error(kvStr + " must not be undefined");
+			}
+		};
+	}
+
+	var checkKey = createKeyValCheck("key"), checkValue = createKeyValCheck("value");
+
+	/*----------------------------------------------------------------------------------------------------------------*/
+
+	function Bucket(hash, firstKey, firstValue, equalityFunction) {
+        this[0] = hash;
+		this.entries = [];
+		this.addEntry(firstKey, firstValue);
+
+		if (equalityFunction !== null) {
+			this.getEqualityFunction = function() {
+				return equalityFunction;
+			};
+		}
+	}
+
+	var EXISTENCE = 0, ENTRY = 1, ENTRY_INDEX_AND_VALUE = 2;
+
+	function createBucketSearcher(mode) {
+		return function(key) {
+			var i = this.entries.length, entry, equals = this.getEqualityFunction(key);
+			while (i--) {
+				entry = this.entries[i];
+				if ( equals(key, entry[0]) ) {
+					switch (mode) {
+						case EXISTENCE:
+							return true;
+						case ENTRY:
+							return entry;
+						case ENTRY_INDEX_AND_VALUE:
+							return [ i, entry[1] ];
+					}
+				}
+			}
+			return false;
+		};
+	}
+
+	function createBucketLister(entryProperty) {
+		return function(aggregatedArr) {
+			var startIndex = aggregatedArr.length;
+			for (var i = 0, len = this.entries.length; i < len; ++i) {
+				aggregatedArr[startIndex + i] = this.entries[i][entryProperty];
+			}
+		};
+	}
+
+	Bucket.prototype = {
+		getEqualityFunction: function(searchValue) {
+			return (typeof searchValue.equals == FUNCTION) ? equals_fixedValueHasEquals : equals_fixedValueNoEquals;
+		},
+
+		getEntryForKey: createBucketSearcher(ENTRY),
+
+		getEntryAndIndexForKey: createBucketSearcher(ENTRY_INDEX_AND_VALUE),
+
+		removeEntryForKey: function(key) {
+			var result = this.getEntryAndIndexForKey(key);
+			if (result) {
+				arrayRemoveAt(this.entries, result[0]);
+				return result[1];
+			}
+			return null;
+		},
+
+		addEntry: function(key, value) {
+			this.entries[this.entries.length] = [key, value];
+		},
+
+		keys: createBucketLister(0),
+
+		values: createBucketLister(1),
+
+		getEntries: function(entries) {
+			var startIndex = entries.length;
+			for (var i = 0, len = this.entries.length; i < len; ++i) {
+				// Clone the entry stored in the bucket before adding to array
+				entries[startIndex + i] = this.entries[i].slice(0);
+			}
+		},
+
+		containsKey: createBucketSearcher(EXISTENCE),
+
+		containsValue: function(value) {
+			var i = this.entries.length;
+			while (i--) {
+				if ( value === this.entries[i][1] ) {
+					return true;
+				}
+			}
+			return false;
+		}
+	};
+
+	/*----------------------------------------------------------------------------------------------------------------*/
+
+	// Supporting functions for searching hashtable buckets
+
+	function searchBuckets(buckets, hash) {
+		var i = buckets.length, bucket;
+		while (i--) {
+			bucket = buckets[i];
+			if (hash === bucket[0]) {
+				return i;
+			}
+		}
+		return null;
+	}
+
+	function getBucketForHash(bucketsByHash, hash) {
+		var bucket = bucketsByHash[hash];
+
+		// Check that this is a genuine bucket and not something inherited from the bucketsByHash's prototype
+		return ( bucket && (bucket instanceof Bucket) ) ? bucket : null;
+	}
+
+	/*----------------------------------------------------------------------------------------------------------------*/
+
+	function Hashtable(hashingFunctionParam, equalityFunctionParam) {
+		var that = this;
+		var buckets = [];
+		var bucketsByHash = {};
+
+		var hashingFunction = (typeof hashingFunctionParam == FUNCTION) ? hashingFunctionParam : hashObject;
+		var equalityFunction = (typeof equalityFunctionParam == FUNCTION) ? equalityFunctionParam : null;
+
+		this.put = function(key, value) {
+			checkKey(key);
+			checkValue(value);
+			var hash = hashingFunction(key), bucket, bucketEntry, oldValue = null;
+
+			// Check if a bucket exists for the bucket key
+			bucket = getBucketForHash(bucketsByHash, hash);
+			if (bucket) {
+				// Check this bucket to see if it already contains this key
+				bucketEntry = bucket.getEntryForKey(key);
+				if (bucketEntry) {
+					// This bucket entry is the current mapping of key to value, so replace old value and we're done.
+					oldValue = bucketEntry[1];
+					bucketEntry[1] = value;
+				} else {
+					// The bucket does not contain an entry for this key, so add one
+					bucket.addEntry(key, value);
+				}
+			} else {
+				// No bucket exists for the key, so create one and put our key/value mapping in
+				bucket = new Bucket(hash, key, value, equalityFunction);
+				buckets[buckets.length] = bucket;
+				bucketsByHash[hash] = bucket;
+			}
+			return oldValue;
+		};
+
+		this.get = function(key) {
+			checkKey(key);
+
+			var hash = hashingFunction(key);
+
+			// Check if a bucket exists for the bucket key
+			var bucket = getBucketForHash(bucketsByHash, hash);
+			if (bucket) {
+				// Check this bucket to see if it contains this key
+				var bucketEntry = bucket.getEntryForKey(key);
+				if (bucketEntry) {
+					// This bucket entry is the current mapping of key to value, so return the value.
+					return bucketEntry[1];
+				}
+			}
+			return null;
+		};
+
+		this.containsKey = function(key) {
+			checkKey(key);
+			var bucketKey = hashingFunction(key);
+
+			// Check if a bucket exists for the bucket key
+			var bucket = getBucketForHash(bucketsByHash, bucketKey);
+
+			return bucket ? bucket.containsKey(key) : false;
+		};
+
+		this.containsValue = function(value) {
+			checkValue(value);
+			var i = buckets.length;
+			while (i--) {
+				if (buckets[i].containsValue(value)) {
+					return true;
+				}
+			}
+			return false;
+		};
+
+		this.clear = function() {
+			buckets.length = 0;
+			bucketsByHash = {};
+		};
+
+		this.isEmpty = function() {
+			return !buckets.length;
+		};
+
+		var createBucketAggregator = function(bucketFuncName) {
+			return function() {
+				var aggregated = [], i = buckets.length;
+				while (i--) {
+					buckets[i][bucketFuncName](aggregated);
+				}
+				return aggregated;
+			};
+		};
+
+		this.keys = createBucketAggregator("keys");
+		this.values = createBucketAggregator("values");
+		this.entries = createBucketAggregator("getEntries");
+
+		this.remove = function(key) {
+			checkKey(key);
+
+			var hash = hashingFunction(key), bucketIndex, oldValue = null;
+
+			// Check if a bucket exists for the bucket key
+			var bucket = getBucketForHash(bucketsByHash, hash);
+
+			if (bucket) {
+				// Remove entry from this bucket for this key
+				oldValue = bucket.removeEntryForKey(key);
+				if (oldValue !== null) {
+					// Entry was removed, so check if bucket is empty
+					if (!bucket.entries.length) {
+						// Bucket is empty, so remove it from the bucket collections
+						bucketIndex = searchBuckets(buckets, hash);
+						arrayRemoveAt(buckets, bucketIndex);
+						delete bucketsByHash[hash];
+					}
+				}
+			}
+			return oldValue;
+		};
+
+		this.size = function() {
+			var total = 0, i = buckets.length;
+			while (i--) {
+				total += buckets[i].entries.length;
+			}
+			return total;
+		};
+
+		this.each = function(callback) {
+			var entries = that.entries(), i = entries.length, entry;
+			while (i--) {
+				entry = entries[i];
+				callback(entry[0], entry[1]);
+			}
+		};
+
+		this.putAll = function(hashtable, conflictCallback) {
+			var entries = hashtable.entries();
+			var entry, key, value, thisValue, i = entries.length;
+			var hasConflictCallback = (typeof conflictCallback == FUNCTION);
+			while (i--) {
+				entry = entries[i];
+				key = entry[0];
+				value = entry[1];
+
+				// Check for a conflict. The default behaviour is to overwrite the value for an existing key
+				if ( hasConflictCallback && (thisValue = that.get(key)) ) {
+					value = conflictCallback(key, thisValue, value);
+				}
+				that.put(key, value);
+			}
+		};
+
+		this.clone = function() {
+			var clone = new Hashtable(hashingFunctionParam, equalityFunctionParam);
+			clone.putAll(that);
+			return clone;
+		};
+	}
+
+	return Hashtable;
+})();/*jslint plusplus: true, vars: true, white: true, nomen: true, maxerr: 50, indent: 4 */
+
+var LLRBTree = {};
+
+// The code basically follows the structure of
+// https://github.com/kazu-yamamoto/llrbtree
+//
+// Mostly comes from the code in:
+//
+// https://github.com/kazu-yamamoto/llrbtree/blob/master/Data/RBTree/LL.hs
+//
+// as well as:
+//
+// https://github.com/kazu-yamamoto/llrbtree/blob/master/Data/RBTree/Internal.hs
+
+(function() {
+    'use strict';
+
+    // function declarations
+    var turnR, turnB;
+    var insert_, balanceL, balanceR, replaceX, remove_;
+    var removeLT, removeGT, removeEQ;
+    var isRed, isBlack, isBlackLeftBlack, isBlackLeftRed;
+    var hardMin;
+    var minimum, removeMin_;
+
+
+    // red and black colors.
+    var R = "R", B = "B";
+
+    // An rbtree is either a Leaf or a Node.
+
+    var Node = function(c, //h,
+                        l, x, r) {
+        this.c = c; // color: (U R B)
+        //this.h = h; // height: int
+        this.l = l; // left: rbtree
+        this.x = x; // x : element
+        this.r = r; // right: rbtree
+    };
+
+
+
+    var Leaf = function() {};
+    // WARNING: DO NOT CONSTRUCT ANY OTHER INSTANCES OF LEAF, OR BAD
+    // THINGS WILL HAPPEN.
+    var EMPTY = new Leaf();
+
+
+
+
+
+
+    var items_ = function(tree, elts) {
+        if (tree === EMPTY) { return; }
+        items_(tree.l, elts);
+        elts.push(tree.x);
+        items_(tree.r, elts);
+    };
+
+    var items = function(tree) {
+        var elts = [];
+        items_(tree, elts);
+        return elts;
+    };
+
+
+
+    // Either returns the element, or undefined if we hit a leaf.
+    var find = function(tree, x, cmp) {
+        while (true) {
+            if (tree === EMPTY) { return undefined; }
+            else {
+                var cmpval = cmp(x, tree.x);
+                if (cmpval < 0) {
+                    tree = tree.l;
+                } else if (cmpval > 0) {
+                    tree = tree.r;
+                } else {
+                    return tree.x;
+                }
+            }
+        }
+    };
+
+    var contains = function(tree, x, cmp) {
+        while (true) {
+            if (tree === EMPTY) { return false; }
+            else {
+                var cmpval = cmp(x, tree.x);
+                if (cmpval < 0) {
+                    tree = tree.l;
+                } else if (cmpval > 0) {
+                    tree = tree.r;
+                } else {
+                    return true;
+                }
+            }
+        }
+    };
+
+
+    var insert = function(tree, x, cmp) {
+        return turnB(insert_(tree, x, cmp));
+    };
+
+    insert_ = function(tree, x, cmp) {
+        var cmpval;
+        if (tree === EMPTY) {
+            return new Node(R, //1,
+                            EMPTY, x, EMPTY);
+        } else {
+            cmpval = cmp(x, tree.x);
+            if (cmpval < 0) {
+                return balanceL(tree.c,// tree.h, 
+                                insert_(tree.l, x, cmp), tree.x, tree.r);
+            } else if (cmpval > 0) {
+                return balanceR(tree.c,// tree.h,
+                                tree.l, tree.x, insert_(tree.r, x, cmp));
+            } else {
+                return replaceX(tree, x);
+            }
+        }
+    };
+
+    balanceL = function(c,// h,
+                        l, x, r) {
+        if (c === B &&
+            l !== EMPTY && l.c === R 
+            && l.l !== EMPTY && l.l.c === R) {
+            return new Node(R,// h+1,
+                            turnB(l.l), l.x, new Node(B, //h,
+                                                      l.r, x, r));
+        } else {
+            return new Node(c,// h,
+                            l, x, r);
+        }
+    };
+
+    balanceR = function(c,// h,
+                        l, x, r) {
+        if (c === B &&
+           l !== EMPTY && l.c === R &&
+           r !== EMPTY && r.c === R) {
+            return new Node(R,// h+1,
+                            turnB(l), x, turnB(r));
+        } else if (r !== EMPTY &&
+                  r.c === R) {
+            return new Node(c,// h,
+                            new Node(R,// r.h,
+                                     l, x, r.l), r.x, r.r);
+        } else {
+            return new Node(c,// h,
+                            l, x, r);
+        }
+    };
+
+
+    var remove = function(tree, x, cmp) {
+        var removed;
+        if (tree === EMPTY) { 
+            return tree; 
+        } else {
+            removed = remove_(turnR(tree), x, cmp);
+            if (removed === EMPTY) {
+                return removed;
+            } else {
+                return turnB(removed);
+            }
+        }
+    };
+
+    remove_ = function(tree, x, cmp) {
+        var cmpval;
+        if (tree === EMPTY) { 
+            return tree; 
+        } else {
+            cmpval = cmp(x, tree.x);
+            if (cmpval < 0) {
+                return removeLT(x, tree.c,// tree.h,
+                                tree.l, tree.x, tree.r, cmp);
+            } else if (cmpval > 0) { 
+                return removeGT(x, tree.c,// tree.h,
+                                tree.l, tree.x, tree.r, cmp);
+            } else {
+                return removeEQ(x, tree.c,// tree.h,
+                                tree.l, tree.x, tree.r, cmp);
+            }
+        }
+    };
+
+    removeLT = function(kx, c,// h,
+                        l, x, r, cmp) {
+        var isBB;
+        var isBR;
+        if (c === R) {
+            isBB = isBlackLeftBlack(l);
+            isBR = isBlackLeftRed(r);
+            if (isBB && isBR) {
+                return new Node(R,
+                                //h,
+                                new Node(B,// r.h,
+                                         remove_(turnR(l), kx, cmp), x, r.l.l),
+                                r.l.x,
+                                new Node(B,// r.h,
+                                         r.l.r, r.x, r.r));
+            } else if (isBB) {
+                return balanceR(B,// h-1,
+                                remove_(turnR(l), kx, cmp), x, turnR(r));
+            }
+        }
+        return new Node(c,// h,
+                        remove_(l, kx, cmp), x,  r);
+    };
+
+
+    removeGT = function(kx, c,// h,
+                        l, x, r, cmp) {
+        var isBB, isBR;
+        if (l !== EMPTY && l.c === R) {
+            return balanceR(c,// h,
+                            l.l, l.x, remove_(new Node(R,// h,
+                                                             l.r, x, r), kx, cmp));
+        }
+        if (c === R) {
+            isBB = isBlackLeftBlack(r);
+            isBR = isBlackLeftRed(l);
+            if (isBB && isBR) {
+                return new Node(R, 
+                                //h,
+                                turnB(l.l), 
+                                l.x, 
+                                balanceR(B,// l.h,
+                                         l.r, x, remove_(turnR(r), kx, cmp)));
+            } 
+            if (isBB) {
+                return balanceR(B,// h-1,
+                                turnR(l), x, remove_(turnR(r), kx, cmp));
+            }
+        }
+        if (c === R) {
+            return new Node(R,// h,
+                            l, x, remove_(r, kx, cmp));
+        }
+        throw new Error("removeGT");
+    };
+
+    removeEQ = function(kx, c,// h,
+                        l, x, r, cmp) {
+        var isBB, isBR, m;
+        if (c === R && l === EMPTY && r === EMPTY) {
+            return EMPTY;
+        }
+        if (l !== EMPTY && l.c === R) {
+            return balanceR(c,// h,
+                            l.l, l.x, remove_(new Node(R,// h,
+                                                             l.r, x, r), kx, cmp));
+        }
+        if (c === R) {
+            isBB = isBlackLeftBlack(r);
+            isBR = isBlackLeftRed(l);
+            if (isBB && isBR) {
+                m = minimum(r);
+                return balanceR(R,// h,
+                                turnB(l.l), l.x, balanceR(B,// l.h,
+                                                          l.r, m, removeMin_(turnR(r))));
+            }
+            if (isBB) {
+                m = minimum(r);
+                return balanceR(B,// h-1,
+                                turnR(l), m, removeMin_(turnR(r)));
+            }
+        }
+        if (c === R &&
+            r !== EMPTY && r.c === B) {
+            m = minimum(r);
+            return new Node(R,// h,
+                            l, m, new Node(B,// r.h,
+                                           removeMin_(r.l), r.x, r.r));
+        }
+        throw new Error("removeEQ");
+    };
+
+
+    removeMin_ = function(t) {
+        // var h;
+        var l, x, r, isBB, isBR;
+        if (t !== EMPTY && t.c === R && 
+            t.l === EMPTY && t.r === EMPTY) {
+            return EMPTY;
+        }
+        if (t !== EMPTY && t.c === R) {
+            //h = t.h;
+            l = t.l; x = t.x; r = t.r;
+            isBB = isBlackLeftBlack(l);
+            isBR = isBlackLeftRed(r);
+            if (isRed(l)) {
+                return new Node(R,// h,
+                                removeMin_(l), x, r);
+            } else if (isBB && isBR) {
+                return hardMin(t);
+            } else if (isBB) {
+                return balanceR(B,// h-1,
+                                removeMin_(turnR(l)), x, turnR(r));
+            } else {
+                return new Node(R,// h,
+                                new Node(B,// l.h,
+                                         removeMin_(l.l), l.x, l.r), x, r);
+            }
+        }
+        throw new Error("removeMin");
+    };
+
+
+    hardMin = function(t) {
+        if (t !== EMPTY && t.c === R &&
+            t.r !== EMPTY && t.r.c === B &&
+            t.r.l !== EMPTY && t.r.l.c === R) {
+            return new Node(R,
+                            //t.h, 
+                            new Node(B,// t.r.h,
+                                     removeMin_(turnR(t.l)), t.x, t.r.l.l), 
+                            t.r.l.x,
+                            new Node(B,// t.r.h,
+                                     t.r.l.r, t.r.x, t.r.r));
+        }
+        throw new Error("hardMin");
+    };
+
+
+
+    //////////////////////////////////////////////////////////////////////
+
+    // turnB: llrbtree -> llrbtree
+    turnB = function(tree) {
+        if (tree === EMPTY) { throw new Error("turnB"); }
+        return new Node(B, //tree.h,
+                        tree.l, tree.x, tree.r);
+    };
+
+    // turnR: llrbtree -> llrbtree
+    turnR = function(tree) {
+        if (tree === EMPTY) { throw new Error("turnR"); }
+        return new Node(R, //tree.h,
+                        tree.l, tree.x, tree.r);
+    };
+
+    // turnR: llrbtree x -> llrbtree
+    replaceX = function(tree, x) {
+        if (tree === EMPTY) { throw new Error("replaceElt"); }
+        return new Node(tree.c, //tree.h,
+                        tree.l, x, tree.r);
+    };
+
+    // isBlack: llrbtree -> boolean
+    isBlack = function(tree) {
+        if (tree === EMPTY) { return true; }
+        return tree.c === B;
+    };
+
+    // isRed: llrbtree -> boolean
+    isRed = function(tree) {
+        if (tree === EMPTY) { return false; }
+        return tree.c === R;
+    };
+
+    // isBlackLeftBlack: llrbtree -> boolean
+    isBlackLeftBlack = function(tree) {
+        if (tree !== EMPTY) {
+            if (tree.c === B) {
+                if (tree.l === EMPTY) {
+                    return true;
+                } else {
+                    return tree.l.c === B;
+                }
+            } else {
+                return false;
+            }
+        } else {
+            return false;
+        }
+    };
+
+
+    // isBlackLeftRed: llrbtree -> boolean
+    isBlackLeftRed = function(tree) {
+        if (tree !== EMPTY) {
+            if (tree.c === B) {
+                if (tree.l !== EMPTY) {
+                    return tree.l.c === R;
+                } else {
+                    return false;
+                }
+            } else {
+                return false;
+            }
+        } else {
+            return false;
+        }
+    };
+
+
+    // minimum: llrbtree -> X
+    // Returns the minimum element in the tree.
+    minimum = function(tree) {
+        if (tree === EMPTY) { throw new Error("minimum"); }
+        while(true) {
+            if (tree.l === EMPTY) { 
+                return tree.x;
+            }
+            tree = tree.l;
+        }
+    };
+
+
+
+    //////////////////////////////////////////////////////////////////////
+    // This Map makes it easier to use the llrbtree as an associative array.
+    // The nodes on the tree are key/value pairs, the comparator of which
+    // focuses only on the key portion of the pair.
+    
+    var Map = function(cmp, tree) {
+        this.cmp = cmp;
+        this.tree = tree;
+    };
+
+    var makeMap = function(keycmp) {
+        keycmp = keycmp || function(x, y) { var sx = String(x), sy = String(y);
+                                            if (sx < sy) { return -1; }
+                                            if (sx > sy) { return 1; }
+                                            return 0; };
+        return new Map(
+            function(n1, n2) {
+                return keycmp(n1[0], n2[0]);
+            },
+            EMPTY);
+    };
+
+    Map.prototype.put = function(key, val) {
+        return new Map(this.cmp,
+                       insert(this.tree, [key, val], this.cmp));
+    };
+
+    Map.prototype.contains = function(key) {
+        return contains(this.tree, [key, undefined], this.cmp);
+    };
+
+    var defaultOnFail = function() { 
+        throw new Error("lookup failed"); 
+    }; 
+
+    Map.prototype.get = function(key, onFail) {
+        var x;
+        onFail = onFail || defaultOnFail;
+        x = find(this.tree, [key, undefined], this.cmp);
+        if (x === undefined) { return onFail(); }
+        return x[1];
+    };
+
+    Map.prototype.remove = function(key) {
+        return new Map(this.cmp,
+                       remove(this.tree, [key, undefined], this.cmp));
+    };
+
+    Map.prototype.isEmpty = function() {
+        return this.tree === EMPTY;
+    };
+
+    Map.prototype.keys = function() {
+        var result = items(this.tree), i;
+        for (i = 0; i < result.length; i++) {
+            result[i] = result[i][0];
+        }
+        return result;
+    };
+
+    Map.prototype.values = function() {
+        var result = items(this.tree), i;
+        for (i = 0; i < result.length; i++) {
+            result[i] = result[i][1];
+        }
+        return result;
+    };
+
+    Map.prototype.items = function() {
+        var result = items(this.tree), i;
+        for (i = 0; i < result.length; i++) {
+            // Make sure to copy so that you can't damage the internal
+            // key/value pairs.
+            result[i] = result[i].slice(0);
+        }
+        return result;
+    };
+
+    // Return the color at the tree.
+    Map.prototype.color = function() {
+        if (this.tree === EMPTY) { return B; }
+        return this.tree.c;
+    };
+
+    // Navigate left
+    Map.prototype.left = function() {
+        if (this.tree === EMPTY) { throw new Error("left"); }
+        return new Map(this.cmp, this.tree.l);
+    };
+
+    // Navigate right
+    Map.prototype.right = function() {
+        if (this.tree === EMPTY) { throw new Error("right"); }
+        return new Map(this.cmp, this.tree.r);
+    };
+
+    // Get the key at the tree
+    Map.prototype.key = function() {
+        if (this.tree === EMPTY) { throw new Error("key"); }
+        return this.tree.x[0];
+    };
+
+    // Get the value at the tree.
+    Map.prototype.val = function() {
+        if (this.tree === EMPTY) { throw new Error("val"); }
+        return this.tree.x[1];
+    };
+
+
+
+
+
+    //////////////////////////////////////////////////////////////////////
+    LLRBTree.EMPTY = EMPTY;
+    LLRBTree.insert = insert;
+    LLRBTree.contains = contains;
+    LLRBTree.find = find;
+    LLRBTree.remove = remove;
+    LLRBTree.items = items;
+
+
+    LLRBTree.makeMap = makeMap;
+}());/*jslint unparam: true, vars: true, white: true, newcap: true, nomen: true, plusplus: true, maxerr: 50, indent: 4 */
+
+/*global window,Hashtable*/
+
+// Mutable hashtables.
+
+
+(function (baselib, Hashtable) {
+    'use strict';
+    var exports = {};
+
+    baselib.hashes = exports;
+
+
+    
+    var _eqHashCodeCounter = 0;
+    var makeEqHashCode = function () {
+        _eqHashCodeCounter++;
+        return String(_eqHashCodeCounter);
+    };
+
+
+    // getEqHashCode: any -> string
+    // Given a value, produces a hashcode appropriate for eq.
+    var getEqHashCode = function (x) {
+        if (typeof (x) === 'string') {
+            return x;
+        }
+        if (typeof (x) === 'number') {
+            return String(x);
+        }
+        if (x && !x._eqHashCode) {
+            x._eqHashCode = makeEqHashCode();
+        }
+        if (x && x._eqHashCode) {
+            return x._eqHashCode;
+        }
+        return '';
+    };
+
+
+    // getEqvHashCode: any -> string
+    var getEqvHashCode = function (x) {
+        if (baselib.numbers.isNumber(x)) {
+            return baselib.numbers.toFixnum(x);
+        }
+        if (baselib.chars.isChar(x)) {
+            return x.val;
+        } 
+        return getEqHashCode(x);
+    };
+
+
+    var eq = function (x, y) { return x === y; };
+    var eqv = baselib.equality.eqv;
+    var equal = function (x, y) {
+        return baselib.equality.equals(x, y, new baselib.UnionFind()); 
+    };
+
+
+    // Creates a low-level hashtable, following the interface of 
+    // http://www.timdown.co.uk/jshashtable/
+    var makeLowLevelEqHash = function () {
+        return new Hashtable(getEqHashCode,
+                             function (x, y) { return x === y; });
+    };
+
+
+    var makeEqHashtable = function() { 
+        return new WhalesongHashtable(
+            "hasheq",
+            getEqHashCode,
+            eq,
+            new Hashtable(getEqHashCode, eq));
+    };
+
+    var makeEqualHashtable = function() {
+        return new WhalesongHashtable(
+            "hash",
+            getEqualHashCode,
+            equal,
+            new Hashtable(getEqualHashCode, equal));
+    };
+    
+    
+    var makeEqvHashtable = function() {
+        return new WhalesongHashtable(
+            "hasheqv",
+            getEqvHashCode,
+            eqv,
+            new Hashtable(getEqvHashCode, eqv));
+    };
+
+
+    var makeImmutableEqHashtable = function() { 
+        return makeEqHashtable().toImmutable();
+    };
+
+    var makeImmutableEqualHashtable = function() {
+        return makeEqualHashtable().toImmutable();
+    };
+        
+    var makeImmutableEqvHashtable = function() {
+        return makeEqvHashtable().toImmutable();
+    };
+
+
+    // When we need to make comparators for the immutable hash tables, use this.
+    var makeComparator = function(hash, eq) {
+        return function(x, y) {
+            var hx = hash(x), hy = hash(y);
+            if (hx < hy) { return -1; }
+            if (hx > hy) { return 1; }
+            
+            if (eq(x, y)) { return 0; }
+
+            hx = getEqHashCode(x);
+            hy = getEqHashCode(y);
+            if (hx < hy) { return -1; }
+            if (hx > hy) { return 1; }
+            return 0;
+        }
+    };
+
+
+    //////////////////////////////////////////////////////////////////////
+    // Whalesong's Hashtables are a thin wrapper around the mutable Hashtable
+    // class to make it printable and equatable.
+    var WhalesongHashtable = function (type, hash_function, equality_function, hash) {
+        this.type = type;
+        this.hash_function = hash_function;
+        this.equality_function = equality_function;
+        this.hash = hash;
+    };
+
+    WhalesongHashtable.prototype.clone = function() {
+        return new WhalesongHashtable(this.type, this.hash_function, this.equality_function, this.hash.clone());
+    };
+
+    WhalesongHashtable.prototype.size = function() {
+        return this.hash.size();
+    };
+
+    WhalesongHashtable.prototype.toWrittenString = function (cache) {
+        var keys = this.hash.keys();
+        var ret = [], i;
+        for (i = 0; i < keys.length; i++) {
+            var keyStr = baselib.format.toWrittenString(keys[i], cache);
+            var valStr = baselib.format.toWrittenString(this.hash.get(keys[i]), cache);
+            ret.push('(' + keyStr + ' . ' + valStr + ')');
+        }
+        return ('#' + this.type + '(' + ret.join(' ') + ')');
+    };
+    
+    WhalesongHashtable.prototype.toDisplayedString = function (cache) {
+        var keys = this.hash.keys();
+        var ret = [], i;
+        for (i = 0; i < keys.length; i++) {
+            var keyStr = baselib.format.toDisplayedString(keys[i], cache);
+            var valStr = baselib.format.toDisplayedString(this.hash.get(keys[i]), cache);
+            ret.push('(' + keyStr + ' . ' + valStr + ')');
+        }
+        return ('#' + this.type + '(' + ret.join(' ') + ')');
+    };
+
+    WhalesongHashtable.prototype.keys = function() {
+        return this.hash.keys();
+    };
+
+    WhalesongHashtable.prototype.values = function() {
+        return this.hash.values();
+    };
+
+
+    WhalesongHashtable.prototype.equals = function (other, aUnionFind) {
+        if (!(other instanceof WhalesongHashtable)) {
+            return false; 
+        }
+        if (other.type !== this.type) { 
+            return false;
+        }
+        if (this.hash.keys().length !== other.hash.keys().length) { 
+            return false;
+        }
+
+        var keys = this.hash.keys(), i;
+        for (i = 0; i < keys.length; i++) {
+            if (!(other.hash.containsKey(keys[i]) &&
+                  baselib.equality.equals(this.hash.get(keys[i]),
+                                          other.hash.get(keys[i]),
+                                          aUnionFind))) {
+                return false;
+            }
+        }
+        return true;
+    };
+
+    WhalesongHashtable.prototype.hashCode = function(depth) {
+        var k = getEqualHashCode(this.type);
+        var keys = this.hash.keys(), i;
+        for (i = 0; i < keys.length; i++) {
+            k += hashMix(getEqualHashCode(this.hash.get(keys[i]), depth));
+        }
+        return hashMix(k);
+    };
+
+
+    WhalesongHashtable.prototype.get = function(key) {
+        return this.hash.get(key);
+    };
+
+    WhalesongHashtable.prototype.put = function(key, value) {
+        this.hash.put(key, value);
+    };
+
+    WhalesongHashtable.prototype.functionalPut = function(key, value) {
+        return this.toImmutable().functionalPut(key, value);
+    };
+
+    WhalesongHashtable.prototype.remove = function(key) {
+        this.hash.remove(key);
+    };
+
+    WhalesongHashtable.prototype.functionalRemove = function(key) {
+        return this.toImmutable().functionalRemove(key);
+    };
+
+    WhalesongHashtable.prototype.containsKey = function(key) {
+        return this.hash.containsKey(key);
+    };
+
+    WhalesongHashtable.prototype.isImmutable = function() {
+        return false;
+    };
+
+    WhalesongHashtable.prototype.toImmutable = function() {
+        var keycmp = makeComparator(this.hash_function, this.equality_function)
+        var immutable = new WhalesongImmutableHashtable(
+            this.type,
+            this.hash_function,
+            this.equality_function,
+            LLRBTree.makeMap(keycmp));
+        var keys = this.hash.keys();
+        var i;
+        for (i = 0; i < keys.length; i++) {
+            immutable = immutable.functionalPut(keys[i], this.hash.get(keys[i]));
+        }
+        return immutable;
+    };
+
+
+    //////////////////////////////////////////////////////////////////////
+    //////////////////////////////////////////////////////////////////////
+    // Whalesong's immutable hashtables are a thin wrapper around the
+    // llrbtree class to make it printable and equatable.
+    // llrbtree comes from: https://github.com/dyoo/js-llrbtree
+    var WhalesongImmutableHashtable = function (type,
+                                                hash_function,
+                                                equality_function,
+                                                map) {
+        this.type = type;
+        this.hash_function = hash_function;
+        this.equality_function = equality_function;
+        this.map = map;
+    };
+
+    WhalesongImmutableHashtable.prototype.size = function() {
+        return this.map.items().length;
+    };
+
+
+    WhalesongImmutableHashtable.prototype.toWrittenString = function (cache) {
+        var items = this.map.items();
+        var ret = [], i;
+        for (i = 0; i < items.length; i++) {
+            var keyStr = baselib.format.toWrittenString(items[i][0], cache);
+            var valStr = baselib.format.toWrittenString(items[i][1], cache);
+            ret.push('(' + keyStr + ' . ' + valStr + ')');
+        }
+        return ('#' + this.type + '(' + ret.join(' ') + ')');
+    };
+    
+    WhalesongImmutableHashtable.prototype.toDisplayedString = function (cache) {
+        var items = this.map.keys();
+        var ret = [], i;
+        for (i = 0; i < items.length; i++) {
+            var keyStr = baselib.format.toDisplayedString(items[i][0], cache);
+            var valStr = baselib.format.toDisplayedString(items[i][1], cache);
+            ret.push('(' + keyStr + ' . ' + valStr + ')');
+        }
+        return ('#' + this.type + '(' + ret.join(' ') + ')');
+    };
+
+    WhalesongImmutableHashtable.prototype.keys = function() {
+        return this.map.keys();
+    };
+
+    WhalesongImmutableHashtable.prototype.values = function() {
+        return this.map.values();
+    };
+
+    WhalesongImmutableHashtable.prototype.equals = function (other, aUnionFind) {
+        if (!(other instanceof WhalesongImmutableHashtable)) {
+            return false; 
+        }
+        if (other.type !== this.type) { 
+            return false;
+        }
+        var litems = this.map.items();
+        var ritems = other.map.items();
+
+        if (litems.length !== ritems.length) { 
+            return false;
+        }
+        var i;
+        for (i = 0; i < litems.length; i++) {
+            if (!(baselib.equality.equals(litems[i][0], ritems[i][0], aUnionFind))) {
+                return false;
+            }
+            if (!(baselib.equality.equals(litems[i][1], ritems[i][1], aUnionFind))) {
+                return false;
+            }
+        }
+        return true;
+    };
+
+    WhalesongImmutableHashtable.prototype.hashCode = function(depth) {
+        var k = getEqualHashCode(this.type);
+        var items = this.map.items(), i;
+        for (i = 0; i < items.length; i++) {
+            k = getEqualHashCode(items[i][0], depth);
+            k = hashMix(k);
+            k = getEqualHashCode(items[i][1], depth);
+            k = hashMix(k);
+        }
+        return hashMix(k);
+    };
+
+
+    WhalesongImmutableHashtable.prototype.get = function(key) {
+        return this.map.get(key);
+    };
+
+    WhalesongImmutableHashtable.prototype.put = function(key, value) {
+        throw new Error();
+    };
+
+    WhalesongImmutableHashtable.prototype.functionalPut = function(key, value) {
+        return new WhalesongImmutableHashtable(this.type,
+                                               this.hash_function,
+                                               this.equality_function,
+                                               this.map.put(key, value));
+    };
+
+    WhalesongImmutableHashtable.prototype.remove = function(key) {
+        throw new Error();
+    };
+
+    WhalesongImmutableHashtable.prototype.functionalRemove = function(key) {
+        return new WhalesongImmutableHashtable(this.type,
+                                               this.hash_function,
+                                               this.equality_function,
+                                               this.map.remove(key));
+    };
+
+    WhalesongImmutableHashtable.prototype.containsKey = function(key) {
+        return this.map.contains(key);
+    };
+
+    WhalesongImmutableHashtable.prototype.isImmutable = function() { 
+        return true;
+    };
+    //////////////////////////////////////////////////////////////////////    
+
+
+
+    var isHash = function (x) { 
+        return (x instanceof WhalesongHashtable || x instanceof WhalesongImmutableHashtable);
+    };
+
+    var isHashEqual = function (x) { 
+        return (x instanceof WhalesongHashtable || x instanceof WhalesongImmutableHashtable) && x.type === 'hash';
+    };
+
+    var isHashEqv = function (x) { 
+        return (x instanceof WhalesongHashtable || x instanceof WhalesongImmutableHashtable) && x.type === 'hasheqv';
+    };
+
+    var isHashEq = function (x) { 
+        return (x instanceof WhalesongHashtable || x instanceof WhalesongImmutableHashtable) && x.type === 'hasheq';
+    };
+
+
+
+    // Arbitrary magic number.  We have to cut off the hashing at some point.
+    var MAX_HASH_DEPTH = 128;
+
+    // Returns a JavaScript number.
+    var getEqualHashCode = function (x, depth) {
+        var i, t, k = 0;
+        if (depth === void(0)) { depth = [0]; }
+
+        if (depth[0] > MAX_HASH_DEPTH) { return 0; }
+
+        if (baselib.numbers.isNumber(x)) {
+            return hashMix(baselib.numbers.toFixnum(x));
+        }
+
+        if (baselib.strings.isString(x)) {
+            t = x.toString();
+            for (i = 0; i < t.length; i++) {
+                k += t.charCodeAt(i);
+                k = hashMix(k);
+            }
+            return k;
+        }
+
+        if (x === void(0) || x === null) {
+            return 1;
+        }
+
+        if (typeof(x) === 'object' &&
+            typeof(x.hashCode) === 'function') {
+            depth[0] = depth[0] + 1;
+            return x.hashCode(depth);
+        }
+        return 0;
+    };
+
+
+    // Does some weird math on k.  Grabbed from Racket's implementation of hashes.
+    // References to: http://www.burtleburtle.net/bob/hash/doobs.html
+    var hashMix = function(k) {
+        k += (k << 10);
+        k ^= (k >> 6);
+        return k;
+    };
+
+
+
+    //////////////////////////////////////////////////////////////////////
+
+    exports.getEqHashCode = getEqHashCode;
+    exports.getEqualHashCode = getEqualHashCode;
+    exports.getEqvHashCode = getEqvHashCode;
+
+    exports.hashMix = hashMix;
+
+    exports.makeEqHashCode = makeEqHashCode;
+    exports.makeLowLevelEqHash = makeLowLevelEqHash;
+
+    exports.makeEqHashtable = makeEqHashtable;
+    exports.makeEqvHashtable = makeEqvHashtable;
+    exports.makeEqualHashtable = makeEqualHashtable;
+
+    exports.makeImmutableEqHashtable = makeImmutableEqHashtable;
+    exports.makeImmutableEqvHashtable = makeImmutableEqvHashtable;
+    exports.makeImmutableEqualHashtable = makeImmutableEqualHashtable;
+
+    exports.isHash = isHash;
+
+    exports.isHashEqual = isHashEqual;
+    exports.isHashEqv = isHashEqv;
+    exports.isHashEq = isHashEq;
+}(window.plt.baselib, Hashtable));}());
+/*jslint vars: true, maxerr: 50, indent: 4 */
+
+(function (baselib) {
+    'use strict';
+    var exports = {};
+    baselib.regexps = exports;
+
+
+    // Regular expressions.
+
+    var RegularExpression = function (pattern) {
+        this.pattern = pattern;
+    };
+
+
+    var ByteRegularExpression = function (pattern) {
+        this.pattern = pattern;
+    };
+
+    //////////////////////////////////////////////////////////////////////
+
+    exports.RegularExpression = RegularExpression;
+    exports.ByteRegularExpression = ByteRegularExpression;
+
+}(this.plt.baselib));/*jslint vars: true, maxerr: 50, indent: 4 */
+
+
+(function (baselib) {
+    'use strict';
+    var exports = {};
+    baselib.paths = exports;
+
+    // Paths
+
+    var Path = function (p) {
+        this.path = p;
+    };
+
+    Path.prototype.toString = function () {
+        return "#<path:" + String(this.path) + ">";
+    };
+
+
+    Path.prototype.equals = function(other, aUnionFind) {
+        return (other instanceof Path &&
+                this.path === other.path);
+    };
+
+    Path.prototype.hashCode = function(depth) {
+        var k = baselib.hashes.getEqualHashCode("path");
+        k += baselib.hashes.getEqualHashCode(this.path, depth);
+        k = baselib.hashes.hashMix(k);
+        return k;
+    };
+
+
+    //////////////////////////////////////////////////////////////////////
+
+    var makePath = function (p) {
+        return new Path(p);
+    };
+
+    var isPath = baselib.makeClassPredicate(Path);
+
+
+
+    exports.Path = Path;
+    exports.makePath = makePath;
+    exports.isPath = isPath;
+
+}(this.plt.baselib));/*jslint browser: true, unparam: true, vars: true, white: true, plusplus: true, maxerr: 50, indent: 4 */
+
+
+// Exceptions
+
+(function(baselib, $) {
+    'use strict';
+    var exports = {};
+    baselib.boxes = exports;
+
+
+    //////////////////////////////////////////////////////////////////////
+    // Boxes
+    
+    var Box = function(x, mutable) {
+	this.val = x;
+	this.mutable = mutable;
+    };
+
+    Box.prototype.ref = function() {
+        return this.val;
+    };
+
+    Box.prototype.set = function(newVal) {
+        if (this.mutable) {
+	    this.val = newVal;
+        }
+    };
+
+    Box.prototype.toString = function(cache) {
+        cache.put(this, true);
+        return "#&" + baselib.format.toWrittenString(this.val, cache);
+    };
+
+    Box.prototype.toWrittenString = function(cache) {
+        cache.put(this, true);
+        return "#&" + baselib.format.toWrittenString(this.val, cache);
+    };
+
+    Box.prototype.toDisplayedString = function(cache) {
+        cache.put(this, true);
+        return "#&" + baselib.format.toDisplayedString(this.val, cache);
+    };
+
+    Box.prototype.toDomNode = function(params) {
+        var node = $('<span/>');
+        if (params.getMode() === 'constructor') {
+            node.append($('<span/>').text('(').addClass('lParen'));
+            node.append($('<span/>').text('box'));
+            node.append(" ");
+            node.append(params.recur(this.val));
+            node.append($('<span/>').text(')').addClass('rParen'));
+        } else {
+            node.append($('<span/>').text('#&'));
+            node.append(params.recur(this.val));
+        }
+        return node.get(0);
+    };
+
+    Box.prototype.equals = function(other, aUnionFind) {
+        return ((other instanceof Box) &&
+	        baselib.equality.equals(this.val, other.val, aUnionFind));
+    };
+
+    Box.prototype.hashCode = function(depth) {
+        var k = baselib.hashes.getEqualHashCode("Box");
+        k = baselib.hashes.hashMix(k);
+        k += baselib.hashes.getEqualHashCode(this.val, depth);
+        k = baselib.hashes.hashMix(k);
+        return k;
+    };
+
+    
+    var makeBox = function(x) { 
+        return new Box(x, true); 
+    };
+
+    var makeImmutableBox = function(x) {
+        return new Box(x, false); 
+    };
+
+    var isBox = function(x) {
+        return x instanceof Box;
+    };
+
+    var isMutableBox = function(x) { 
+        return (x instanceof Box && x.mutable); 
+    };
+
+    var isImmutableBox = function(x) { 
+        return (x instanceof Box && (!x.mutable));
+    };
+
+
+
+
+    //////////////////////////////////////////////////////////////////////
+    exports.Box = Box;
+    exports.isBox = isBox;
+    exports.isMutableBox = isMutableBox;
+    exports.isImmutableBox = isImmutableBox;
+    exports.makeBox = makeBox;
+    exports.makeImmutableBox = makeImmutableBox;
+
+
+}(this.plt.baselib, jQuery));
+// Placeholders
+/*jslint browser: true, unparam: true, vars: true, maxerr: 50, indent: 4 */
+(function (baselib) {
+    'use strict';
+    var exports = {};
+    baselib.placeholders = exports;
+
+
+    // Placeholders: same thing as boxes.  Distinct type just to support make-reader-graph.
+
+    var Placeholder = function (x, mutable) {
+        this.val = x;
+    };
+
+    Placeholder.prototype.ref = function () {
+        return this.val;
+    };
+
+    Placeholder.prototype.set = function (newVal) {
+        this.val = newVal;
+    };
+
+    Placeholder.prototype.toString = function (cache) {
+        return "#<placeholder>";
+    };
+
+    Placeholder.prototype.toWrittenString = function (cache) {
+        return "#<placeholder>";
+    };
+
+    Placeholder.prototype.toDisplayedString = function (cache) {
+        return "#<placeholder>";
+    };
+
+    Placeholder.prototype.toDomNode = function (cache) {
+        var parent = document.createElement("span");
+        parent.appendChild(document.createTextNode('#<placeholder>'));
+        return parent;
+    };
+
+    Placeholder.prototype.equals = function (other, aUnionFind) {
+        return ((other instanceof Placeholder) &&
+                baselib.equality.equals(this.val, other.val, aUnionFind));
+    };
+
+    Placeholder.prototype.hashCode = function(depth) {
+        var k = baselib.hashes.hashCode("Placeholder");
+        k += baselib.hashes.hashCode(this.val, depth);
+        return baselib.hashes.hashMix(k);
+    };
+
+
+    var makePlaceholder = function(v) {
+        return new Placeholder(v);
+    };
+
+    var isPlaceholder = function (x) { 
+        return x instanceof Placeholder; 
+    };
+    
+
+
+    //////////////////////////////////////////////////////////////////////
+    exports.Placeholder = Placeholder;
+    exports.makePlaceholder = makePlaceholder;
+    exports.isPlaceholder = isPlaceholder;
+
+
+
+}(this.plt.baselib));/*jslint unparam: true, vars: true, maxerr: 50, indent: 4 */
+
+// Keywords
+
+(function (baselib) {
+    'use strict';
+    var exports = {};
+    baselib.keywords = exports;
+
+
+    var Keyword = function (val) {
+        this.val = val;
+    };
+
+    var keywordCache = {};
+
+    var hasOwnProperty = {}.hasOwnProperty;
+    
+    // makeInstance: string -> Keyword.
+    Keyword.makeInstance = function (val) {
+        // To ensure that we can eq? symbols with equal values.
+        if (!(hasOwnProperty.call(keywordCache, val))) {
+            keywordCache[val] = new Keyword(val);
+        }
+        return keywordCache[val];
+    };
+    
+    Keyword.prototype.equals = function (other, aUnionFind) {
+        return other instanceof Keyword &&
+            this.val === other.val;
+    };
+
+    Keyword.prototype.hashCode = function(depth) {
+        var k = baselib.hashes.getEqualHashCode("Keyword");
+        k += baselib.hashes.getEqualHashCode(this.val, depth);
+        k = baselib.hashes.hashMix(k);
+        return k;
+    };
+    
+
+    Keyword.prototype.toString = function (cache) {
+        return this.val;
+    };
+
+    Keyword.prototype.toWrittenString = function (cache) {
+        return this.val;
+    };
+
+    Keyword.prototype.toDisplayedString = function (cache) {
+        return this.val;
+    };
+
+
+    exports.Keyword = Keyword;
+
+}(this.plt.baselib));/*jslint browser: true, unparam: true, vars: true, white: true, nomen: true, plusplus: true, maxerr: 50, indent: 4 */
+/*globals $*/
+(function (baselib, $) {
+    "use strict";
+    var exports = {};
+    baselib.structs = exports;
+
+
+
+    //////////////////////////////////////////////////////////////////////
+
+    var Struct = function (constructorName, fields, structType) {
+        this._constructorName = constructorName; // Symbol
+        this._fields = [];
+        this.structType = structType;
+    };
+
+    Struct.prototype.toWrittenString = function (cache) { 
+        var buffer = [], i;
+        cache.put(this, true);
+        buffer.push("(");
+        buffer.push(this._constructorName);
+        for(i = 0; i < this._fields.length; i++) {
+            buffer.push(" ");
+            buffer.push(baselib.format.toWrittenString(this._fields[i], cache));
+        }
+        buffer.push(")");
+        return buffer.join("");
+    };
+
+    Struct.prototype.toDisplayedString = function (cache) {
+        return baselib.format.toWrittenString(this, cache); 
+    };
+
+    Struct.prototype.toDomNode = function (params) {
+        var node = $('<span/>');
+        var i;
+        node.append($('<span/>').text("(").addClass('lParen'));
+        node.append($('<span/>').text(this._constructorName+''));
+        for(i = 0; i < this._fields.length; i++) {
+            node.append(" ");
+            node.append(params.recur(this._fields[i]));
+        }
+        node.append($('<span/>').text(")").addClass('rParen'));
+        return node.get(0);
+    };
+
+
+    Struct.prototype.equals = function (other, aUnionFind) {
+        var i;
+        if (!(other instanceof this.type)) {
+            return false;
+        }
+        for (i = 0; i < this._fields.length; i++) {
+            if (! baselib.equality.equals(this._fields[i],
+                                          other._fields[i],
+                                          aUnionFind)) {
+                return false;
+            }
+        }
+        return true;
+    };
+
+    Struct.prototype.hashCode = function(depth) {
+        var k = baselib.hashes.getEqualHashCode(this.name);
+        var i;
+        k = baselib.hashes.hashMix(k);
+        for (i = 0; i < this._fields.length; i++) {
+            k += baselib.hashes.getEqualHashCode(this._fields[i], depth);
+            k = baselib.hashes.hashMix(k);
+        }
+        return k;
+    };
+
+
+    Struct.prototype.type = Struct;
+
+
+    //////////////////////////////////////////////////////////////////////
+
+
+    var StructType = function (name,             // string
+                               type,             // StructType
+                               numberOfArgs,     // number
+                               numberOfFields,   // number
+                               firstField,
+                               applyGuard,
+                               constructor,
+                               predicate, 
+                               accessor,
+                               mutator,
+                               propertiesList) {
+        this.name = name;
+        this.type = type;
+        this.numberOfArgs = numberOfArgs;
+        this.numberOfFields = numberOfFields;
+        this.firstField = firstField;
+
+        this.applyGuard = applyGuard;
+        this.constructor = constructor;
+        this.predicate = predicate;
+        this.accessor = accessor;
+        this.mutator = mutator;
+        this.propertiesList = propertiesList;
+    };
+
+
+    StructType.prototype.toString = function (cache) {
+        return '#<struct-type:' + this.name + '>';
+    };
+
+
+    StructType.prototype.equals = function (other, aUnionFind) {
+        return this === other;
+    };
+
+    StructType.prototype.hashCode = function(depth) {
+        var k = baselib.hashes.getEqualHashCode("StructType");
+        k = baselib.hashes.hashMix(k);
+        k += baselib.hashes.getEqualHashCode(this.name);
+        k = baselib.hashes.hashMix(k);
+        return k;
+    };
+
+
+
+
+    // guard-function: array string (array -> value)
+
+
+
+
+
+    // Default structure guard just calls the continuation argument.
+    var DEFAULT_GUARD = function (args, name, k) { 
+        return k(args); 
+    };
+
+
+    // The default parent type refers to the toplevel Struct.
+    var DEFAULT_PARENT_TYPE = { type: Struct,
+                                numberOfArgs: 0,
+                                numberOfFields: 0,
+                                firstField: 0,
+                                applyGuard: DEFAULT_GUARD };
+
+
+
+    // makeStructureType: string StructType number number boolean
+    //                    guard-function -> StructType
+    //
+    // Creates a new structure type.
+
+    var makeStructureType = function (theName,
+                                      parentType, 
+                                      initFieldCnt, 
+                                      autoFieldCnt, 
+                                      autoV, 
+                                      guard,
+                                      propertiesList) {
+
+
+        // Defaults
+        autoFieldCnt = autoFieldCnt || 0;
+        parentType = parentType || DEFAULT_PARENT_TYPE;
+        guard = guard || DEFAULT_GUARD;
+
+
+        // RawConstructor creates a new struct type inheriting from
+        // the parent, with no guard checks.
+        var RawConstructor = function (name, args, structType) {
+            var i;
+            parentType.type.call(this, name, args, structType);
+            for (i = 0; i < initFieldCnt; i++) {
+                this._fields.push(args[i+parentType.numberOfArgs]);
+            }
+            for (i = 0; i < autoFieldCnt; i++) {
+                this._fields.push(autoV);
+            }
+        };
+        RawConstructor.prototype = baselib.heir(parentType.type.prototype);
+
+        var theNameSymbol = 
+            baselib.symbols.makeSymbol(theName);
+
+        // Set type, necessary for equality checking
+        RawConstructor.prototype.type = RawConstructor;
+
+
+        var constructAfterGuard =  function (res) { 
+            return new RawConstructor(theName, res, newType); 
+        };
+
+        // The structure type consists of the name, its constructor, a
+        // record of how many argument it and its parent type contains,
+        // the list of autofields, the guard, and functions corresponding
+        // to the constructor, the predicate, the accessor, and mutators.
+        var newType = new StructType(
+            theName,
+            RawConstructor,
+            initFieldCnt + parentType.numberOfArgs,
+            initFieldCnt + autoFieldCnt,
+            parentType.firstField + parentType.numberOfFields,
+            function (args, name, k) {
+                return guard(args, name,
+                             function (result) {
+                                 var parentArgs = result.slice(0, parentType.numberOfArgs);
+                                 var restArgs = result.slice(parentType.numberOfArgs);
+                                 return parentType.applyGuard(
+                                     parentArgs, name,
+                                     function (parentRes) {
+                                         return k( parentRes.concat(restArgs) ); });
+                             });
+            },
+            // constructor
+            function (args) {
+                return newType.applyGuard(
+                    args,
+                    theNameSymbol,
+                    constructAfterGuard);
+            },
+
+            // predicate
+            function (x) { 
+                return x instanceof RawConstructor; 
+            },
+
+            // accessor
+            function (x, i) { return x._fields[i + this.firstField]; },
+
+            // mutator
+            function (x, i, v) { x._fields[i + this.firstField] = v; },
+
+            // structure properties list
+            propertiesList);
+        return newType;
+    };
+
+
+
+
+    var StructTypeProperty = function(name, guards, supers) {
+        this.name = name;
+        this.guards = guards;
+        this.supers = supers;
+    };
+
+
+
+    // supportsStructureTypeProperty: StructType StructureTypeProperty -> boolean
+    // Produces true if the structure type provides a binding for the
+    // given structure property.
+    var supportsStructureTypeProperty = function(structType, property) {
+        var propertiesList = structType.propertiesList;
+        if (! propertiesList) {
+            return false;
+        }
+        while (propertiesList !== baselib.lists.EMPTY) {
+            if (propertiesList.first.first === property) {
+                return true;
+            }
+            propertiesList = propertiesList.rest;
+        }
+        return false;
+    };
+
+
+    // lookupStructureTypeProperty: StructType StructureTypeProperty -> any
+    // Returns the binding associated to this particular structure type propery.
+    var lookupStructureTypeProperty = function(structType, property) {
+        var propertiesList = structType.propertiesList;
+        if (! propertiesList) {
+            return void(0);
+        }
+        while (propertiesList !== baselib.lists.EMPTY) {
+            if (propertiesList.first.first === property) {
+                return propertiesList.first.rest;
+            }
+            propertiesList = propertiesList.rest;
+        }
+        return void(0);
+    };
+
+
+    // A structure type property for noting if an exception supports
+    var propExnSrcloc = new StructTypeProperty("prop:exn:srcloc");
+
+
+
+    var isStruct = baselib.makeClassPredicate(Struct);
+    var isStructType = baselib.makeClassPredicate(StructType);
+    var isStructTypeProperty = baselib.makeClassPredicate(StructTypeProperty);
+
+
+
+    //////////////////////////////////////////////////////////////////////
+
+
+    exports.StructType = StructType;
+    exports.Struct = Struct;
+    exports.makeStructureType = makeStructureType;
+
+    exports.StructTypeProperty = StructTypeProperty;
+    exports.supportsStructureTypeProperty = supportsStructureTypeProperty;
+    exports.lookupStructureTypeProperty = lookupStructureTypeProperty;
+
+    exports.propExnSrcloc = propExnSrcloc;
+
+    exports.isStruct = isStruct;
+    exports.isStructType = isStructType;
+    exports.isStructTypeProperty = isStructTypeProperty;
+}(this.plt.baselib, jQuery));
+/*jslint vars: true, white: true, plusplus: false, maxerr: 50, indent: 4 */
+(function(baselib) {
+    'use strict';
+
+    var exports = {};
+    baselib.srclocs = exports;
+
+    // (define-struct srcloc (source line column position span))
+    var srcloc = baselib.structs.makeStructureType(
+        'srcloc', false, 5, 0, false, false);
+    
+    var makeSrcloc = function() { 
+        var args = [].slice.call(arguments);
+        return srcloc.constructor(args);
+    };
+
+    var isSrcloc = srcloc.predicate;
+    var srclocSource = function(x) { return srcloc.accessor(x, 0); };
+    var srclocLine = function(x) { return srcloc.accessor(x, 1); };
+    var srclocColumn = function(x) { return srcloc.accessor(x, 2); };
+    var srclocPosition = function(x) { return srcloc.accessor(x, 3); };
+    var srclocSpan = function(x) { return srcloc.accessor(x, 4); };
+
+    //////////////////////////////////////////////////////////////////////
+    exports.makeSrcloc = makeSrcloc;
+    exports.isSrcloc = isSrcloc;
+    exports.srclocSource = srclocSource;
+    exports.srclocLine = srclocLine;
+    exports.srclocColumn = srclocColumn;
+    exports.srclocPosition = srclocPosition;
+    exports.srclocSpan = srclocSpan;
+
+}(this.plt.baselib));// Arity structure
+/*jslint unparam: true, sub: true, vars: true, maxerr: 50, indent: 4 */
+/*globals $*/
+(function (baselib, $) {
+    'use strict';
+    var exports = {};
+    baselib.ports = exports;
+
+
+    // Output Ports
+    var OutputPort = function () {};
+    var isOutputPort = baselib.makeClassPredicate(OutputPort);
+
+
+    var StandardOutputPort = function () {
+        OutputPort.call(this);
+    };
+    StandardOutputPort.prototype = baselib.heir(OutputPort.prototype);
+    StandardOutputPort.prototype.writeDomNode = function (MACHINE, domNode) {
+        MACHINE.params['currentDisplayer'](MACHINE, domNode);
+        $(domNode).trigger({type : 'afterAttach'});
+        $('*', domNode).trigger({type : 'afterAttach'});
+        // Force a trampoline to send control back to the browser
+        // for rendering.
+        MACHINE.cbt=0;
+    };
+
+    var StandardErrorPort = function () {
+        OutputPort.call(this);
+    };
+    StandardErrorPort.prototype = baselib.heir(OutputPort.prototype);
+    StandardErrorPort.prototype.writeDomNode = function (MACHINE, domNode) {
+        MACHINE.params['currentErrorDisplayer'](MACHINE, domNode);
+        $(domNode).trigger({type : 'afterAttach'});
+        $('*', domNode).trigger({type : 'afterAttach'});
+        // Force a trampoline to send control back to the browser
+        // for rendering.
+        MACHINE.cbt=0;
+    };
+
+
+
+
+
+    var OutputStringPort = function () {
+        this.buf = [];
+    };
+    OutputStringPort.prototype = baselib.heir(OutputPort.prototype);
+    OutputStringPort.prototype.writeDomNode = function (MACHINE, v) {
+        this.buf.push($(v).text());
+    };
+    OutputStringPort.prototype.getOutputString = function () {
+        return this.buf.join('');
+    };
+    var isOutputStringPort = baselib.makeClassPredicate(OutputStringPort);
+
+
+
+
+    // Input ports
+    // Input Ports need to provide two things:
+    //
+    // readByte:
+    // callWhenReady:
+
+    var InputPort = function () {};
+    InputPort.prototype.readByte = function(MACHINE) {
+        return baselib.constants.EOF_VALUE;
+    };
+    InputPort.prototype.callWhenReady = function(MACHINE, k) {
+        throw new Error("unimplemented");
+    };
+    var isInputPort = baselib.makeClassPredicate(InputPort);
+
+
+    var StandardInputPort = function() {
+        this.content = [];
+        this.closed = false;
+    };
+    StandardInputPort.prototype = baselib.heir(InputPort.prototype);
+
+    StandardInputPort.prototype.readByte = function(MACHINE) {
+        if (this.content.length !== 0) {
+            return this.content.shift();
+        }
+        return baselib.constants.EOF_VALUE;
+    };
+
+    StandardInputPort.prototype.callWhenReady = function(MACHINE, k) {
+        if (this.content.length > 0) {
+            return k();
+        }
+        if (this.closed) {
+            return k();
+        }
+        var that = this;
+        var textFieldDiv = $("<div>" +
+                             "  <input class='readline' type='text' size='80%'/>" +
+                             "  <input class='eofread' type='button' value='EOF'/>"+
+                             "</div>");
+        var readLine = textFieldDiv.find(".readline");
+        var eofRead = textFieldDiv.find(".eofread");
+        var cleanupAndContinue = function() {
+            readLine.unbind('keypress');
+            eofRead.unbind('click');
+            textFieldDiv.remove();
+            return k();
+        };
+
+        readLine.keypress(
+            function(e) {
+                var val, i;
+                // On return, send the text content into that.content;
+                if (e.which === 13) {
+                    e.stopPropagation();
+                    e.preventDefault();
+                    val = readLine.val();
+                    for (i = 0; i < val.length; i++) {
+                        that.content.push(val.charCodeAt(i));
+                    }
+                    that.content.push('\n'.charCodeAt(0));
+                    cleanupAndContinue();
+                }
+            });
+        eofRead.click(
+            function(e) {
+                e.stopPropagation();
+                e.preventDefault();
+                that.closed = true;
+                cleanupAndContinue();
+            });
+        MACHINE.params['currentDisplayer'](MACHINE, textFieldDiv.get(0));
+        readLine.focus();
+    };
+
+
+    //////////////////////////////////////////////////////////////////////
+    exports.OutputPort = OutputPort;
+    exports.isOutputPort = isOutputPort;
+    exports.StandardOutputPort = StandardOutputPort;
+    exports.StandardErrorPort = StandardErrorPort;
+    exports.OutputStringPort = OutputStringPort;
+    exports.isOutputStringPort = isOutputStringPort;
+
+    exports.InputPort = InputPort;
+    exports.isInputPort = isInputPort;
+    exports.StandardInputPort = StandardInputPort;
+
+
+}(this.plt.baselib, jQuery));
+/*jslint unparam: true, sub: true, vars: true, white: true, plusplus: true, maxerr: 50, indent: 4 */
+
+// Procedures
+
+// For historical reasons, this module is called 'functions' instead of 'procedures'.
+// This may change soon.
+
+/*global plt*/
+
+(function (baselib, plt) {
+    'use strict';
+    var exports = {};
+    baselib.functions = exports;
+    
+    // Procedure types: a procedure is either a Primitive or a Closure.
+
+    // A Primitive is a function that's expected to return.  It is not
+    // allowed to call into Closures.  Its caller is expected to pop off
+    // its argument stack space.
+    //
+
+
+
+
+
+
+    // A Closure is a function that takes on more responsibilities: it is
+    // responsible for popping off stack space before it finishes, and it
+    // is also explicitly responsible for continuing the computation by 
+    // popping off the control stack and doing the jump.  Because of this,
+    // closures can do pretty much anything to the machine.
+
+    // A closure consists of its free variables as well as a label
+    // into its text segment.
+    var Closure = function (label, arity, closedVals, displayName) {
+        this.label = label;              // (MACHINE -> void)
+        this.racketArity = arity;              // number
+        this.closedVals = closedVals;    // arrayof number
+        this.displayName = displayName;  // string
+    };
+
+
+    // Finalize the return from a closure.  This is a helper function
+    // for those who implement Closures by hand.
+    //
+    // If used in the body of a Closure, it must be in tail
+    // position.  This finishes the closure call, and does the following:
+    //
+    //     * Clears out the existing arguments off the stack frame
+    //     * Sets up the return value
+    //     * Jumps either to the single-value return point, or the multiple-value
+    //       return point.
+    //
+    // I'd personally love for this to be a macro and avoid the
+    // extra function call here.
+    var finalizeClosureCall = function (MACHINE) {
+        MACHINE.cbt--;
+        var returnArgs = [].slice.call(arguments, 1);
+
+        // clear out stack space
+        MACHINE.e.length -= MACHINE.a;
+
+        if (returnArgs.length === 1) {
+            MACHINE.v = returnArgs[0];
+            return MACHINE.c.pop().label(MACHINE);
+        } else if (returnArgs.length === 0) {
+            MACHINE.a = 0;
+            return (MACHINE.c.pop().label.mvr || plt.runtime.si_context_expected_1)(MACHINE);
+        } else {
+            MACHINE.a = returnArgs.length;
+            MACHINE.v = returnArgs.shift();
+            MACHINE.e.push.apply(MACHINE.e, returnArgs.reverse());
+            return (MACHINE.c.pop().label.mvr || plt.runtime.si_context_expected_1)(MACHINE);
+        }
+    };
+
+
+    var isClosure = function (x) {
+        return x instanceof Closure;
+    };
+
+
+    var isProcedure = function (x) {
+        return (typeof (x) === 'function' || x instanceof Closure);
+    };
+
+
+    var coerseClosureToJavaScript = function (v, MACHINE) {
+        var f = function (succ, fail) {
+            var args = [];
+            var i;
+            for (i = 0; i < arguments.length; i++) {
+                args.push(arguments[i]);
+            }
+
+            MACHINE.exclusiveLock.acquire(
+                "js-as-closure",
+                function(releaseLock) {
+                    var wrappedSucc = function() { 
+                        releaseLock(); 
+                        (succ || function () {}).apply(null, arguments); 
+                    };
+                    var wrappedFail = function(err) {
+                        (fail || function () {})(err);
+                    };
+                    if (!(baselib.arity.isArityMatching(v.racketArity, args.length - 2))) {
+                        var msg = baselib.format.format(
+                            "arity mismatch: ~s expected ~s argument(s) but received ~s",
+                            [v.displayName, v.racketArity, args.length - 2]);
+                        releaseLock();
+                        return wrappedFail(new baselib.exceptions.RacketError(
+                            msg,
+                            baselib.exceptions.makeExnFailContractArity(msg,
+                                                                        MACHINE.captureContinuationMarks())));
+                    }
+
+                    var oldVal = MACHINE.v;
+                    var oldArgcount = MACHINE.a;
+                    var oldProc = MACHINE.p;
+                    var oldErrorHandler = MACHINE.params['currentErrorHandler'];
+
+                    var afterGoodInvoke = function (MACHINE) { 
+                        plt.runtime.PAUSE(
+                            function (restart) {
+                                MACHINE.params['currentErrorHandler'] = oldErrorHandler;
+                                var returnValue = MACHINE.v;
+                                MACHINE.v = oldVal;
+                                MACHINE.a = oldArgcount;
+                                MACHINE.p = oldProc;
+                                wrappedSucc(returnValue);
+                            });
+                    };
+                    afterGoodInvoke.mvr = function (MACHINE) {
+                        plt.runtime.PAUSE(
+                            function (restart) {
+                                MACHINE.params['currentErrorHandler'] = oldErrorHandler;
+                                var returnValues = [MACHINE.v], i;
+                                for (i = 0; i < MACHINE.a - 1; i++) {
+                                    returnValues.push(MACHINE.e.pop());
+                                }
+                                MACHINE.v = oldVal;
+                                MACHINE.a = oldArgcount;
+                                MACHINE.p = oldProc;
+                                wrappedSucc.apply(null, returnValues);
+                            });
+                    };
+
+                    MACHINE.c.push(
+                        new baselib.frames.CallFrame(afterGoodInvoke, v));
+                    MACHINE.a = args.length - 2;
+                    var i;
+                    for (i = 0; i < args.length - 2; i++) {
+                        MACHINE.e.push(args[args.length - 1 - i]);
+                    }
+                    MACHINE.p = v;
+                    MACHINE.params['currentErrorHandler'] = function (MACHINE, e) {
+                        MACHINE.params['currentErrorHandler'] = oldErrorHandler;
+                        MACHINE.v = oldVal;
+                        MACHINE.a = oldArgcount;
+                        MACHINE.p = oldProc;
+                        // The lock is released by _trampoline in this case.
+                        wrappedFail(e);
+                    };
+
+                    MACHINE._trampoline(v.label, false, releaseLock);
+                });
+        };
+        return f;
+    };
+
+    // coerseToJavaScript: racket function -> JavaScript function
+    // Given a closure or primitive, produces an
+    // asynchronous JavaScript function.
+    // The function will run on the provided MACHINE.
+    //
+    // It assumes that it must begin its own trampoline.
+    var asJavaScriptFunction = function (v, MACHINE) {
+        MACHINE = MACHINE || plt.runtime.currentMachine;
+        if (isClosure(v)) {
+            return coerseClosureToJavaScript(v, MACHINE);
+        } else {
+            baselib.exceptions.raise(MACHINE,
+                                     baselib.exceptions.makeExnFailContract(
+                                         baselib.format.format(
+                                             "not a procedure: ~e",
+                                             [v]),
+                                         MACHINE.captureContinuationMarks()));
+        }
+    };
+
+
+    // internallCallDuringPause: call a Racket procedure and get its results.
+    // The use assumes the machine is in a running-but-paused state, where the
+    // lock is still in effect.  The lock will continue to be in effect
+    // after coming back from the internal call.
+    var internalCallDuringPause = function (MACHINE, proc, success, fail) {
+        var args = [];
+        var i;
+        for (i = 0; i < arguments.length; i++) {
+            args.push(arguments[i]);
+        }
+
+        var i;
+
+        if (MACHINE.breakScheduled) {
+            return fail(baselib.exceptions.makeExnBreak(
+                "User break.",
+                MACHINE.captureContinuationMarks(),
+                // FIXME: capture the continuation as well,
+                // rather than just hold false.
+                false));
+        }
+
+        var oldArgcount, oldVal, oldProc, oldErrorHandler, oldControlLength, oldEnvLength;
+        if (! baselib.arity.isArityMatching(proc.racketArity, args.length - 4)) {
+            var msg = baselib.format.format("arity mismatch: ~s expected ~s arguments, but received ~s",
+                                            [proc.displayName, proc.racketArity, args.length - 4]);
+            return fail(baselib.exceptions.makeExnFailContractArity(msg,
+                                                                    MACHINE.captureContinuationMarks()));
+        }
+
+        if (! isClosure(proc)) {
+            return fail(baselib.exceptions.makeExnFail(
+                baselib.format.format(
+                    "Not a procedure: ~e",
+                    [proc]),
+                MACHINE.captureContinuationMarks()));
+        }
+
+        oldVal = MACHINE.v;
+        oldArgcount = MACHINE.a;
+        oldProc = MACHINE.p;
+        oldControlLength = MACHINE.c.length;
+        oldEnvLength = MACHINE.e.length;
+
+        oldErrorHandler = MACHINE.params['currentErrorHandler'];
+        var afterGoodInvoke = function (MACHINE) { 
+            plt.runtime.PAUSE(function (restart) {
+                MACHINE.params['currentErrorHandler'] = oldErrorHandler;
+                var returnValue = MACHINE.v;
+                MACHINE.v = oldVal;
+                MACHINE.a = oldArgcount;
+                MACHINE.p = oldProc;
+                return success(returnValue);
+            });
+        };
+        afterGoodInvoke.mvr = function (MACHINE) {
+            plt.runtime.PAUSE(function (restart) {
+                MACHINE.params['currentErrorHandler'] = oldErrorHandler;
+                var returnValues = [MACHINE.v];
+                var i;
+                for (i = 0; i < MACHINE.a - 1; i++) {
+                    returnValues.push(MACHINE.e.pop());
+                }
+                MACHINE.v = oldVal;
+                MACHINE.a = oldArgcount;
+                MACHINE.p = oldProc;
+                return success.apply(null, returnValues);
+            });
+        };
+
+        MACHINE.c.push(
+            new baselib.frames.CallFrame(afterGoodInvoke, proc));
+        MACHINE.a = args.length - 4;
+        for (i = 0; i < args.length - 4; i++) {
+            MACHINE.e.push(args[args.length - 1 - i]);
+        }
+        MACHINE.p = proc;
+        MACHINE.params['currentErrorHandler'] = function (MACHINE, e) {
+            MACHINE.params['currentErrorHandler'] = oldErrorHandler;
+            MACHINE.v = oldVal;
+            MACHINE.a = oldArgcount;
+            MACHINE.p = oldProc;
+            MACHINE.c.length = oldControlLength;
+            MACHINE.e.length = oldEnvLength;
+            return fail(e);
+        };
+        MACHINE._trampoline(proc.label, 
+                            false, 
+                            function() {
+                                // The lock should still being held, so we don't
+                                // automatically unlock control.
+                            });
+    };
+
+
+
+
+
+
+
+    var makeClosure = function (name, arity, f, closureArgs) {
+        if (! closureArgs) { closureArgs = []; }
+        return new Closure(f,
+                           arity,
+                           closureArgs,
+                           name);
+    };
+
+
+    var makePrimitiveProcedure = function (name, arity, f) {
+        var impl = function(M) {
+            if(--M.cbt < 0) {
+                throw impl;
+            }
+            M.v = f(M);
+            M.e.length -= M.a;
+            return M.c.pop().label(M);
+        };
+        var proc = makeClosure(name, arity, impl, []);
+        // Also, record the raw implementation of the function.
+        proc._i = f;
+        return proc;
+    };
+
+
+
+
+
+
+
+
+    var renameProcedure = function (f, name) {
+        return makeClosure(name, f.racketArity, f.label, f.closedVals);
+    };
+
+
+
+    // Applying a procedure.
+    // Assumptions: the procedure register has been assigned, as has
+    // the argcount and environment.
+    // Must be running in the context of a trampoline.
+    var rawApply = function(M) {
+        M.cbt--;
+        if (baselib.arity.isArityMatching(M.p.racketArity, M.a)) {
+            return M.p.label(M);
+        } else {
+            baselib.exceptions.raiseArityMismatchError(M, M.p, M.a);
+        }
+    };
+
+
+
+    //////////////////////////////////////////////////////////////////////
+    exports.Closure = Closure;
+    exports.internalCallDuringPause = internalCallDuringPause;
+    exports.finalizeClosureCall = finalizeClosureCall;
+
+    exports.makePrimitiveProcedure = makePrimitiveProcedure;
+    exports.makeClosure = makeClosure;
+
+    exports.isClosure = isClosure;
+
+    exports.isProcedure = isProcedure;
+
+
+    exports.renameProcedure = renameProcedure;
+
+    exports.asJavaScriptFunction = asJavaScriptFunction;
+    exports.rawApply = rawApply;
+
+
+}(this.plt.baselib, this.plt));
+/*jslint sub: true, vars: true, nomen: true, plusplus: true, maxerr: 50, indent: 4 */
+/*global plt*/
+
+// Modules
+(function (baselib, plt) {
+    'use strict';
+    var exports = {};
+    baselib.modules = exports;
+
+    var hasOwnProperty = {}.hasOwnProperty;
+
+    var Namespace = function(modrec) {
+        this.modrec = modrec;
+
+        // Returns the key/value pairs of the prefix.
+        // mapping: string -> value
+        this.mapping = {}; 
+    };
+
+    Namespace.prototype.get = function(name) {
+        return this.mapping[name];
+    };
+
+    Namespace.prototype.hasKey = function(name) {
+        return hasOwnProperty.call(this.mapping, name);
+    };
+
+    Namespace.prototype.set = function(name, value) {
+        this.mapping[name] = value;
+    };
+
+    var ModuleRecord = function (name, label) {
+        this.name = name;
+        this.label = label;
+        this.isInvoked = false;
+        this.prefix = false;
+        this.exports = new Namespace(this);
+        this.externalExports = new Namespace(this);
+
+        // JavaScript-implemented code will assign privateExports
+        // with all of the exported identifiers.
+        this.privateExports = {};
+    };
+
+    // Returns the offset into the prefix in which the value will be stored.
+    ModuleRecord.prototype.getPrefixOffset = function(externalName) {
+        var i;
+        for (i = 0; i < this.prefix.names.length; i++) {
+            if (this.prefix.names[i] === externalName) {
+                return i;
+            }
+        }
+        return void(0);
+    };
+
+    // Returns access to the names provided in the module.
+    // Note that the names are the names internal to the module.
+    ModuleRecord.prototype.getExports = function () {
+        return this.exports;
+    };    
+
+    // Returns access to the names defined with their external names.
+    ModuleRecord.prototype.getExternalExports = function() {
+        return this.externalExports;
+    };
+
+    // External invokation of a module.
+    ModuleRecord.prototype.invoke = function (MACHINE, succ, fail) {
+        this._invoke(false, MACHINE, succ, fail);
+    };
+
+    // Internal invokation of a module.
+    ModuleRecord.prototype.internalInvoke = function (MACHINE, succ, fail) {
+        this._invoke(true, MACHINE, succ, fail);
+    };
+
+    // Private: general invokation of a module
+    ModuleRecord.prototype._invoke = function (isInternal, MACHINE, succ, fail) {
+        var that = this;
+        MACHINE = MACHINE || plt.runtime.currentMachine;
+        succ = succ || function () {};
+        fail = fail || function () {};
+
+        var oldErrorHandler = MACHINE.params['currentErrorHandler'];
+        var afterGoodInvoke = function (MACHINE) { 
+            MACHINE.params['currentErrorHandler'] = oldErrorHandler;
+            if (isInternal) { succ(); }
+            else {
+                throw new plt.runtime.HaltError(succ)
+            }
+        };
+
+        if (this.isInvoked) {
+            succ();
+        } else {
+            if (isInternal) {
+                MACHINE.params['currentErrorHandler'] = function (MACHINE, anError) {
+                    MACHINE.params['currentErrorHandler'] = oldErrorHandler;
+                    fail(MACHINE, anError);
+                };
+                MACHINE.c.push(new plt.baselib.frames.CallFrame(afterGoodInvoke, null));
+                throw that.label;
+            } else {
+                MACHINE.exclusiveLock.acquire(
+                    void(0),
+                    function(release) {
+                        MACHINE.params['currentErrorHandler'] = function (MACHINE, anError) {
+                            MACHINE.params['currentErrorHandler'] = oldErrorHandler;
+                            fail(MACHINE, anError);
+                        };
+                        MACHINE.c.push(new plt.baselib.frames.CallFrame(afterGoodInvoke, null));
+                        MACHINE._trampoline(that.label, false, release);
+                    });
+            }
+        }
+    };
+    
+
+
+    exports.ModuleRecord = ModuleRecord;
+
+
+}(this.plt.baselib, this.plt));
+/*global plt*/
+/*jslint browser: true, unparam: true, vars: true, white: true, maxerr: 50, indent: 4 , plusplus: true */
+
+// Continuation marks
+(function(baselib) {
+    'use strict';
+    var exports = {};
+    baselib.contmarks = exports;
+
+
+    var ContinuationMarkSet = function(kvlists) {
+        this.kvlists = kvlists;
+    };
+
+
+    ContinuationMarkSet.prototype.shift = function() {
+        this.kvlists.shift();
+    };
+
+    ContinuationMarkSet.prototype.toDomNode = function(params) {
+        var dom = document.createElement("span");
+        dom.appendChild(document.createTextNode('#<continuation-mark-set>'));
+        return dom;
+    };
+
+    ContinuationMarkSet.prototype.toWrittenString = function(cache) {
+        return '#<continuation-mark-set>';
+    };
+
+    ContinuationMarkSet.prototype.toDisplayedString = function(cache) {
+        return '#<continuation-mark-set>';
+    };
+
+    ContinuationMarkSet.prototype.ref = function(key, promptTag) {
+        // FIXME: ref needs to watch the promptTag as well and capture up to it.
+        var i, j;
+        var result = [];
+        var kvlist;
+        for (i = 0; i < this.kvlists.length; i++) {
+            kvlist = this.kvlists[i];
+            for (j = 0; j < kvlist.length; j++) {
+                if (baselib.equality.equals(kvlist[j][0], key)) {
+                    result.push(kvlist[j][1]);
+                }
+            }
+        }
+        return baselib.lists.arrayToList(result);
+    };
+
+
+    ContinuationMarkSet.prototype.refFirst = function(key, promptTag) {
+        // FIXME: refFirst needs to watch the promptTag as well and capture up to it.
+        var i, j;
+        var result = [];
+        var kvlist;
+        for (i = 0; i < this.kvlists.length; i++) {
+            kvlist = this.kvlists[i];
+            for (j = 0; j < kvlist.length; j++) {
+                if (baselib.equality.equals(kvlist[j][0], key)) {
+                    return (kvlist[j][1]);
+                }
+            }
+        }
+        return undefined;
+    };
+
+
+
+
+    // Returns an approximate stack trace.
+    // getContext: MACHINE -> (arrayof (U Procedure (Vector source line column position span)))
+    ContinuationMarkSet.prototype.getContext = function(MACHINE) {
+        var i, j;
+        var result = [];
+        var kvlist;
+
+        var tracedAppKey = plt.runtime.getTracedAppKey(MACHINE);
+        var tracedCalleeKey = plt.runtime.getTracedCalleeKey(MACHINE);
+        var proc, locationVector;
+
+        for (i = 0; i < this.kvlists.length; i++) {
+            kvlist = this.kvlists[i];
+            for (j = 0; j < kvlist.length; j++) {
+                if (kvlist[j][0] === tracedAppKey) {
+                    locationVector = kvlist[j][1];
+                    result.push(locationVector);
+                } else if (kvlist[j][0] === tracedCalleeKey) {
+                    proc = kvlist[j][1];
+                    if (proc !== null) {
+                        result.push(proc);
+                    }
+                }
+            }
+        }
+        return result;
+    };
+
+
+    var isContinuationMarkSet = baselib.makeClassPredicate(ContinuationMarkSet);
+
+
+
+
+
+    // A continuation prompt tag labels a prompt frame.
+    var ContinuationPromptTag = function(name) {
+	this.name = name;         // (U String false)
+
+    };
+
+    ContinuationPromptTag.prototype.toDomNode = function(params) {
+        var dom = document.createElement("span");
+        if (this.name) {
+            dom.appendChild(document.createTextNode('#<continuation-prompt-tag:' 
+                                                    + this.name + '>'));
+        } else {
+            dom.appendChild(document.createTextNode('#<continuation-prompt-tag>'));
+        }
+        return dom;
+    };
+
+    ContinuationPromptTag.prototype.toWrittenString = function(cache) {
+        if (this.name) {
+            return '#<continuation-prompt-tag' + this.name + '>';
+        } else {
+            return '#<continuation-prompt-tag>';
+        }
+    };
+
+    ContinuationPromptTag.prototype.toDisplayedString = function(cache) {
+        if (this.name) {
+            return '#<continuation-prompt-tag' + this.name + '>';
+        } else {
+            return '#<continuation-prompt-tag>';
+        }
+    };
+
+
+
+    var isContinuationPromptTag = baselib.makeClassPredicate(ContinuationPromptTag);
+
+    var DEFAULT_CONTINUATION_PROMPT_TAG =
+        new ContinuationPromptTag("default");
+
+
+    exports.ContinuationMarkSet = ContinuationMarkSet;
+    exports.isContinuationMarkSet = isContinuationMarkSet;
+    exports.ContinuationPromptTag = ContinuationPromptTag;
+
+    exports.isContinuationPromptTag = isContinuationPromptTag;
+    exports.DEFAULT_CONTINUATION_PROMPT_TAG = DEFAULT_CONTINUATION_PROMPT_TAG;
+}(this.plt.baselib));
+/*jslint browser: false, unparam: true, vars: true, white: true, plusplus: true, maxerr: 50, indent: 4 */
+
+// Arity structure
+(function(baselib) {
+    'use strict';
+    var exports = {};
+    baselib.arity = exports;
+
+
+
+    var ArityAtLeast = baselib.structs.makeStructureType(
+        'arity-at-least', false, 1, 0, false, false);
+
+
+    // An arity is either a primitive number, an ArityAtLeast instance,
+    // or a list of either primitive numbers or ArityAtLeast instances.
+
+
+
+    var isArityAtLeast = ArityAtLeast.predicate;
+    var arityAtLeastValue = function(x) { 
+        var val = ArityAtLeast.accessor(x, 0);
+        return val;
+    };
+
+
+    ArityAtLeast.type.prototype.toString = function() {
+        return '#<arity-at-least ' + arityAtLeastValue(this) + '>';
+    };
+
+
+
+    // isArityMatching: arity natural -> boolean
+    // Produces true if n satisfies the arity.
+    var isArityMatching = function(arity, n) {
+	if (typeof(arity) === 'number') {
+	    return arity === n;
+	} else if (isArityAtLeast(arity)) {
+	    return n >= arityAtLeastValue(arity);
+	} else {
+	    while (arity !== baselib.lists.EMPTY) {
+		if (typeof(arity.first) === 'number') {
+		    if (arity.first === n) { return true; }
+		} else if (isArityAtLeast(arity.first)) {
+		    if (n >= arityAtLeastValue(arity.first)) { return true; }
+		}
+		arity = arity.rest;
+	    }
+	    return false;
+	}
+    };
+
+
+
+
+
+    //////////////////////////////////////////////////////////////////////
+
+    exports.ArityAtLeast = ArityAtLeast;
+    exports.makeArityAtLeast = function() { 
+        var args = [].slice.call(arguments);
+        return ArityAtLeast.constructor(args);
+    };
+    exports.isArityAtLeast = isArityAtLeast;
+    exports.isArityMatching = isArityMatching;
+    exports.arityAtLeastValue = arityAtLeastValue;
+
+}(this.plt.baselib));/*jslint vars: true, maxerr: 50, indent: 4 */
+
+// Structure types
+
+(function (baselib) {
+    'use strict';
+    var exports = {};
+    baselib.inspectors = exports;
+
+
+    var Inspector = function () {
+    };
+    var DEFAULT_INSPECTOR = new Inspector();
+
+    Inspector.prototype.toString = function () {
+        return "#<inspector>";
+    };
+
+    var isInspector = baselib.makeClassPredicate(Inspector);
+
+
+
+    exports.Inspector = Inspector;
+    exports.DEFAULT_INSPECTOR = DEFAULT_INSPECTOR;
+
+    exports.isInspector = isInspector;
+
+
+}(this.plt.baselib));/*jslint browser: true, undef: false, unparam: true, sub: true, vars: true, white: true, plusplus: true, maxerr: 50, indent: 4 */
+
+// Exceptions
+
+(function(baselib) {
+    'use strict';
+    var exceptions = {};
+    baselib.exceptions = exceptions;
+
+
+
+    var RacketError = function(message, racketError) {
+        Error.call(this, message);
+        this.message = message;
+        this.racketError = racketError;
+    };
+    RacketError.prototype = baselib.heir(Error.prototype);
+    var isRacketError = baselib.makeClassPredicate(RacketError);
+
+
+
+    // (define-struct exn (message continuation-mark-set))
+    var Exn = baselib.structs.makeStructureType(
+        'exn', false, 2, 0, false, false);
+
+
+    // (define-struct (exn:break exn) (continuation))
+    var ExnBreak = baselib.structs.makeStructureType(
+        'exn:break', Exn, 1, 0, false, false);
+
+
+    var ExnFail = baselib.structs.makeStructureType(
+        'exn:fail', Exn, 0, 0, false, false);
+
+    var ExnFailContract = baselib.structs.makeStructureType(
+        'exn:fail:contract', ExnFail, 0, 0, false, false);
+
+    var ExnFailContractArity = baselib.structs.makeStructureType(
+        'exn:fail:contract:arity', ExnFailContract, 0, 0, false, false);
+
+    // exn:fail:contract (id)
+    var ExnFailContractVariable = baselib.structs.makeStructureType(
+        'exn:fail:contract:variable', ExnFailContract, 1, 0, false, false);
+
+    var ExnFailContractDivisionByZero = baselib.structs.makeStructureType(
+        'exn:fail:contract:divide-by-zero', ExnFailContract, 0, 0, false, false);
+
+
+
+
+
+    var exceptionHandlerKey = new baselib.symbols.Symbol("exnh");
+
+
+
+
+
+    //////////////////////////////////////////////////////////////////////
+
+    // Raise error to the toplevel.
+
+    // If the error is of an exception type, make sure e.message holds the string
+    // value to allow integration with systems that don't recognize Racket error 
+    // structures.
+    var raise = function(MACHINE, e) { 
+        if (isRacketError(e) && Exn.predicate(e.racketError)) {
+            e.message = Exn.accessor(e.racketError, 0);
+        } else if (Exn.predicate(e)) {
+            e = new RacketError(Exn.accessor(e, 0), e);
+        }
+
+        // if (window.console !== void(0) &&
+        //     typeof(window.console.log) === 'function') {
+        //     window.console.log(MACHINE);
+        //     if (e.stack) { window.console.log(e.stack); }
+        //     else { window.console.log(e); }
+        // } 
+
+        throw e; 
+    };
+
+
+    var raiseExnBreak = function(MACHINE, msg) {
+        var contMarks = MACHINE.captureContinuationMarks();
+        var k = false;
+        // FIXME: capture the current continuation and stuff it into
+        // k, to allow restart if possible.
+        raise(MACHINE, ExnBreak.constructor([msg, contMarks, k]));
+    };
+
+
+
+    var raiseFailure = function(MACHINE, msg) {
+        var contMarks = MACHINE.captureContinuationMarks();
+        raise(MACHINE, ExnFail.constructor([msg, contMarks]));
+    };
+
+    var raiseContractError = function(MACHINE, msg) {
+        var contMarks = MACHINE.captureContinuationMarks();
+        raise(MACHINE, ExnFailContract.constructor([msg, contMarks]));
+    };
+
+    var raiseDivisionByZeroError = function(MACHINE, msg) {
+        var contMarks = MACHINE.captureContinuationMarks();
+        raise(MACHINE, ExnFailContractDivisionByZero.constructor([msg, contMarks]));
+    };
+
+
+    var raiseUnboundToplevelError = function(MACHINE, name) {
+        var message = baselib.format.format("Not bound: ~a", [name]);
+        var contMarks = MACHINE.captureContinuationMarks();
+        raise(MACHINE, 
+              ExnFailContractVariable.constructor([message, 
+                                                   contMarks, 
+                                                   baselib.symbols.makeSymbol(name)])); 
+    };
+
+
+    var raiseArgumentTypeError = function(MACHINE, 
+                                          callerName,
+                                          expectedTypeName,
+                                          argumentOffset,
+                                          actualValue) {
+        var message;
+        var contMarks = MACHINE.captureContinuationMarks();
+        if (argumentOffset !== void(0)) {
+            message = baselib.format.format(
+                          "~a: expected ~a as argument ~e but received ~e",
+                          [callerName,
+                           expectedTypeName,
+                           (argumentOffset + 1),
+                           actualValue]);
+            raise(MACHINE, ExnFailContract.constructor([message, contMarks]));
+        } else {
+            message = baselib.format.format(
+                          "~a: expected ~a but received ~e",
+                          [callerName,
+                           expectedTypeName,
+                           actualValue]);
+            raise(MACHINE, ExnFailContract.constructor([message, contMarks]));
+        }
+    };
+
+    var raiseContextExpectedValuesError = function(MACHINE, expected) {
+        var message = baselib.format.format("expected ~e values, received ~e values",
+                                            [expected, MACHINE.a]);
+        var contMarks = MACHINE.captureContinuationMarks();
+        raise(MACHINE, ExnFailContract.constructor([message, contMarks]));
+    };
+
+    var raiseArityMismatchError = function(MACHINE, proc, received) {
+        raise(MACHINE, makeArityMismatchError(MACHINE, proc, received));
+    };
+
+    var makeArityMismatchError = function(MACHINE, proc, received) {
+        var message = baselib.format.format("~a: expected ~e value(s), received ~e value(s)",
+                                            [proc.displayName,
+                                             proc.racketArity,
+                                             received]);
+        var contMarks = MACHINE.captureContinuationMarks();
+        return ExnFailContractArity.constructor([message, contMarks]);
+    };
+
+
+    var raiseOperatorApplicationError = function(MACHINE, operator) {
+        var message = baselib.format.format("not a procedure: ~e",
+                                            [operator]);
+        var contMarks = MACHINE.captureContinuationMarks();
+        raise(MACHINE, 
+              ExnFailContract.constructor([message, contMarks]));
+    };
+
+
+    var raiseOperatorIsNotPrimitiveProcedure = function(MACHINE, operator) {
+        var message = baselib.format.format("not a primitive procedure: ~e",
+                                            [operator]);
+        var contMarks = MACHINE.captureContinuationMarks();
+        raise(MACHINE,
+              ExnFailContract.constructor([message, contMarks]));
+    };
+
+
+    var raiseUnimplementedPrimitiveError = function(MACHINE, name) {
+        var message = "unimplemented kernel procedure: " + name;
+        var contMarks = MACHINE.captureContinuationMarks();
+        raise(MACHINE,
+              ExnFailContract.constructor([message, contMarks]));
+    };
+
+
+    var raiseModuleLoadingError = function(MACHINE, name) {
+        var message = "unable to dynamically load module: " + name;
+        var contMarks = MACHINE.captureContinuationMarks();
+        raise(MACHINE,
+              ExnFail.constructor([message, contMarks]));
+    };
+
+
+
+
+
+
+
+
+    //////////////////////////////////////////////////////////////////////
+    // Exports
+
+
+
+    exceptions.RacketError = RacketError;
+    exceptions.isRacketError = isRacketError;
+
+    exceptions.Exn = Exn;
+    exceptions.makeExn = function(msg, marks) { return Exn.constructor([msg, marks]); };
+    exceptions.isExn = Exn.predicate;
+    exceptions.exnMessage = function(exn) { return Exn.accessor(exn, 0); };
+    exceptions.exnContMarks = function(exn) { return Exn.accessor(exn, 1); };
+    exceptions.exnSetContMarks = function(exn, v) { Exn.mutator(exn, 1, v); };
+
+    exceptions.ExnBreak = ExnBreak;
+    exceptions.makeExnBreak = function(msg, marks, k) { return ExnBreak.constructor([msg, marks, k]); };
+    exceptions.isExnBreak = ExnBreak.predicate;
+    exceptions.exnBreakContinuation = 
+        function(exn) { return ExnBreak.accessor(exn, 0); };
+
+    exceptions.ExnFail = ExnFail;
+    exceptions.makeExnFail = function(msg, marks) { return ExnFail.constructor([msg, marks]); };
+    exceptions.isExnFail = ExnFail.predicate;
+
+    exceptions.ExnFailContract = ExnFailContract;
+    exceptions.makeExnFailContract = function(msg, marks) { return ExnFailContract.constructor([msg, marks]); };
+    exceptions.isExnFailContract = ExnFailContract.predicate;
+
+    exceptions.ExnFailContractArity = ExnFailContractArity;
+    exceptions.makeExnFailContractArity = function(msg, marks) { return ExnFailContractArity.constructor([msg, marks]); };
+    exceptions.isExnFailContractArity = ExnFailContractArity.predicate;
+
+    exceptions.ExnFailContractVariable = ExnFailContractVariable;
+    exceptions.makeExnFailContractVariable = function(msg, marks) { return ExnFailContractVariable.constructor([msg, marks]); };
+    exceptions.isExnFailContractVariable = ExnFailContractVariable.predicate;
+    exceptions.exnFailContractVariableId = 
+        function(exn) { return ExnFailContractVariable.accessor(exn, 0); };
+
+
+    exceptions.ExnFailContractDivisionByZero = ExnFailContractDivisionByZero;
+    exceptions.makeExnFailContractDivisionByZero = 
+        function(msg, marks) { return ExnFailContractDivisionByZero.constructor([msg, marks]); };
+    exceptions.isExnFailContractDivisionByZero = ExnFailContractDivisionByZero.predicate;
+
+
+    exceptions.exceptionHandlerKey = exceptionHandlerKey;
+
+
+
+
+    exceptions.raise = raise;
+    exceptions.raiseExnBreak = raiseExnBreak;
+    exceptions.raiseFailure = raiseFailure;
+    exceptions.raiseContractError = raiseContractError;
+    exceptions.raiseDivisionByZeroError = raiseDivisionByZeroError;
+    exceptions.raiseUnboundToplevelError = raiseUnboundToplevelError;
+    exceptions.raiseArgumentTypeError = raiseArgumentTypeError;
+    exceptions.raiseContextExpectedValuesError = raiseContextExpectedValuesError;
+    exceptions.raiseArityMismatchError = raiseArityMismatchError;
+    exceptions.makeArityMismatchError = makeArityMismatchError;
+    exceptions.raiseOperatorApplicationError = raiseOperatorApplicationError;
+    exceptions.raiseOperatorIsNotPrimitiveProcedure = raiseOperatorIsNotPrimitiveProcedure;
+    exceptions.raiseUnimplementedPrimitiveError = raiseUnimplementedPrimitiveError;
+    exceptions.raiseModuleLoadingError = raiseModuleLoadingError;
+
+
+}(this.plt.baselib));
+/*jslint vars: true, nomen: true, plusplus: true, maxerr: 50, indent: 4 */
+// Arity structure
+(function (baselib) {
+    'use strict';
+    var exports = {};
+    baselib.readergraph = exports;
+
+
+    var readerGraph = function (x, objectHash, n) {
+        var i;
+        if (typeof (x) === 'object' && objectHash.containsKey(x)) {
+            return objectHash.get(x);
+        }
+
+        if (baselib.lists.isPair(x)) {
+            var consPair = baselib.lists.makePair(x.first, x.rest);
+            objectHash.put(x, consPair);
+            consPair.first = readerGraph(x.first, objectHash, n + 1);
+            consPair.rest = readerGraph(x.rest, objectHash, n + 1);
+            return consPair;
+        }
+
+        if (baselib.vectors.isVector(x)) {
+            var len = x.length();
+            var aVector = baselib.vectors.makeVector(x.elts.slice(0));
+            objectHash.put(x, aVector); 
+            for (i = 0; i < len; i++) {
+                aVector.elts[i] = readerGraph(aVector.elts[i], objectHash, n + 1);
+            }
+            return aVector;
+        }
+
+        if (baselib.boxes.isBox(x)) {
+            var aBox = baselib.boxes.makeBox(x.ref());
+            objectHash.put(x, aBox);
+            aBox.val = readerGraph(x.ref(), objectHash, n + 1);
+            return aBox;
+        }
+
+        if (baselib.hashes.isHash(x)) {
+            throw new Error("make-reader-graph of hash not implemented yet");
+        }
+
+        if (baselib.structs.isStruct(x)) {
+            var aStruct = baselib.clone(x);
+            objectHash.put(x, aStruct);
+            for (i = 0; i < x._fields.length; i++) {
+                x._fields[i] = readerGraph(x._fields[i], objectHash, n + 1);
+            }
+            return aStruct;
+        }
+
+        if (baselib.placeholders.isPlaceholder(x)) {
+            return readerGraph(x.ref(), objectHash, n + 1);
+        }
+
+        return x;
+    };
+
+    exports.readerGraph = readerGraph;
+
+}(this.plt.baselib));/*jslint vars: true, white: true, plusplus: true, maxerr: 50, indent: 4 */
+
+
+// Helper functions for argument checking.
+
+(function (baselib) {
+    'use strict';
+    var exports = {};
+    baselib.check = exports;
+
+    var EMPTY = baselib.lists.EMPTY;
+    var isPair = baselib.lists.isPair;
+    var isList = baselib.lists.isList;
+    var makeLowLevelEqHash = baselib.hashes.makeLowLevelEqHash;
+
+
+    //////////////////////////////////////////////////////////////////////
+
+    // testArgument: (X -> boolean) X number string string -> boolean
+    // Produces the argument value the predicate is true, and otherwise raises an error.
+    var testArgument = function (MACHINE,
+                                 expectedTypeName,
+                                 predicate,                          
+                                 val, 
+                                 index, 
+                                 callerName) {
+        if (predicate(val)) {
+            return val;
+        } else {
+            if (typeof(expectedTypeName) === 'function') { 
+                expectedTypeName = expectedTypeName(); 
+            }
+            baselib.exceptions.raiseArgumentTypeError(MACHINE, 
+                                                      callerName,
+                                                      expectedTypeName,
+                                                      index,
+                                                      val);
+        }
+    };
+
+
+    var makeCheckArgumentType = function (predicate, predicateName) {
+        return function (MACHINE, callerName, position) {
+            return testArgument(
+                MACHINE,
+                predicateName,
+                predicate,
+                MACHINE.e[MACHINE.e.length - 1 - position],
+                position,
+                callerName);
+        };
+    };
+
+
+
+    var makeCheckListofArgumentType = function (predicate, predicateName) {
+        var listPredicate = function (x) {
+            if (! isList(x)) { return false; }
+            while (true) {
+                if (x === EMPTY){
+                    return true;
+                }
+                if (! predicate(x.first)) {
+                    return false;
+                }
+                x = x.rest;
+            }
+        };
+        return function (MACHINE, callerName, position) {
+            return testArgument(
+                MACHINE,
+                'list of ' + predicateName,
+                listPredicate,
+                MACHINE.e[MACHINE.e.length - 1 - position],
+                position,
+                callerName);
+        };
+    };
+
+
+
+
+
+
+
+    var testArity = function (MACHINE, callerName, observed, minimum, maximum) {
+        if (observed < minimum || observed > maximum) {
+            baselib.exceptions.raise(
+                MACHINE, 
+                baselib.exceptions.ExnFailContractArity.constructor(
+                    [callerName + ": expected at least " + minimum
+                     + " arguments "
+                     + " but received " + observed,
+                     MACHINE.captureContinuationMarks()]));
+        }
+    };
+
+
+
+
+    var checkOutputPort = makeCheckArgumentType(
+        baselib.ports.isOutputPort,
+        'output port');
+
+    var checkInputPort = makeCheckArgumentType(
+        baselib.ports.isInputPort,
+        'input port');
+
+    var checkSymbol = makeCheckArgumentType(
+        baselib.symbols.isSymbol,
+        'symbol');
+
+    var checkString = makeCheckArgumentType(
+        baselib.strings.isString,
+        'string');
+
+    var checkSymbolOrString = makeCheckArgumentType(
+        function(x) { return (baselib.symbols.isSymbol(x) || 
+                              baselib.strings.isString(x)); },
+        'symbol or string');
+
+    var checkMutableString = makeCheckArgumentType(
+        baselib.strings.isMutableString,
+        'mutable string');
+
+    var checkChar = makeCheckArgumentType(
+        baselib.chars.isChar,
+        'character');
+
+    var checkProcedure = makeCheckArgumentType(
+        baselib.functions.isProcedure,
+        'procedure');
+
+    var checkNumber = makeCheckArgumentType(
+        baselib.numbers.isNumber,
+        'number');
+
+    var checkReal = makeCheckArgumentType(
+        baselib.numbers.isReal,
+        'real');
+
+    var checkNatural = makeCheckArgumentType(
+        baselib.numbers.isNatural,
+        'natural');
+
+    var checkNaturalOrFalse = makeCheckArgumentType(
+        function(x) { return (baselib.numbers.isNatural(x) || 
+                              x === false); },
+        'natural or false');
+
+    var checkByte = makeCheckArgumentType(
+        baselib.numbers.isByte,
+        'byte');
+
+    var checkBytes = makeCheckArgumentType(
+        baselib.bytes.isBytes,
+        'bytes');
+
+    var checkNaturalInRange = function(M, callerName, index, a, b) {
+        var expectedTypeName;
+        var x = M.e[M.e.length - 1 - index];
+        // fast path: if a, b, and x are numbers
+        if (typeof(x) === 'number' && typeof(a) === 'number' && typeof(b) === 'number') {
+            if (a <= x && x < b) { 
+                return x; 
+            }
+            else {
+                expectedTypeName = baselib.format.format('natural between ~a and ~a', [a, b]);
+                return baselib.exceptions.raiseArgumentTypeError(m, 
+                                                                 callerName,
+                                                                 expectedTypeName,
+                                                                 index,
+                                                                 x);
+            }
+        } else {
+            if (baselib.numbers.lessThanOrEqual(a, x) && baselib.numbers.lessThan(x, b)) {
+                return x;
+            } else {
+                expectedTypeName = baselib.format.format('natural between ~a and ~a', [a, b]);
+                return baselib.exceptions.raiseArgumentTypeError(m, 
+                                                                 callerName,
+                                                                 expectedTypeName,
+                                                                 index,
+                                                                 x);
+            }
+        }
+    };
+
+
+    var checkInteger = makeCheckArgumentType(
+        baselib.numbers.isInteger,
+        'integer');
+
+    var checkRational = makeCheckArgumentType(
+        baselib.numbers.isRational,
+        'rational');
+
+    var checkNonNegativeReal = makeCheckArgumentType(
+        baselib.numbers.isNonNegativeReal,
+        'non-negative real');
+
+    var checkPair = makeCheckArgumentType(
+        baselib.lists.isPair,
+        'pair');
+
+    var checkList = makeCheckArgumentType(
+        isList,
+        'list');
+
+    var checkVector = makeCheckArgumentType(
+        baselib.vectors.isVector,
+        'vector');
+
+    var checkBoolean = makeCheckArgumentType(
+        function (x) { return x === true || x === false; },
+        'boolean');
+
+    var checkBox = makeCheckArgumentType(
+        baselib.boxes.isBox,
+        'box');
+
+    var checkMutableBox = makeCheckArgumentType(
+        baselib.boxes.isMutableBox,
+        'mutable box');
+
+    var checkInspector = makeCheckArgumentType(
+        baselib.inspectors.isInspector,
+        'inspector');
+
+
+    var checkPlaceholder = makeCheckArgumentType(
+        baselib.placeholders.isPlaceholder,
+        'placeholder');
+
+
+    var checkSrcloc = makeCheckArgumentType(
+        baselib.srclocs.isSrcloc,
+        'srcloc');
+
+    var checkContinuationMarkSet = makeCheckArgumentType(
+        baselib.contmarks.isContinuationMarkSet,
+        'continuation mark set');
+
+    var checkContinuationPromptTag = makeCheckArgumentType(
+        baselib.contmarks.isContinuationPromptTag,
+        'continuation prompt tag');
+
+    var checkExn = makeCheckArgumentType(
+        baselib.exceptions.isExn,
+        'exn');
+
+    var checkHash = makeCheckArgumentType(
+        baselib.hashes.isHash,
+        'hash');
+    var checkHasheq = makeCheckArgumentType(
+        baselib.hashes.isHasheq,
+        'hash');
+    var checkHasheqv = makeCheckArgumentType(
+        baselib.hashes.isHasheqv,
+        'hash');
+    var checkMutableHash = makeCheckArgumentType(
+        function(x) { return baselib.hashes.isHash(x) && ! x.isImmutable()},
+        'mutable hash');
+    var checkImmutableHash = makeCheckArgumentType(
+        function(x) { return baselib.hashes.isHash(x) && x.isImmutable()},
+        'immutable hash');
+
+
+
+
+
+
+    //////////////////////////////////////////////////////////////////////
+
+
+    exports.testArgument = testArgument;
+    exports.testArity = testArity;
+    exports.makeCheckArgumentType = makeCheckArgumentType;
+    exports.makeCheckListofArgumentType = makeCheckListofArgumentType;
+    exports.checkOutputPort = checkOutputPort;
+    exports.checkInputPort = checkInputPort;
+    exports.checkSymbol = checkSymbol;
+    exports.checkString = checkString;
+    exports.checkSymbolOrString = checkSymbolOrString;
+    exports.checkMutableString = checkMutableString;
+    exports.checkChar = checkChar;
+    exports.checkProcedure = checkProcedure;
+    exports.checkNumber = checkNumber;
+    exports.checkReal = checkReal;
+    exports.checkNonNegativeReal = checkNonNegativeReal;
+    exports.checkNatural = checkNatural;
+    exports.checkNaturalOrFalse = checkNaturalOrFalse;
+    exports.checkNaturalInRange = checkNaturalInRange;
+    exports.checkByte = checkByte;
+    exports.checkBytes = checkBytes;
+    exports.checkInteger = checkInteger;
+    exports.checkRational = checkRational;
+    exports.checkPair = checkPair;
+    exports.checkList = checkList;
+    exports.checkVector = checkVector;
+    exports.checkBox = checkBox;
+    exports.checkMutableBox = checkMutableBox;
+    exports.checkInspector = checkInspector;
+    exports.checkByte = checkByte;
+    exports.checkBoolean = checkBoolean;
+    exports.checkPlaceholder = checkPlaceholder;
+    exports.checkSrcloc = checkSrcloc;
+    exports.checkContinuationMarkSet = checkContinuationMarkSet;
+    exports.checkContinuationPromptTag = checkContinuationPromptTag;
+    exports.checkExn = checkExn;
+    exports.checkHash = checkHash;
+    exports.checkImmutableHash = checkImmutableHash;
+    exports.checkMutableHash = checkMutableHash;
+
+}(this.plt.baselib));
+/*global plt*/
+/*jslint unparam: true, sub: true, vars: true, white: true, nomen: true, plusplus: true, maxerr: 50, indent: 4 */
+
+// Arity structure
+(function (baselib) {
+    'use strict';
+    var exports = {};
+    baselib.primitives = exports;
+
+
+    //////////////////////////////////////////////////////////////////////
+    //////////////////////////////////////////////////////////////////////
+    // We try to isolate the effect of external modules: all the identifiers we
+    // pull from external modules should be listed here, and should otherwise not
+    // show up outside this section!
+    var isNumber = baselib.numbers.isNumber;
+
+    var isProcedure = baselib.functions.isProcedure;
+    var isReal = baselib.numbers.isReal;
+    var isInexact = baselib.numbers.isInexact;
+    var isComplex = baselib.numbers.isComplex;
+    var isRational = baselib.numbers.isRational;
+    var isBytes = baselib.bytes.isBytes;
+
+    var isNatural = baselib.numbers.isNatural;
+    var isPair = baselib.lists.isPair;
+    var isList = baselib.lists.isList;
+    var isChar = baselib.chars.isChar;
+    var isVector = baselib.vectors.isVector;
+    var isString = baselib.strings.isString;
+    var isSymbol = baselib.symbols.isSymbol;
+    var isBox = baselib.boxes.isBox;
+    var isStruct = baselib.structs.isStruct;
+    var isStructType = baselib.structs.isStructType;
+    var equals = baselib.equality.equals;
+
+    var NULL = baselib.lists.EMPTY;
+    var VOID = baselib.constants.VOID_VALUE;
+
+    var makeFloat = baselib.numbers.makeFloat;
+    var makeComplex = baselib.numbers.makeComplex;
+    var makeComplexPolar = baselib.numbers.makeComplexPolar;
+
+    var makeSymbol = baselib.symbols.makeSymbol;
+
+    var makeBox = baselib.boxes.makeBox;
+
+    var makeVector = baselib.vectors.makeVector;
+    var makeList = baselib.lists.makeList;
+    var makePair = baselib.lists.makePair;
+
+    var finalizeClosureCall = baselib.functions.finalizeClosureCall;
+    var makePrimitiveProcedure = baselib.functions.makePrimitiveProcedure;
+    var makeClosure = baselib.functions.makeClosure;
+
+
+    // Other helpers
+    var withArguments = baselib.withArguments;
+    var toDomNode = baselib.format.toDomNode;
+
+
+
+    // Exceptions and error handling.
+    var raise = baselib.exceptions.raise;
+    var raiseContractError = baselib.exceptions.raiseContractError;
+    var raiseDivisionByZeroError = baselib.exceptions.raiseDivisionByZeroError;
+    var raiseArgumentTypeError = baselib.exceptions.raiseArgumentTypeError;
+    var raiseArityMismatchError = baselib.exceptions.raiseArityMismatchError;
+
+
+
+    var testArgument = baselib.check.testArgument;
+
+    var checkOutputPort = baselib.check.checkOutputPort;
+    var checkInputPort = baselib.check.checkInputPort;
+    var checkString = baselib.check.checkString;
+    var checkSymbolOrString = baselib.check.checkSymbolOrString;
+    var checkMutableString = baselib.check.checkMutableString;
+    var checkSymbol = baselib.check.checkSymbol;
+    var checkByte = baselib.check.checkByte;
+    var checkChar = baselib.check.checkChar;
+    var checkProcedure = baselib.check.checkProcedure;
+    var checkNumber = baselib.check.checkNumber;
+    var checkReal = baselib.check.checkReal;
+    var checkNonNegativeReal = baselib.check.checkNonNegativeReal;
+    var checkNatural = baselib.check.checkNatural;
+    var checkNaturalOrFalse = baselib.check.checkNaturalOrFalse;
+    var checkNaturalInRange = baselib.check.checkNaturalInRange;
+    var checkInteger = baselib.check.checkInteger;
+    var checkIntegerForChar = baselib.check.makeCheckArgumentType(
+        function(x) {
+            return (baselib.numbers.isInteger(x) &&
+                    ((baselib.numbers.lessThanOrEqual(0, x) &&
+                      baselib.numbers.lessThanOrEqual(x, 55295))
+                     ||
+                     (baselib.numbers.lessThanOrEqual(57344, x) &&
+                      baselib.numbers.lessThanOrEqual(x, 1114111))));
+        },
+        'integer'
+    );
+    var checkRational = baselib.check.checkRational;
+    var checkPair = baselib.check.checkPair;
+    var checkList = baselib.check.checkList;
+    var checkListofChars = baselib.check.makeCheckListofArgumentType(isChar, 'character');
+    var checkListofPairs = baselib.check.makeCheckListofArgumentType(isPair, 'pair');
+    var checkVector = baselib.check.checkVector;
+    var checkBox = baselib.check.checkBox;
+    var checkMutableBox = baselib.check.checkMutableBox;
+    var checkInspector = baselib.check.checkInspector;
+    var checkPlaceholder = baselib.check.checkPlaceholder;
+    var checkSrcloc = baselib.check.checkSrcloc;
+    var checkContinuationPromptTag = baselib.check.checkContinuationPromptTag;
+    var checkContinuationMarkSet = baselib.check.checkContinuationMarkSet;
+    var checkExn = baselib.check.checkExn;
+    var checkHash = baselib.check.checkHash;
+    var checkMutableHash = baselib.check.checkMutableHash;
+    var checkImmutableHash = baselib.check.checkImmutableHash;
+
+    // Just for consistency with the other names, we provide checkAny, which
+    // doesn't really do any checking.
+    var checkAny = function(M, name, offset) {
+        return M.e[M.e.length-1-offset];
+    };
+
+    var checkPromptTag = baselib.check.makeCheckArgumentType(
+        baselib.contmarks.isContinuationPromptTag,
+        'prompt tag');
+
+    var PromptFrame = baselib.frames.PromptFrame;
+
+    //////////////////////////////////////////////////////////////////////
+
+
+
+
+
+    // Primitives are the set of primitive values.  Not all primitives
+    // are coded here; several of them (including call/cc) are injected by
+    // the bootstrapping code in compiler/boostrapped-primitives.rkt
+    var Primitives = {};
+
+    var installPrimitiveProcedure = function (name, arity, f) {
+        Primitives[name] = makePrimitiveProcedure(name, arity, f);
+    };
+
+    var installPrimitiveClosure = function (name, arity, f) {
+        Primitives[name] = makeClosure(name, arity, f, []);
+    };
+
+
+    var installPrimitiveConstant = function (name, v) {
+        Primitives[name] = v;
+    };
+
+
+
+    installPrimitiveConstant('pi', baselib.numbers.pi);
+    installPrimitiveConstant('e', baselib.numbers.e);
+    installPrimitiveConstant('null', NULL);
+    installPrimitiveConstant('true', true);
+    installPrimitiveConstant('false', false);
+    installPrimitiveConstant('eof', baselib.constants.EOF_VALUE);
+
+
+    installPrimitiveConstant('exception-handler-key',
+                             baselib.paramz.exceptionHandlerKey);
+    installPrimitiveConstant('parameterization-key',
+                             baselib.paramz.parameterizationKey);
+    installPrimitiveConstant('break-enabled-key',
+                             baselib.paramz.breakEnabledKey);
+
+
+    var gensymCounter = 0;
+    installPrimitiveProcedure(
+        'gensym',
+        makeList(0, 1),
+        function(M) {
+            var baseName = "g";
+            if (M.a === 1) {
+                baseName = checkSymbolOrString(M, 'gensym', 0).toString();
+            }
+            gensymCounter++;
+            return new baselib.symbols.Symbol(baseName + gensymCounter);
+        });
+
+
+    installPrimitiveProcedure(
+        'display',
+        makeList(1, 2),
+        function (M) {
+            var firstArg = M.e[M.e.length - 1];
+            var outputPort = M.params.currentOutputPort;
+            if (M.a === 2) {
+                outputPort = checkOutputPort(M, 'display', 1);
+            }
+            outputPort.writeDomNode(M, toDomNode(firstArg, 'display'));
+            return VOID;
+        });
+
+    installPrimitiveProcedure(
+        'write',
+        makeList(1, 2),
+        function (M) {
+            var firstArg = M.e[M.e.length - 1];
+            var outputPort = M.params.currentOutputPort;
+            if (M.a === 2) {
+                outputPort = checkOutputPort(M, 'write', 1);
+            }
+            outputPort.writeDomNode(M, toDomNode(firstArg, 'write'));
+            return VOID;
+        });
+
+    installPrimitiveProcedure(
+        'write-byte',
+        makeList(1, 2),
+        function (M) {
+            var firstArg = checkByte(M, 'write-byte', 0);
+            var outputPort = M.params.currentOutputPort;
+            if (M.a === 2) {
+                outputPort = checkOutputPort(M, 'display', 1);
+            }
+            outputPort.writeDomNode(M, toDomNode(String.fromCharCode(firstArg), 'display'));
+            return VOID;
+        });
+
+
+    installPrimitiveProcedure(
+        'newline', makeList(0, 1),
+        function (M) {
+            var outputPort = M.params.currentOutputPort;
+            if (M.a === 1) {
+                outputPort = checkOutputPort(M, 'newline', 1);
+            }
+            outputPort.writeDomNode(M, toDomNode("\n", 'display'));
+            return VOID;
+        });
+
+    installPrimitiveProcedure(
+        'displayln',
+        makeList(1, 2),
+        function (M){
+            var firstArg = M.e[M.e.length-1];
+            var outputPort = M.params.currentOutputPort;
+            if (M.a === 2) {
+                outputPort = checkOutputPort(M, 'displayln', 1);
+            }
+            outputPort.writeDomNode(M, toDomNode(firstArg, 'display'));
+            outputPort.writeDomNode(M, toDomNode("\n", 'display'));
+            return VOID;
+        });
+
+
+
+    installPrimitiveProcedure(
+        'format',
+        baselib.arity.makeArityAtLeast(1),
+        function (M) {
+            var args = [], i, formatString;
+            formatString = checkString(M, 'format', 0).toString();
+            for(i = 1; i < M.a; i++) {
+                args.push(M.e[M.e.length - 1 - i]);
+            }
+            return baselib.format.format(formatString, args, 'format');
+        });
+
+
+    installPrimitiveProcedure(
+        'printf',
+        baselib.arity.makeArityAtLeast(1),
+        function (M) {
+            var args = [], i, formatString, result, outputPort;
+            formatString = checkString(M, 'printf', 0).toString();
+            for(i = 1; i < M.a; i++) {
+                args.push(M.e[M.e.length - 1 - i]);
+            }
+            result = baselib.format.format(formatString, args, 'format');
+            outputPort = M.params.currentOutputPort;
+            outputPort.writeDomNode(M, toDomNode(result, 'display'));
+            return VOID;
+        });
+
+
+    installPrimitiveProcedure(
+        'fprintf',
+        baselib.arity.makeArityAtLeast(2),
+        function (M) {
+            var args = [], i, formatString, outputPort, result;
+            outputPort = checkOutputPort(M, 'fprintf', 0);
+            formatString = checkString(M, 'fprintf', 1).toString();
+            for(i = 2; i < M.a; i++) {
+                args.push(M.e[M.e.length - 1 - i]);
+            }
+            result = baselib.format.format(formatString, args, 'format');
+            outputPort.writeDomNode(M, toDomNode(result, 'display'));
+            return VOID;
+        });
+
+
+
+    installPrimitiveProcedure(
+        'current-print',
+        makeList(0, 1),
+        function (M) {
+            if (M.a === 1) {
+                M.params['currentPrint'] =
+                    checkProcedure(M, 'current-print', 0);
+                return VOID;
+            } else {
+                return M.params['currentPrint'];
+            }
+        });
+
+
+    installPrimitiveProcedure(
+        'current-print-mode',
+        makeList(0, 1),
+        function (M) {
+            if (M.a === 1) {
+                M.params['print-mode'] = checkString(M, 'print-mode', 0);
+                return VOID;
+            } else {
+                return M.params['print-mode'];
+            }
+        });
+
+
+    installPrimitiveProcedure(
+        'current-output-port',
+        makeList(0, 1),
+        function (M) {
+            if (M.a === 1) {
+                M.params['currentOutputPort'] =
+                    checkOutputPort(M, 'current-output-port', 0);
+                return VOID;
+            } else {
+                return M.params['currentOutputPort'];
+            }
+        });
+
+
+
+    installPrimitiveProcedure(
+        'current-error-port',
+        makeList(0, 1),
+        function (M) {
+            if (M.a === 1) {
+                M.params['currentErrorPort'] =
+                    checkOutputPort(M, 'current-output-port', 0);
+                return VOID;
+            } else {
+                return M.params['currentOutputPort'];
+            }
+        });
+
+
+
+    installPrimitiveProcedure(
+        'current-input-port',
+        makeList(0, 1),
+        function (M) {
+            if (M.a === 1) {
+                M.params['currentInputPort'] =
+                    checkInputPort(M, 'current-input-port', 0);
+                return VOID;
+            } else {
+                return M.params['currentInputPort'];
+            }
+        });
+
+
+
+    installPrimitiveClosure(
+        'read-byte',
+        makeList(0, 1),
+        function(M) {
+            var inputPort = M.params['currentInputPort'];
+            if (M.a === 1) {
+                inputPort = checkInputPort(M, 'read-byte', 0);
+            }
+            return plt.runtime.PAUSE(function(restart) {
+                inputPort.callWhenReady(M, function() {
+                    restart(function(MACHINE) {
+                        plt.runtime.finalizeClosureCall(MACHINE,
+                                                        inputPort.readByte(MACHINE));
+                    });
+                });
+            });
+        });
+
+
+
+    installPrimitiveProcedure(
+        '=',
+        baselib.arity.makeArityAtLeast(2),
+        function (M) {
+	    var i;
+            var firstArg = checkNumber(M, '=', 0), secondArg;
+            for (i = 1; i < M.a; i++) {
+                secondArg = checkNumber(M, '=', i);
+                if (! (baselib.numbers.equals(firstArg, secondArg))) {
+                    return false;
+                }
+            }
+            return true;
+        });
+
+
+    installPrimitiveProcedure(
+        '=~',
+        3,
+        function (M) {
+            var x = checkReal(M, '=~', 0);
+            var y = checkReal(M, '=~', 1);
+            var range = checkNonNegativeReal(M, '=~', 2);
+            return baselib.numbers.lessThanOrEqual(
+                baselib.numbers.abs(baselib.numbers.subtract(x, y)),
+                range);
+        });
+
+
+
+    var makeChainingBinop = function (predicate, name) {
+        return function (M) {
+            var firstArg = checkNumber(M, name, 0), secondArg, i;
+            for (i = 1; i < M.a; i++) {
+                secondArg = checkNumber(M, name, i);
+                if (! (predicate(firstArg, secondArg))) {
+                    return false;
+                }
+                firstArg = secondArg;
+            }
+            return true;
+        };
+    };
+
+    installPrimitiveProcedure(
+        '<',
+        baselib.arity.makeArityAtLeast(2),
+        makeChainingBinop(baselib.numbers.lessThan, '<'));
+
+
+    installPrimitiveProcedure(
+        '>',
+        baselib.arity.makeArityAtLeast(2),
+        makeChainingBinop(baselib.numbers.greaterThan, '>'));
+
+
+    installPrimitiveProcedure(
+        '<=',
+        baselib.arity.makeArityAtLeast(2),
+        makeChainingBinop(baselib.numbers.lessThanOrEqual, '<='));
+
+
+    installPrimitiveProcedure(
+        '>=',
+        baselib.arity.makeArityAtLeast(2),
+        makeChainingBinop(baselib.numbers.greaterThanOrEqual, '>='));
+
+
+    installPrimitiveProcedure(
+        '+',
+        baselib.arity.makeArityAtLeast(0),
+        function (M) {
+            var result = 0;
+            var i = 0;
+            for (i = 0; i < M.a; i++) {
+                result = baselib.numbers.add(
+                    result,
+                    checkNumber(M, '+', i));
+            }
+            return result;
+        });
+
+
+    installPrimitiveProcedure(
+        '*',
+        baselib.arity.makeArityAtLeast(0),
+        function (M) {
+            var result = 1;
+            var i = 0;
+            for (i=0; i < M.a; i++) {
+                result = baselib.numbers.multiply(
+                    result,
+                    checkNumber(M, '*', i));
+            }
+            return result;
+        });
+
+    installPrimitiveProcedure(
+        '-',
+        baselib.arity.makeArityAtLeast(1),
+        function (M) {
+            if (M.a === 1) {
+                return baselib.numbers.subtract(
+                    0,
+                    checkNumber(M, '-', 0));
+            }
+            var result = checkNumber(M, '-', 0), i;
+            for (i = 1; i < M.a; i++) {
+                result = baselib.numbers.subtract(
+                    result,
+                    checkNumber(M, '-', i));
+            }
+            return result;
+        });
+
+    installPrimitiveProcedure(
+        '/',
+        baselib.arity.makeArityAtLeast(1),
+        function (M) {
+            var result = checkNumber(M, '/', 0), i;
+            for (i = 1; i < M.a; i++) {
+                result = baselib.numbers.divide(
+                    result,
+                    checkNumber(M, '/', i));
+            }
+            return result;
+        });
+
+    installPrimitiveProcedure(
+        'add1',
+        1,
+        function (M) {
+            var firstArg = checkNumber(M, 'add1', 0);
+            return baselib.numbers.add(firstArg, 1);
+        });
+
+
+    installPrimitiveProcedure(
+        'sub1',
+        1,
+        function (M) {
+            var firstArg = checkNumber(M, 'sub1', 0);
+            return baselib.numbers.subtract(firstArg, 1);
+        });
+
+
+    installPrimitiveProcedure(
+        'zero?',
+        1,
+        function (M) {
+            var firstArg = M.e[M.e.length-1];
+            return baselib.numbers.equals(firstArg, 0);
+        });
+
+
+    installPrimitiveProcedure(
+        'cons',
+        2,
+        function (M) {
+            var firstArg = M.e[M.e.length-1];
+            var secondArg = M.e[M.e.length-2];
+            return makePair(firstArg, secondArg);
+        });
+
+
+    installPrimitiveProcedure(
+        'list',
+        baselib.arity.makeArityAtLeast(0),
+        function (M) {
+            var result = NULL, i;
+            for (i = 0; i < M.a; i++) {
+                result = makePair(M.e[M.e.length - (M.a - i)],
+                                  result);
+            }
+            return result;
+        });
+
+    installPrimitiveProcedure(
+        'list*',
+        baselib.arity.makeArityAtLeast(1),
+        function (M) {
+            var result = checkAny(M, 'list*', M.a - 1), i;
+            for (i = M.a - 2; i >= 0; i--) {
+                result = makePair(M.e[M.e.length - 1 - i],
+                                  result);
+            }
+            return result;
+        });
+
+
+    installPrimitiveProcedure(
+        'list-ref',
+        2,
+        function (M) {
+            var lst = checkList(M, 'list-ref', 0);
+            var index = checkNaturalInRange(M, 'list-ref', 1,
+                                            0, baselib.lists.length(lst));
+            return baselib.lists.listRef(lst, baselib.numbers.toFixnum(index));
+        });
+
+    installPrimitiveProcedure(
+        'unsafe-car',
+        1,
+        function (M) {
+            var firstArg = checkAny(M, 'unsafe-car', 0);
+            return firstArg.first;
+        });
+    installPrimitiveProcedure(
+        'unsafe-cdr',
+        1,
+        function (M) {
+            var firstArg = checkAny(M, 'unsafe-cdr', 0);
+            return firstArg.rest;
+        });
+    installPrimitiveProcedure(
+        'car',
+        1,
+        function (M) {
+            var firstArg = checkPair(M, 'car', 0);
+            return firstArg.first;
+        });
+    installPrimitiveProcedure(
+        'cdr',
+        1,
+        function (M) {
+            var firstArg = checkPair(M, 'cdr', 0);
+            return firstArg.rest;
+        });
+
+    //////////////////////////////////////////////////////////////////////
+    //////////////////////////////////////////////////////////////////////
+    // The code from this point up to the end of the c**r functions
+    // is autogenerated by whalesong/generate-c-star-d.rkt.
+    //
+    // Don't modify this code manually: rather, edit the generator and
+    // inject the content back in here.
+    // Too bad we don't have macros in JavaScript...
+
+    installPrimitiveProcedure(
+        'caar',
+        1,
+        function(M) {
+            var x = M.e[M.e.length-1];
+            if (isPair(x)&&isPair(x.first)) {
+                return x.first.first;
+            } else {
+                raiseArgumentTypeError(M, "caar", "caarable value", 0, x);
+            }
+        });
+    installPrimitiveProcedure(
+        'cdar',
+        1,
+        function(M) {
+            var x = M.e[M.e.length-1];
+            if (isPair(x)&&isPair(x.first)) {
+                return x.first.rest;
+            } else {
+                raiseArgumentTypeError(M, "cdar", "cdarable value", 0, x);
+            }
+        });
+    installPrimitiveProcedure(
+        'cadr',
+        1,
+        function(M) {
+            var x = M.e[M.e.length-1];
+            if (isPair(x)&&isPair(x.rest)) {
+                return x.rest.first;
+            } else {
+                raiseArgumentTypeError(M, "cadr", "cadrable value", 0, x);
+            }
+        });
+    installPrimitiveProcedure(
+        'cddr',
+        1,
+        function(M) {
+            var x = M.e[M.e.length-1];
+            if (isPair(x)&&isPair(x.rest)) {
+                return x.rest.rest;
+            } else {
+                raiseArgumentTypeError(M, "cddr", "cddrable value", 0, x);
+            }
+        });
+    installPrimitiveProcedure(
+        'caaar',
+        1,
+        function(M) {
+            var x = M.e[M.e.length-1];
+            if (isPair(x)&&isPair(x.first)&&isPair(x.first.first)) {
+                return x.first.first.first;
+            } else {
+                raiseArgumentTypeError(M, "caaar", "caaarable value", 0, x);
+            }
+        });
+    installPrimitiveProcedure(
+        'cdaar',
+        1,
+        function(M) {
+            var x = M.e[M.e.length-1];
+            if (isPair(x)&&isPair(x.first)&&isPair(x.first.first)) {
+                return x.first.first.rest;
+            } else {
+                raiseArgumentTypeError(M, "cdaar", "cdaarable value", 0, x);
+            }
+        });
+    installPrimitiveProcedure(
+        'cadar',
+        1,
+        function(M) {
+            var x = M.e[M.e.length-1];
+            if (isPair(x)&&isPair(x.first)&&isPair(x.first.rest)) {
+                return x.first.rest.first;
+            } else {
+                raiseArgumentTypeError(M, "cadar", "cadarable value", 0, x);
+            }
+        });
+    installPrimitiveProcedure(
+        'cddar',
+        1,
+        function(M) {
+            var x = M.e[M.e.length-1];
+            if (isPair(x)&&isPair(x.first)&&isPair(x.first.rest)) {
+                return x.first.rest.rest;
+            } else {
+                raiseArgumentTypeError(M, "cddar", "cddarable value", 0, x);
+            }
+        });
+    installPrimitiveProcedure(
+        'caadr',
+        1,
+        function(M) {
+            var x = M.e[M.e.length-1];
+            if (isPair(x)&&isPair(x.rest)&&isPair(x.rest.first)) {
+                return x.rest.first.first;
+            } else {
+                raiseArgumentTypeError(M, "caadr", "caadrable value", 0, x);
+            }
+        });
+    installPrimitiveProcedure(
+        'cdadr',
+        1,
+        function(M) {
+            var x = M.e[M.e.length-1];
+            if (isPair(x)&&isPair(x.rest)&&isPair(x.rest.first)) {
+                return x.rest.first.rest;
+            } else {
+                raiseArgumentTypeError(M, "cdadr", "cdadrable value", 0, x);
+            }
+        });
+    installPrimitiveProcedure(
+        'caddr',
+        1,
+        function(M) {
+            var x = M.e[M.e.length-1];
+            if (isPair(x)&&isPair(x.rest)&&isPair(x.rest.rest)) {
+                return x.rest.rest.first;
+            } else {
+                raiseArgumentTypeError(M, "caddr", "caddrable value", 0, x);
+            }
+        });
+    installPrimitiveProcedure(
+        'cdddr',
+        1,
+        function(M) {
+            var x = M.e[M.e.length-1];
+            if (isPair(x)&&isPair(x.rest)&&isPair(x.rest.rest)) {
+                return x.rest.rest.rest;
+            } else {
+                raiseArgumentTypeError(M, "cdddr", "cdddrable value", 0, x);
+            }
+        });
+    installPrimitiveProcedure(
+        'caaaar',
+        1,
+        function(M) {
+            var x = M.e[M.e.length-1];
+            if (isPair(x)&&isPair(x.first)&&isPair(x.first.first)&&isPair(x.first.first.first)) {
+                return x.first.first.first.first;
+            } else {
+                raiseArgumentTypeError(M, "caaaar", "caaaarable value", 0, x);
+            }
+        });
+    installPrimitiveProcedure(
+        'cdaaar',
+        1,
+        function(M) {
+            var x = M.e[M.e.length-1];
+            if (isPair(x)&&isPair(x.first)&&isPair(x.first.first)&&isPair(x.first.first.first)) {
+                return x.first.first.first.rest;
+            } else {
+                raiseArgumentTypeError(M, "cdaaar", "cdaaarable value", 0, x);
+            }
+        });
+    installPrimitiveProcedure(
+        'cadaar',
+        1,
+        function(M) {
+            var x = M.e[M.e.length-1];
+            if (isPair(x)&&isPair(x.first)&&isPair(x.first.first)&&isPair(x.first.first.rest)) {
+                return x.first.first.rest.first;
+            } else {
+                raiseArgumentTypeError(M, "cadaar", "cadaarable value", 0, x);
+            }
+        });
+    installPrimitiveProcedure(
+        'cddaar',
+        1,
+        function(M) {
+            var x = M.e[M.e.length-1];
+            if (isPair(x)&&isPair(x.first)&&isPair(x.first.first)&&isPair(x.first.first.rest)) {
+                return x.first.first.rest.rest;
+            } else {
+                raiseArgumentTypeError(M, "cddaar", "cddaarable value", 0, x);
+            }
+        });
+    installPrimitiveProcedure(
+        'caadar',
+        1,
+        function(M) {
+            var x = M.e[M.e.length-1];
+            if (isPair(x)&&isPair(x.first)&&isPair(x.first.rest)&&isPair(x.first.rest.first)) {
+                return x.first.rest.first.first;
+            } else {
+                raiseArgumentTypeError(M, "caadar", "caadarable value", 0, x);
+            }
+        });
+    installPrimitiveProcedure(
+        'cdadar',
+        1,
+        function(M) {
+            var x = M.e[M.e.length-1];
+            if (isPair(x)&&isPair(x.first)&&isPair(x.first.rest)&&isPair(x.first.rest.first)) {
+                return x.first.rest.first.rest;
+            } else {
+                raiseArgumentTypeError(M, "cdadar", "cdadarable value", 0, x);
+            }
+        });
+    installPrimitiveProcedure(
+        'caddar',
+        1,
+        function(M) {
+            var x = M.e[M.e.length-1];
+            if (isPair(x)&&isPair(x.first)&&isPair(x.first.rest)&&isPair(x.first.rest.rest)) {
+                return x.first.rest.rest.first;
+            } else {
+                raiseArgumentTypeError(M, "caddar", "caddarable value", 0, x);
+            }
+        });
+    installPrimitiveProcedure(
+        'cdddar',
+        1,
+        function(M) {
+            var x = M.e[M.e.length-1];
+            if (isPair(x)&&isPair(x.first)&&isPair(x.first.rest)&&isPair(x.first.rest.rest)) {
+                return x.first.rest.rest.rest;
+            } else {
+                raiseArgumentTypeError(M, "cdddar", "cdddarable value", 0, x);
+            }
+        });
+    installPrimitiveProcedure(
+        'caaadr',
+        1,
+        function(M) {
+            var x = M.e[M.e.length-1];
+            if (isPair(x)&&isPair(x.rest)&&isPair(x.rest.first)&&isPair(x.rest.first.first)) {
+                return x.rest.first.first.first;
+            } else {
+                raiseArgumentTypeError(M, "caaadr", "caaadrable value", 0, x);
+            }
+        });
+    installPrimitiveProcedure(
+        'cdaadr',
+        1,
+        function(M) {
+            var x = M.e[M.e.length-1];
+            if (isPair(x)&&isPair(x.rest)&&isPair(x.rest.first)&&isPair(x.rest.first.first)) {
+                return x.rest.first.first.rest;
+            } else {
+                raiseArgumentTypeError(M, "cdaadr", "cdaadrable value", 0, x);
+            }
+        });
+    installPrimitiveProcedure(
+        'cadadr',
+        1,
+        function(M) {
+            var x = M.e[M.e.length-1];
+            if (isPair(x)&&isPair(x.rest)&&isPair(x.rest.first)&&isPair(x.rest.first.rest)) {
+                return x.rest.first.rest.first;
+            } else {
+                raiseArgumentTypeError(M, "cadadr", "cadadrable value", 0, x);
+            }
+        });
+    installPrimitiveProcedure(
+        'cddadr',
+        1,
+        function(M) {
+            var x = M.e[M.e.length-1];
+            if (isPair(x)&&isPair(x.rest)&&isPair(x.rest.first)&&isPair(x.rest.first.rest)) {
+                return x.rest.first.rest.rest;
+            } else {
+                raiseArgumentTypeError(M, "cddadr", "cddadrable value", 0, x);
+            }
+        });
+    installPrimitiveProcedure(
+        'caaddr',
+        1,
+        function(M) {
+            var x = M.e[M.e.length-1];
+            if (isPair(x)&&isPair(x.rest)&&isPair(x.rest.rest)&&isPair(x.rest.rest.first)) {
+                return x.rest.rest.first.first;
+            } else {
+                raiseArgumentTypeError(M, "caaddr", "caaddrable value", 0, x);
+            }
+        });
+    installPrimitiveProcedure(
+        'cdaddr',
+        1,
+        function(M) {
+            var x = M.e[M.e.length-1];
+            if (isPair(x)&&isPair(x.rest)&&isPair(x.rest.rest)&&isPair(x.rest.rest.first)) {
+                return x.rest.rest.first.rest;
+            } else {
+                raiseArgumentTypeError(M, "cdaddr", "cdaddrable value", 0, x);
+            }
+        });
+    installPrimitiveProcedure(
+        'cadddr',
+        1,
+        function(M) {
+            var x = M.e[M.e.length-1];
+            if (isPair(x)&&isPair(x.rest)&&isPair(x.rest.rest)&&isPair(x.rest.rest.rest)) {
+                return x.rest.rest.rest.first;
+            } else {
+                raiseArgumentTypeError(M, "cadddr", "cadddrable value", 0, x);
+            }
+        });
+    installPrimitiveProcedure(
+        'cddddr',
+        1,
+        function(M) {
+            var x = M.e[M.e.length-1];
+            if (isPair(x)&&isPair(x.rest)&&isPair(x.rest.rest)&&isPair(x.rest.rest.rest)) {
+                return x.rest.rest.rest.rest;
+            } else {
+                raiseArgumentTypeError(M, "cddddr", "cddddrable value", 0, x);
+            }
+        });
+
+    // End autogenerated code.
+    //////////////////////////////////////////////////////////////////////
+    //////////////////////////////////////////////////////////////////////
+
+
+    installPrimitiveProcedure(
+        'pair?',
+        1,
+        function (M) {
+            var firstArg = M.e[M.e.length-1];
+            return isPair(firstArg);
+        });
+
+
+    installPrimitiveProcedure(
+        'list?',
+        1,
+        function (M) {
+            return isList(M.e[M.e.length -1]);
+        });
+
+
+    installPrimitiveProcedure(
+        'set-car!',
+        2,
+        function (M) {
+            var firstArg = checkPair(M, 'set-car!', 0);
+            var secondArg = M.e[M.e.length-2];
+            firstArg.first = secondArg;
+            return VOID;
+        });
+
+
+    installPrimitiveProcedure(
+        'set-cdr!',
+        2,
+        function (M) {
+            var firstArg = checkPair(M, 'set-car!', 0);
+            var secondArg = M.e[M.e.length-2];
+            firstArg.rest = secondArg;
+            return VOID;
+        });
+
+    installPrimitiveProcedure(
+        'not',
+        1,
+        function (M) {
+            var firstArg = M.e[M.e.length-1];
+            return (firstArg === false);
+        });
+
+
+    installPrimitiveProcedure(
+        'null?',
+        1,
+        function (M) {
+            var firstArg = M.e[M.e.length-1];
+            return firstArg === NULL;
+        });
+
+
+    installPrimitiveProcedure(
+        'vector?',
+        1,
+        function (M) {
+            var firstArg = M.e[M.e.length-1];
+            return isVector(firstArg);
+        });
+
+    installPrimitiveProcedure(
+        'vector',
+        baselib.arity.makeArityAtLeast(0),
+        function (M) {
+            var i;
+            var result = [];
+            for (i = 0; i < M.a; i++) {
+                result.push(M.e[M.e.length-1-i]);
+            }
+            var newVector = makeVector(result);
+            return newVector;
+        });
+
+
+    installPrimitiveProcedure(
+        'make-vector',
+        makeList(1, 2),
+        function (M) {
+            var value = 0;
+            var length = baselib.numbers.toFixnum(
+                checkNatural(M, 'make-vector', 0));
+            if (M.a === 2) {
+                value = M.e[M.e.length - 2];
+            }
+            var arr = [];
+	    var i;
+            for(i = 0; i < length; i++) {
+                arr[i] = value;
+            }
+            return makeVector(arr);
+        });
+
+    installPrimitiveProcedure(
+        'vector->list',
+        1,
+        function (M) {
+            var elts = checkVector(M, 'vector->list', 0).elts;
+            var i;
+            var result = NULL;
+            for (i = 0; i < elts.length; i++) {
+                result = makePair(elts[elts.length - 1 - i], result);
+            }
+            return result;
+        });
+
+    installPrimitiveProcedure(
+        'list->vector',
+        1,
+        function (M) {
+            var firstArg = checkList(M, 'list->vector', 0);
+            var result = [];
+            while (firstArg !== NULL) {
+                result.push(firstArg.first);
+                firstArg = firstArg.rest;
+            }
+            return makeVector(result);
+        });
+
+
+    installPrimitiveProcedure(
+        'vector-ref',
+        2,
+        function (M) {
+            var elts = checkVector(M, 'vector-ref', 0).elts;
+            var index = baselib.numbers.toFixnum(
+                checkNaturalInRange(M, 'vector-ref', 1, 0, elts.length));
+            return elts[index];
+        });
+
+
+    installPrimitiveProcedure(
+        'vector-set!',
+        3,
+        function (M) {
+            var elts = checkVector(M, 'vector-set!', 0).elts;
+            // FIXME: check out-of-bounds vector
+            var index = baselib.numbers.toFixnum(
+                checkNaturalInRange(M, 'vector-set!', 1,
+                                    0, elts.length));
+            var val = M.e[M.e.length - 1 - 2];
+            elts[index] = val;
+            return VOID;
+        });
+
+
+    installPrimitiveProcedure(
+        'vector-length',
+        1,
+        function (M) {
+            return checkVector(M, 'vector-length', 0).elts.length;
+        });
+
+
+
+    installPrimitiveProcedure(
+        'make-string',
+        makeList(1, 2),
+        function (M) {
+            var value = String.fromCharCode(0);
+            var length = baselib.numbers.toFixnum(
+                checkNatural(M, 'make-string', 0));
+            if (M.a === 2) {
+                value = checkChar(M, 'make-string', 1).val;
+            }
+            var arr = [];
+	    var i;
+            for(i = 0; i < length; i++) {
+                arr[i] = value;
+            }
+            return baselib.strings.makeMutableString(arr);
+        });
+
+    installPrimitiveProcedure(
+        'substring',
+        makeList(2, 3),
+        function(M) {
+            var str = checkString(M, 'substring', 0).toString();
+            var start = baselib.numbers.toFixnum(checkNatural(M, 'substring', 1));
+            var end = str.length;
+            if (M.a === 3) {
+                end = baselib.numbers.toFixnum(checkNatural(M, 'substring', 2));
+            }
+            return baselib.strings.makeMutableString((str.substring(start, end)).split(""));
+        });
+
+    installPrimitiveProcedure(
+        'string-copy',
+        1,
+        function(M) {
+            var str = checkString(M, 'substring', 0).toString();
+            return baselib.strings.makeMutableString(str.substring(0, str.length).split(""));
+        });
+
+
+    installPrimitiveProcedure(
+        'list->string',
+        1,
+        function (M) {
+            var firstArg = checkListofChars(M, 'list->string', 0);
+            var result = [];
+            while (firstArg !== NULL) {
+                result.push(firstArg.first.val);
+                firstArg = firstArg.rest;
+            }
+            return result.join('');
+        });
+
+
+    installPrimitiveProcedure(
+        'string',
+        baselib.arity.makeArityAtLeast(0),
+        function (M) {
+            var i;
+            var chars = [];
+            for (i = 0; i < M.a; i++) {
+                chars.push(checkChar(M, 'string', i).val);
+            }
+            return chars.join('');
+        });
+
+
+    installPrimitiveProcedure(
+        'string->list',
+        1,
+        function (M) {
+            var str = checkString(M, 'string->list', 0).toString();
+            var i;
+            var result = NULL;
+            for (i = str.length - 1; i >= 0; i--) {
+                result = makePair(baselib.chars.makeChar(str.charAt(i)), result);
+            }
+            return result;
+        });
+
+
+
+    installPrimitiveProcedure(
+        'string-set!',
+        3,
+        function (M) {
+            var str = checkMutableString(M, 'string-set!', 0);
+            var k = checkNatural(M, 'string-set!', 1);
+            var ch = checkChar(M, 'string-set!', 2);
+	    str.set(baselib.numbers.toFixnum(k), ch.val);
+            return VOID;
+        });
+
+
+
+
+
+    installPrimitiveProcedure(
+        'symbol?',
+        1,
+        function (M) {
+            var firstArg = M.e[M.e.length-1];
+            return isSymbol(firstArg);
+        });
+
+    installPrimitiveProcedure(
+        'symbol->string',
+        1,
+        function (M) {
+            var firstArg = checkSymbol(M, 'symbol->string', 0);
+            return firstArg.toString();
+        });
+
+
+    installPrimitiveProcedure(
+        'string=?',
+        baselib.arity.makeArityAtLeast(1),
+        function (M) {
+            var s = checkString(M, 'string=?', 0).toString();
+	    var i;
+            for (i = 1; i < M.a; i++) {
+                if (s !== checkString(M, 'string=?', i).toString()) {
+                    return false;
+                }
+            }
+            return true;
+        });
+
+
+    installPrimitiveProcedure(
+        'string<=?',
+        baselib.arity.makeArityAtLeast(1),
+        function (M) {
+            var s = checkString(M, 'string<=?', 0).toString();
+	    var i;
+            for (i = 1; i < M.a; i++) {
+                if ((s <= checkString(M, 'string<=?', i).toString()) === false) {
+                    return false;
+                }
+            }
+            return true;
+        });
+
+    installPrimitiveProcedure(
+        'string<?',
+        baselib.arity.makeArityAtLeast(1),
+        function (M) {
+            var s = checkString(M, 'string<?', 0).toString();
+	    var i;
+            for (i = 1; i < M.a; i++) {
+                if ((s < checkString(M, 'string<?', i).toString()) === false) {
+                    return false;
+                }
+            }
+            return true;
+        });
+
+    installPrimitiveProcedure(
+        'string>=?',
+        baselib.arity.makeArityAtLeast(1),
+        function (M) {
+            var s = checkString(M, 'string>=?', 0).toString();
+	    var i;
+            for (i = 1; i < M.a; i++) {
+                if ((s >= checkString(M, 'string>=?', i).toString()) === false) {
+                    return false;
+                }
+            }
+            return true;
+        });
+
+    installPrimitiveProcedure(
+        'string>?',
+        baselib.arity.makeArityAtLeast(1),
+        function (M) {
+            var s = checkString(M, 'string>?', 0).toString();
+	    var i;
+            for (i = 1; i < M.a; i++) {
+                if ((s > checkString(M, 'string>?', i).toString()) === false) {
+                    return false;
+                }
+            }
+            return true;
+        });
+
+
+    installPrimitiveProcedure(
+        'string-ci=?',
+        baselib.arity.makeArityAtLeast(1),
+        function (M) {
+            var s = checkString(M, 'string-ci=?', 0).toString().toUpperCase();
+	    var i;
+            for (i = 1; i < M.a; i++) {
+                if (s !== checkString(M, 'string-ci=?', i).toString().toUpperCase()) {
+                    return false;
+                }
+            }
+            return true;
+        });
+
+
+    installPrimitiveProcedure(
+        'string-ci<=?',
+        baselib.arity.makeArityAtLeast(1),
+        function (M) {
+            var s = checkString(M, 'string-ci<=?', 0).toString().toUpperCase();
+	    var i;
+            for (i = 1; i < M.a; i++) {
+                if ((s <= checkString(M, 'string-ci<=?', i).toString().toUpperCase()) === false) {
+                    return false;
+                }
+            }
+            return true;
+        });
+
+    installPrimitiveProcedure(
+        'string-ci<?',
+        baselib.arity.makeArityAtLeast(1),
+        function (M) {
+            var s = checkString(M, 'string-ci<?', 0).toString().toUpperCase();
+	    var i;
+            for (i = 1; i < M.a; i++) {
+                if ((s < checkString(M, 'string-ci<?', i).toString().toUpperCase()) === false) {
+                    return false;
+                }
+            }
+            return true;
+        });
+
+    installPrimitiveProcedure(
+        'string-ci>=?',
+        baselib.arity.makeArityAtLeast(1),
+        function (M) {
+            var s = checkString(M, 'string-ci>=?', 0).toString().toUpperCase();
+	    var i;
+            for (i = 1; i < M.a; i++) {
+                if ((s >= checkString(M, 'string-ci>=?', i).toString().toUpperCase()) === false) {
+                    return false;
+                }
+            }
+            return true;
+        });
+
+    installPrimitiveProcedure(
+        'string-ci>?',
+        baselib.arity.makeArityAtLeast(1),
+        function (M) {
+            var s = checkString(M, 'string-ci>?', 0).toString().toUpperCase();
+	    var i;
+            for (i = 1; i < M.a; i++) {
+                if ((s > checkString(M, 'string-ci>?', i).toString().toUpperCase()) === false) {
+                    return false;
+                }
+            }
+            return true;
+        });
+
+
+    installPrimitiveProcedure(
+        'string-append',
+        baselib.arity.makeArityAtLeast(0),
+        function (M) {
+            var buffer = [];
+            var i;
+            for (i = 0; i < M.a; i++) {
+                buffer.push(checkString(M, 'string-append', i).toString());
+            }
+            return buffer.join('');
+        });
+
+    installPrimitiveProcedure(
+        'string-length',
+        1,
+        function (M) {
+            var firstArg = checkString(M, 'string-length', 0).toString();
+            return firstArg.length;
+        });
+
+
+    installPrimitiveProcedure(
+        'string-ref',
+        2,
+        function (M) {
+            var firstArg = checkString(M, 'string-ref', 0).toString();
+            var index = baselib.numbers.toFixnum(
+                checkNaturalInRange(M, 'string-ref', 1,
+                                    0, firstArg.length));
+            return baselib.chars.makeChar(firstArg.charAt(index));
+        });
+
+
+
+    installPrimitiveProcedure(
+        'string?',
+        1,
+        function (M) {
+            return isString(M.e[M.e.length - 1]);
+        });
+
+
+    installPrimitiveProcedure(
+        'number->string',
+        1,
+        function (M) {
+            return checkNumber(M, 'number->string', 0).toString();
+        });
+
+
+    installPrimitiveProcedure(
+        'string->symbol',
+        1,
+        function (M) {
+            return makeSymbol(checkString(M, 'string->symbol', 0).toString());
+        });
+
+
+    installPrimitiveProcedure(
+        'string->number',
+        1,
+        function (M) {
+            return baselib.numbers.fromString(
+                checkString(M, 'string->number', 0).toString());
+        });
+
+
+    installPrimitiveProcedure(
+        'boolean?',
+        1,
+        function(M) {
+            var v = M.e[M.e.length - 1];
+            return (v === true || v === false);
+        });
+
+
+    installPrimitiveProcedure(
+        'char?',
+        1,
+        function(M) {
+            return isChar(M.e[M.e.length -1 ]);
+        });
+
+
+    var makeCharComparator = function(name, cmp) {
+        return function(M) {
+            var s = checkChar(M, name, 0).val;
+	    var i;
+            for (i = 1; i < M.a; i++) {
+                if (!(cmp(s, checkChar(M, name, i).val))) {
+                    return false;
+                }
+            }
+            return true;
+        };
+    };
+
+    installPrimitiveProcedure(
+        'char>?',
+        baselib.arity.makeArityAtLeast(2),
+        makeCharComparator('char>?',
+                           function(x, y) {
+                               return x > y;
+                           }));
+
+    installPrimitiveProcedure(
+        'char>=?',
+        baselib.arity.makeArityAtLeast(2),
+        makeCharComparator('char>=?',
+                           function(x, y) {
+                               return x >= y;
+                           }));
+
+    installPrimitiveProcedure(
+        'char<?',
+        baselib.arity.makeArityAtLeast(2),
+        makeCharComparator('char<?',
+                           function(x, y) {
+                               return x < y;
+                           }));
+
+    installPrimitiveProcedure(
+        'char<=?',
+        baselib.arity.makeArityAtLeast(2),
+        makeCharComparator('char<=?',
+                           function(x, y) {
+                               return x <= y;
+                           }));
+
+    installPrimitiveProcedure(
+        'char=?',
+        baselib.arity.makeArityAtLeast(2),
+        makeCharComparator('char=?',
+                           function(x, y) {
+                               return x === y;
+                           }));
+
+    installPrimitiveProcedure(
+        'char-ci>?',
+        baselib.arity.makeArityAtLeast(2),
+        makeCharComparator('char-ci>?',
+                           function(x, y) {
+                               return x.toUpperCase() > y.toUpperCase();
+                           }));
+
+    installPrimitiveProcedure(
+        'char-ci>=?',
+        baselib.arity.makeArityAtLeast(2),
+        makeCharComparator('char-ci>=?',
+                           function(x, y) {
+                               return x.toUpperCase() >= y.toUpperCase();
+                           }));
+
+    installPrimitiveProcedure(
+        'char-ci<?',
+        baselib.arity.makeArityAtLeast(2),
+        makeCharComparator('char-ci<?',
+                           function(x, y) {
+                               return x.toUpperCase() < y.toUpperCase();
+                           }));
+
+    installPrimitiveProcedure(
+        'char-ci<=?',
+        baselib.arity.makeArityAtLeast(2),
+        makeCharComparator('char-ci<=?',
+                           function(x, y) {
+                               return x.toUpperCase() <= y.toUpperCase();
+                           }));
+
+    installPrimitiveProcedure(
+        'char-ci=?',
+        baselib.arity.makeArityAtLeast(2),
+        makeCharComparator('char-ci=?',
+                           function(x, y) {
+                               return x.toUpperCase() === y.toUpperCase();
+                           }));
+
+
+
+    installPrimitiveProcedure(
+        'char->integer',
+        1,
+        function(M) {
+            return checkChar(M, 'char->integer', 0).val.charCodeAt(0);
+        });
+
+    installPrimitiveProcedure(
+        'integer->char',
+        1,
+        function(M) {
+            var ch = baselib.numbers.toFixnum(checkIntegerForChar(M, 'integer->char', 0));
+            return baselib.chars.makeChar(String.fromCharCode(ch));
+        });
+
+    installPrimitiveProcedure(
+        'char-upcase',
+        1,
+        function(M) {
+            var ch = checkChar(M, 'char=?', 0).val;
+            return baselib.chars.makeChar(ch.toUpperCase());
+        });
+
+    installPrimitiveProcedure(
+        'char-downcase',
+        1,
+        function(M) {
+            var ch = checkChar(M, 'char=?', 0).val;
+            return baselib.chars.makeChar(ch.toLowerCase());
+        });
+
+    installPrimitiveProcedure(
+        'char-numeric?',
+        1,
+        function(M) {
+            var val = checkChar(M, 'char-numeric?', 0).val;
+            return val >= '0' && val <= '9';
+        });
+
+    installPrimitiveProcedure(
+        'char-alphabetic?',
+        1,
+        function(M) {
+            var val = checkChar(M, 'char-alphabetic?', 0).val;
+            return ((val >= 'a' && val <= 'z') ||
+                    (val >= 'A' && val <= 'Z'));
+        });
+
+    var whitespaceRegexp = new RegExp("^\\s*$");
+    installPrimitiveProcedure(
+        'char-whitespace?',
+        1,
+        function(M) {
+            var val = checkChar(M, 'char-whitespace?', 0).val;
+            return val.match(whitespaceRegexp ? true : false);
+      });
+
+
+    installPrimitiveProcedure(
+        'char-upper-case?',
+        1,
+        function(M) {
+            var val = checkChar(M, 'char-upper-case?', 0).val;
+            return val === val.toUpperCase();
+      });
+
+    installPrimitiveProcedure(
+        'char-lower-case?',
+        1,
+        function(M) {
+            var val = checkChar(M, 'char-lower-case?', 0).val;
+            return val === val.toLowerCase();
+      });
+
+
+    installPrimitiveProcedure(
+        'box',
+        1,
+        function (M) {
+            var firstArg = M.e[M.e.length-1];
+            return makeBox(firstArg);
+        });
+
+    installPrimitiveProcedure(
+        'unbox',
+        1,
+        function (M) {
+            var firstArg = checkBox(M, 'unbox', 0);
+            return firstArg.ref();
+        });
+
+    installPrimitiveProcedure(
+        'set-box!',
+        2,
+        function (M) {
+            var firstArg = checkMutableBox(M, 'set-box!', 0);
+            var secondArg = M.e[M.e.length-2];
+            firstArg.set(secondArg);
+            return VOID;
+        });
+
+    installPrimitiveProcedure(
+        'void',
+        baselib.arity.makeArityAtLeast(0),
+        function (M) {
+            return VOID;
+        });
+
+
+    installPrimitiveProcedure(
+        'random',
+        makeList(0, 1),
+        function (M) {
+            if (M.a === 0) {
+                return makeFloat(Math.random());
+            } else {
+                var n = checkNatural(M, 'random', 0);
+                return Math.floor(Math.random() * baselib.numbers.toFixnum(n));
+            }
+        });
+
+
+    installPrimitiveProcedure(
+        'eq?',
+        2,
+        function (M) {
+            var firstArg = M.e[M.e.length-1];
+            var secondArg = M.e[M.e.length-2];
+            return firstArg === secondArg;
+        });
+
+    installPrimitiveProcedure(
+        'eqv?',
+        2,
+        function (M) {
+            var firstArg = M.e[M.e.length-1];
+            var secondArg = M.e[M.e.length-2];
+            return baselib.equality.eqv(firstArg, secondArg);
+        });
+
+
+
+    installPrimitiveProcedure(
+        'equal?',
+        2,
+        function (M) {
+            var firstArg = M.e[M.e.length-1];
+            var secondArg = M.e[M.e.length-2];
+            return equals(firstArg, secondArg);
+        });
+
+
+    // This definition of apply will take precedence over the
+    // implementation of apply in the boostrapped-primitives.rkt,
+    // since it provides nicer error handling.
+    var applyImplementation = function (M) {
+        if(--M.cbt < 0) {
+            throw applyImplementation;
+        }
+        var proc = checkProcedure(M, 'apply', 0);
+        M.e.pop();
+        M.a--;
+        checkList(M, 'apply', M.a - 1);
+        M.spliceListIntoStack(M.a - 1);
+        M.p = proc;
+        if (baselib.arity.isArityMatching(proc.racketArity, M.a)) {
+            return proc.label(M);
+        } else {
+            raiseArityMismatchError(M, proc, M.a);
+        }
+    };
+
+    installPrimitiveClosure(
+        'apply',
+        baselib.arity.makeArityAtLeast(2),
+        applyImplementation);
+
+
+    // FIXME: The definition of call-with-values is in
+    // bootstrapped-primitives.rkt.  We may want to replace it with an
+    // explicitly defined one here.
+
+
+
+
+
+    installPrimitiveProcedure(
+        'procedure?',
+        1,
+        function (M) {
+            return isProcedure(M.e[M.e.length - 1]);
+        });
+
+    installPrimitiveProcedure(
+        'procedure-arity-includes?',
+        2,
+        function (M) {
+            var proc = checkProcedure(M, 'procedure-arity-includes?', 0);
+            var a = checkNatural(M, 'procedure-arity-includes?', 1);
+            return baselib.arity.isArityMatching(proc.racketArity, a);
+        });
+
+    installPrimitiveProcedure(
+        'procedure-arity',
+        1,
+        function (M) {
+            var proc = checkProcedure(M, 'procedure-arity-includes?', 0);
+            return proc.racketArity;
+        });
+
+
+    installPrimitiveProcedure(
+        'procedure-rename',
+        2,
+        function (M) {
+            var proc = checkProcedure(M, 'procedure-rename', 0);
+            var name = checkSymbol(M, 'procedure-rename', 1);
+            return baselib.functions.renameProcedure(proc, name);
+        });
+
+
+
+    installPrimitiveProcedure(
+        'member',
+        2,
+        function (M) {
+            var x = M.e[M.e.length-1];
+            var lst = M.e[M.e.length-2];
+            while (true) {
+                if (lst === NULL) {
+                    return false;
+                }
+                if (! isPair(lst)) {
+                    raiseArgumentTypeError(M,
+                                           'member',
+                                           'list',
+                                           1,
+                                           M.e[M.e.length - 1 - 1]);
+                }
+                if (equals(x, (lst.first))) {
+                    return lst;
+                }
+                lst = lst.rest;
+            }
+        });
+
+
+    installPrimitiveProcedure(
+        'reverse',
+        1,
+        function (M) {
+            var rev = NULL;
+            var lst = M.e[M.e.length-1];
+            while(lst !== NULL) {
+                rev = makePair(testArgument(M, 'pair', isPair, lst, 0, 'reverse').first,
+                               rev);
+                lst = lst.rest;
+            }
+            return rev;
+        });
+
+    installPrimitiveProcedure(
+        'void?',
+        1,
+        function(M) {
+            return M.e[M.e.length -1] === VOID;
+        });
+
+
+    installPrimitiveProcedure(
+        'box?',
+        1,
+        function(M) {
+            return isBox(M.e[M.e.length -1]);
+        });
+
+
+    installPrimitiveProcedure(
+        'eof-object?',
+        1,
+        function(M) {
+            return M.e[M.e.length -1] === baselib.constants.EOF_VALUE;
+        });
+
+    installPrimitiveProcedure(
+	'number?',
+	1,
+	function(M) {
+	    return isNumber(M.e[M.e.length - 1]);
+	});
+
+    installPrimitiveProcedure(
+	'real?',
+	1,
+	function(M) {
+	    return isReal(M.e[M.e.length - 1]);
+	});
+
+    installPrimitiveProcedure(
+	'inexact?',
+	1,
+	function(M) {
+	    return isInexact(M.e[M.e.length - 1]);
+	});
+
+    installPrimitiveProcedure(
+	'complex?',
+	1,
+	function(M) {
+	    return isComplex(M.e[M.e.length - 1]);
+	});
+
+    installPrimitiveProcedure(
+        'bytes?',
+        1,
+        function(M) {
+            return isBytes(M.e[M.e.length-1]);
+        });
+
+    installPrimitiveProcedure(
+	'byte?',
+	1,
+	function(M) {
+	    var v = M.e[M.e.length - 1];
+            if(!isNatural(v)) { return false; }
+            v = baselib.numbers.toFixnum(v);
+            return v >= 0 && v < 256;
+	});
+
+    installPrimitiveProcedure(
+	'rational?',
+	1,
+	function(M) {
+	    return isRational(M.e[M.e.length - 1]);
+	});
+
+    installPrimitiveProcedure(
+        'even?',
+        1,
+        function(M) {
+            var n = checkInteger(M, 'even?', 0);
+            return baselib.numbers.equals(0, baselib.numbers.modulo(n, 2));
+        });
+
+    installPrimitiveProcedure(
+        'odd?',
+        1,
+        function(M) {
+            var n = checkInteger(M, 'odd?', 0);
+            return baselib.numbers.equals(1, baselib.numbers.modulo(n, 2));
+        });
+
+
+    installPrimitiveProcedure(
+        'positive?',
+        1,
+        function(M) {
+            var n = checkReal(M, 'positive?', 0);
+            return baselib.numbers.greaterThan(n, 0);
+        });
+
+    installPrimitiveProcedure(
+        'negative?',
+        1,
+        function(M) {
+            var n = checkReal(M, 'negative?', 0);
+            return baselib.numbers.lessThan(n, 0);
+        });
+
+
+    installPrimitiveProcedure(
+        'inexact->exact',
+        1,
+        function (M) {
+            return baselib.numbers.toExact(
+                checkNumber(M, 'inexact->exact', 0));
+        });
+
+    installPrimitiveProcedure(
+        'exact->inexact',
+        1,
+        function (M) {
+            return baselib.numbers.toInexact(
+                checkNumber(M, 'exact->inexact', 0));
+        });
+
+    installPrimitiveProcedure(
+        'abs',
+        1,
+        function (M) {
+            return baselib.numbers.abs(
+                checkNumber(M, 'abs', 0));
+        });
+
+    installPrimitiveProcedure(
+        'acos',
+        1,
+        function (M) {
+            return baselib.numbers.acos(
+                checkNumber(M, 'acos', 0));
+        });
+
+
+    installPrimitiveProcedure(
+        'asin',
+        1,
+        function (M) {
+            return baselib.numbers.asin(
+                checkNumber(M, 'asin', 0));
+        });
+
+    installPrimitiveProcedure(
+        'sin',
+        1,
+        function (M) {
+            return baselib.numbers.sin(
+                checkNumber(M, 'sin', 0));
+        });
+
+
+
+    installPrimitiveProcedure(
+        'sinh',
+        1,
+        function (M) {
+            return baselib.numbers.sinh(
+                checkNumber(M, 'sinh', 0));
+        });
+
+
+    installPrimitiveProcedure(
+        'tan',
+        1,
+        function (M) {
+            return baselib.numbers.tan(
+                checkNumber(M, 'tan', 0));
+        });
+
+
+    installPrimitiveProcedure(
+        'atan',
+        makeList(1, 2),
+        function (M) {
+            if (M.a === 1) {
+                return baselib.numbers.atan(
+                    checkNumber(M, 'atan', 0));
+            } else {
+                return makeFloat(
+                    Math.atan2(
+                        baselib.numbers.toFixnum(checkNumber(M, 'atan', 0)),
+                        baselib.numbers.toFixnum(checkNumber(M, 'atan', 1))));
+            }
+        });
+
+
+    installPrimitiveProcedure(
+        'angle',
+        1,
+        function (M) {
+            return baselib.numbers.angle(
+                checkNumber(M, 'angle', 0));
+        });
+
+    installPrimitiveProcedure(
+        'magnitude',
+        1,
+        function (M) {
+            return baselib.numbers.magnitude(
+                checkNumber(M, 'magnitude', 0));
+        });
+
+    installPrimitiveProcedure(
+        'conjugate',
+        1,
+        function (M) {
+            return baselib.numbers.conjugate(
+                checkNumber(M, 'conjugate', 0));
+        });
+
+
+
+
+    installPrimitiveProcedure(
+        'cos',
+        1,
+        function (M) {
+            return baselib.numbers.cos(
+                checkNumber(M, 'cos', 0));
+        });
+
+
+    installPrimitiveProcedure(
+        'cosh',
+        1,
+        function (M) {
+            return baselib.numbers.cosh(
+                checkNumber(M, 'cosh', 0));
+        });
+
+    installPrimitiveProcedure(
+        'gcd',
+        baselib.arity.makeArityAtLeast(1),
+        function (M) {
+            var args = [], i, x;
+            for (i = 0; i < M.a; i++) {
+                args.push(checkNumber(M, 'gcd', i));
+            }
+            x = args.shift();
+            return baselib.numbers.gcd(x, args);
+        });
+
+    installPrimitiveProcedure(
+        'lcm',
+        baselib.arity.makeArityAtLeast(1),
+        function (M) {
+            var args = [], i, x;
+            for (i = 0; i < M.a; i++) {
+                args.push(checkNumber(M, 'lcm', i));
+            }
+            x = args.shift();
+            return baselib.numbers.lcm(x, args);
+        });
+
+
+
+
+    installPrimitiveProcedure(
+        'exp',
+        1,
+        function (M) {
+            return baselib.numbers.exp(
+                checkNumber(M, 'exp', 0));
+        });
+
+
+    installPrimitiveProcedure(
+        'expt',
+        2,
+        function (M) {
+            return baselib.numbers.expt(
+                checkNumber(M, 'expt', 0),
+                checkNumber(M, 'expt', 1));
+        });
+
+    installPrimitiveProcedure(
+        'exact?',
+        1,
+        function (M) {
+            return baselib.numbers.isExact(
+                checkNumber(M, 'exact?', 0));
+        });
+
+
+    installPrimitiveProcedure(
+        'integer?',
+        1,
+        function (M) {
+            return baselib.numbers.isInteger(M.e[M.e.length - 1]);
+        });
+
+    installPrimitiveProcedure(
+        'exact-integer?',
+        1,
+        function (M) {
+            return (baselib.numbers.isInteger(M.e[M.e.length - 1]) &&
+                    baselib.numbers.isExact(M.e[M.e.length - 1]));
+        });
+
+    installPrimitiveProcedure(
+        'exact-nonnegative-integer?',
+        1,
+        function (M) {
+            return isNatural(M.e[M.e.length - 1]);
+        });
+
+
+
+    installPrimitiveProcedure(
+        'imag-part',
+        1,
+        function (M) {
+            return baselib.numbers.imaginaryPart(
+                checkNumber(M, 'imag-part', 0));
+        });
+
+
+    installPrimitiveProcedure(
+        'real-part',
+        1,
+        function (M) {
+            return baselib.numbers.realPart(
+                checkNumber(M, 'real-part', 0));
+        });
+
+
+    installPrimitiveProcedure(
+        'make-polar',
+        2,
+        function (M) {
+            return makeComplexPolar(
+                checkReal(M, 'make-polar', 0),
+                checkReal(M, 'make-polar', 1));
+        });
+
+
+    installPrimitiveProcedure(
+        'make-rectangular',
+        2,
+        function (M) {
+            return makeComplex(
+                checkReal(M, 'make-rectangular', 0),
+                checkReal(M, 'make-rectangular', 1));
+        });
+
+    installPrimitiveProcedure(
+        'modulo',
+        2,
+        function (M) {
+            return baselib.numbers.modulo(
+                checkInteger(M, 'modulo', 0),
+                checkInteger(M, 'modulo', 1));
+        });
+
+
+    installPrimitiveProcedure(
+        'remainder',
+        2,
+        function (M) {
+            return baselib.numbers.remainder(
+                checkInteger(M, 'remainder', 0),
+                checkInteger(M, 'remainder', 1));
+        });
+
+
+    installPrimitiveProcedure(
+        'quotient',
+        2,
+        function (M) {
+            return baselib.numbers.quotient(
+                checkInteger(M, 'quotient', 0),
+                checkInteger(M, 'quotient', 1));
+        });
+
+
+
+    installPrimitiveProcedure(
+        'floor',
+        1,
+        function (M) {
+            return baselib.numbers.floor(
+                checkReal(M, 'floor', 0));
+        });
+
+
+    installPrimitiveProcedure(
+        'ceiling',
+        1,
+        function (M) {
+            return baselib.numbers.ceiling(
+                checkReal(M, 'ceiling', 0));
+        });
+
+
+    installPrimitiveProcedure(
+        'round',
+        1,
+        function (M) {
+            return baselib.numbers.round(
+                checkReal(M, 'round', 0));
+        });
+
+
+    installPrimitiveProcedure(
+        'truncate',
+        1,
+        function (M) {
+            var n = checkReal(M, 'truncate', 0);
+            if (baselib.numbers.lessThan(n, 0)) {
+                return baselib.numbers.ceiling(n);
+            } else {
+                return baselib.numbers.floor(n);
+            }
+        });
+
+
+    installPrimitiveProcedure(
+        'numerator',
+        1,
+        function (M) {
+            return baselib.numbers.numerator(
+                checkRational(M, 'numerator', 0));
+        });
+
+
+    installPrimitiveProcedure(
+        'denominator',
+        1,
+        function (M) {
+            return baselib.numbers.denominator(
+                checkRational(M, 'denominator', 0));
+        });
+
+
+    installPrimitiveProcedure(
+        'log',
+        1,
+        function (M) {
+            return baselib.numbers.log(
+                checkNumber(M, 'log', 0));
+        });
+
+
+    installPrimitiveProcedure(
+        'sqr',
+        1,
+        function (M) {
+            return baselib.numbers.sqr(
+                checkNumber(M, 'sqr', 0));
+        });
+
+
+
+
+    installPrimitiveProcedure(
+        'sqrt',
+        1,
+        function (M) {
+            return baselib.numbers.sqrt(
+                checkNumber(M, 'sqrt', 0));
+        });
+
+
+
+    installPrimitiveProcedure(
+        'integer-sqrt',
+        1,
+        function (M) {
+            return baselib.numbers.integerSqrt(
+                checkInteger(M, 'integer-sqrt', 0));
+        });
+
+
+
+    installPrimitiveProcedure(
+        'sgn',
+        1,
+        function (M) {
+            return baselib.numbers.sign(
+                checkInteger(M, 'sgn', 0));
+        });
+
+
+    installPrimitiveProcedure(
+        'min',
+        baselib.arity.makeArityAtLeast(1),
+        function(M) {
+            var i;
+            var next;
+            var currentMin = checkReal(M, 'min', 0);
+            for (i = 1; i < M.a; i++) {
+                next = checkReal(M, 'min', i);
+                if (baselib.numbers.lessThan(next, currentMin)) {
+                    currentMin = next;
+                }
+            }
+            return currentMin;
+        });
+
+    installPrimitiveProcedure(
+        'max',
+        baselib.arity.makeArityAtLeast(1),
+        function(M) {
+            var i;
+            var next;
+            var currentMax = checkReal(M, 'min', 0);
+            for (i = 1; i < M.a; i++) {
+                next = checkReal(M, 'min', i);
+                if (baselib.numbers.greaterThan(next, currentMax)) {
+                    currentMax = next;
+                }
+            }
+            return currentMax;
+        });
+
+
+
+
+
+
+    installPrimitiveProcedure(
+        'error',
+        baselib.arity.makeArityAtLeast(1),
+        function (M) {
+	    var i;
+            if (M.a === 1) {
+                var sym = checkSymbol(M, 'error', 1);
+                raise(M, baselib.exceptions.makeExnFail(sym.toString(),
+                                                        M.captureContinuationMarks()));
+            }
+
+            if (isString(M.e[M.e.length - 1])) {
+                var vs = [];
+                for (i = 1; i < M.a; i++) {
+                    vs.push(baselib.format.format("~e", [M.e[M.e.length - 1 - i]]));
+                }
+                raise(M, baselib.exceptions.makeExnFail(M.e[M.e.length - 1].toString() +
+                                                        ": " +
+                                                        vs.join(' '),
+                                                        M.captureContinuationMarks()));
+            }
+
+            if (isSymbol(M.e[M.e.length - 1])) {
+                var fmtString = checkString(M, 'error', 1);
+                var args = [M.e[M.e.length - 1]];
+                for (i = 2; i < M.a; i++) {
+                    args.push(M.e[M.e.length - 1 - i]);
+                }
+                raise(M, baselib.exceptions.makeExnFail(
+                    baselib.format.format('~s: ' + fmtString.toString(),
+                                          args),
+                    M.captureContinuationMarks()));
+            }
+
+            // Fall-through
+            raiseArgumentTypeError(M, 'error', 'symbol or string', 0, M.e[M.e.length - 1]);
+        });
+
+
+    installPrimitiveProcedure(
+        'raise',
+        makeList(1, 2),
+        function(M) {
+            var v = M.e[M.e.length - 1];
+            // At the moment, not using the continuation barrier yet.
+            // var withBarrier = M.e[M.e.length - 2];
+            raise(M, v);
+        });
+
+
+
+    installPrimitiveProcedure(
+        'raise-mismatch-error',
+        3,
+        function (M) {
+            var name = checkSymbol(M, 'raise-mismatch-error', 0);
+            var message = checkString(M, 'raise-mismatch-error', 0);
+            var val = M.e[M.e.length - 1 - 2];
+            raise(M, baselib.exceptions.makeExnFail(
+		baselib.format.format("~a: ~a~e",
+                                      [name,
+                                       message,
+                                       val]),
+                M.captureContinuationMarks()));
+        });
+
+
+    installPrimitiveProcedure(
+        'raise-type-error',
+        baselib.arity.makeArityAtLeast(3),
+        function (M) {
+            var name = checkSymbol(M, 'raise-type-error', 0);
+            var expected = checkString(M, 'raise-type-error', 1);
+            if (M.a === 3) {
+                raiseArgumentTypeError(M,
+                                       name,
+                                       expected,
+                                       void(0),
+                                       M.e[M.e.length - 1 - 2]);
+            } else {
+                raiseArgumentTypeError(M,
+                                       name,
+                                       expected,
+                                       checkNatural(M, 'raise-type-error', 2),
+                                       M.e[M.e.length - 1 - 2]);
+            }
+        });
+
+
+
+    installPrimitiveProcedure(
+        'make-exn',
+        2,
+        function(M) {
+            var message = checkString(M, 'make-exn', 0);
+            var marks = checkContinuationMarkSet(M, 'make-exn', 1);
+            return baselib.exceptions.makeExn(message, marks);
+        });
+
+
+    installPrimitiveConstant(
+        'struct:exn:fail',
+        baselib.exceptions.ExnFail);
+
+
+    installPrimitiveConstant(
+        'prop:exn:srclocs',
+        baselib.structs.propExnSrcloc);
+
+
+    installPrimitiveProcedure(
+        'make-exn:fail',
+        2,
+        function(M) {
+            var message = checkString(M, 'make-exn:fail', 0);
+            var marks = checkContinuationMarkSet(M, 'make-exn:fail', 1);
+            return baselib.exceptions.makeExnFail(message, marks);
+        });
+
+
+    installPrimitiveProcedure(
+        'make-exn:fail:contract',
+        2,
+        function(M) {
+            var message = checkString(M, 'make-exn:fail:contract', 0);
+            var marks = checkContinuationMarkSet(M, 'make-exn:fail:contract', 1);
+            return baselib.exceptions.makeExnFailContract(message, marks);
+        });
+
+
+    installPrimitiveProcedure(
+        'make-exn:fail:contract:arity',
+        2,
+        function(M) {
+            var message = checkString(M, 'make-exn:fail:contract:arity', 0);
+            var marks = checkContinuationMarkSet(M, 'make-exn:fail:contract:arity', 1);
+            return baselib.exceptions.makeExnFailContractArity(message, marks);
+        });
+
+    installPrimitiveProcedure(
+        'make-exn:fail:contract:variable',
+        2,
+        function(M) {
+            var message = checkString(M, 'make-exn:fail:contract:variable', 0);
+            var marks = checkContinuationMarkSet(M, 'make-exn:fail:contract:variable', 1);
+            return baselib.exceptions.makeExnFailContractVariable(message, marks);
+        });
+
+    installPrimitiveProcedure(
+        'make-exn:fail:contract:divide-by-zero',
+        2,
+        function(M) {
+            var message = checkString(M, 'make-exn:fail:contract:divide-by-zero', 0);
+            var marks = checkContinuationMarkSet(M, 'make-exn:fail:contract:divide-by-zero', 1);
+            return baselib.exceptions.makeExnFailContractDivisionByZero(message, marks);
+        });
+
+    installPrimitiveProcedure(
+        'exn:fail?',
+        1,
+        function(M) {
+            return baselib.exceptions.isExnFail(M.e[M.e.length-1]);
+        });
+
+    installPrimitiveProcedure(
+        'exn:fail:contract?',
+        1,
+        function(M) {
+            return baselib.exceptions.isExnFailContract(M.e[M.e.length-1]);
+        });
+
+    installPrimitiveProcedure(
+        'exn:fail:contract:arity?',
+        1,
+        function(M) {
+            return baselib.exceptions.isExnFailContractArity(M.e[M.e.length-1]);
+        });
+
+
+    installPrimitiveProcedure(
+        'exn-message',
+        1,
+        function(M) {
+            var exn = checkExn(M, 'exn-message', 0);
+            return baselib.exceptions.exnMessage(exn);
+        });
+
+    installPrimitiveProcedure(
+        'exn-continuation-marks',
+        1,
+        function(M) {
+            var exn = checkExn(M, 'exn-continuation-marks', 0);
+            return baselib.exceptions.exnContMarks(exn);
+        });
+
+
+    installPrimitiveProcedure(
+        'current-continuation-marks',
+        makeList(0, 1),
+        function(M) {
+            var promptTag = baselib.contmarks.DEFAULT_CONTINUATION_PROMPT_TAG;
+            if (M.a === 1) {
+                promptTag = checkContinuationPromptTag(M, 'current-continuation-marks', 0);
+            }
+            var contMarks = M.captureContinuationMarks(promptTag);
+            return contMarks;
+        });
+
+    installPrimitiveProcedure(
+        'continuation-mark-set->list',
+        makeList(2, 3),
+        function(M) {
+            var marks = checkContinuationMarkSet(M, 'continuation-mark-set->list', 0);
+            var key = checkAny(M, 'continuation-mark-set->list', 1);
+            var promptTag = baselib.contmarks.DEFAULT_CONTINUATION_PROMPT_TAG;
+            if (M.a === 3) {
+                promptTag = checkContinuationPromptTag(M, 'current-continuation-marks', 2);
+            }
+            return marks.ref(key, promptTag);
+        });
+
+
+
+    installPrimitiveClosure(
+        'make-struct-type',
+        makeList(4, 5, 6, 7, 8, 9, 10, 11),
+        function (M) {
+            withArguments(
+                M,
+                4,
+                [false,
+                 NULL,
+                 false,
+                 false,
+                 NULL,
+                 false,
+                 false],
+                function (name,
+                          superType,
+                          initFieldCount,
+                          autoFieldCount,
+                          autoV,
+                          props,
+                          inspector,  // FIXME: currently ignored
+                          procSpec,   // FIXME: currently ignored
+                          immutables, // FIXME: currently ignored
+                          guard,      // FIXME: currently ignored
+                          constructorName
+                         ) {
+                    var structType = baselib.structs.makeStructureType(
+                        name,
+                        superType,
+                        initFieldCount,
+                        autoFieldCount,
+                        autoV,
+                        //inspector,
+                        //procSpec,
+                        //immutables,
+                        guard,
+                        props);
+
+                    var constructorValue =
+                        makePrimitiveProcedure(
+                            constructorName,
+                            initFieldCount + (superType ? superType.numberOfArgs : 0),
+                            function (M) {
+                                var args = M.e.slice(M.e.length - M.a).reverse();
+                                return structType.constructor(args);
+                            });
+
+                    var predicateValue =
+                        makePrimitiveProcedure(
+                            name.toString() + "?",
+                            1,
+                            function (M) {
+                                return structType.predicate(M.e[M.e.length - 1]);
+                            });
+
+                    var accessorValue =
+                        makePrimitiveProcedure(
+                            name.toString() + "-accessor",
+                            2,
+                            function (M) {
+                                return structType.accessor(
+                                    M.e[M.e.length - 1],
+                                    baselib.numbers.toFixnum(M.e[M.e.length - 2]));
+                            });
+                    accessorValue.structType = structType;
+
+                    var mutatorValue =
+                        makePrimitiveProcedure(
+                            name.toString() + "-mutator",
+                            3,
+                            function (M) {
+                                return structType.mutator(
+                                    M.e[M.e.length - 1],
+                                    baselib.numbers.toFixnum(M.e[M.e.length - 2]),
+                                    M.e[M.e.length - 3]);
+                            });
+                    mutatorValue.structType = structType;
+
+
+                    finalizeClosureCall(M,
+                                        structType,
+                                        constructorValue,
+                                        predicateValue,
+                                        accessorValue,
+                                        mutatorValue);
+                });
+        });
+
+    installPrimitiveProcedure(
+        'struct?',
+        1,
+        function(M) {
+            return isStruct(M.e[M.e.length - 1]);
+        });
+
+    installPrimitiveProcedure(
+        'struct-type?',
+        1,
+        function(M) {
+            return isStructType(M.e[M.e.length - 1]);
+        });
+
+    installPrimitiveProcedure(
+        'current-inspector',
+        makeList(0, 1),
+        function (M) {
+            if (M.a === 1) {
+                M.params['currentInspector'] =
+                    checkInspector(M, 'current-inspector', 0);
+                return VOID;
+            } else {
+                return M.params['currentInspector'];
+            }
+        }
+    );
+
+
+    installPrimitiveProcedure(
+        'make-struct-field-accessor',
+        makeList(2, 3),
+        function (M){
+            var structType = M.e[M.e.length - 1].structType;
+            var index = M.e[M.e.length - 2];
+            var name;
+            if (M.a === 3) {
+                name = structType.name + "-" + M.e[M.e.length - 3].toString();
+            } else {
+                name = structType.name + "-" + 'field' + index;
+            }
+            var checkStruct = baselib.check.makeCheckArgumentType(structType.predicate,
+                                                                  structType.name);
+            return makePrimitiveProcedure(
+                name,
+                1,
+                function (M) {
+                    var aStruct = checkStruct(M, name, 0);
+                    return structType.accessor(
+                        aStruct,
+                        baselib.numbers.toFixnum(index));
+                });
+        });
+
+
+    installPrimitiveProcedure(
+        'make-struct-field-mutator',
+        makeList(2, 3),
+        function (M){
+            var structType = M.e[M.e.length - 1].structType;
+            var index = M.e[M.e.length - 2];
+            var name;
+            if (M.a === 3) {
+                name = "set-" + structType.name + "-" + M.e[M.e.length - 3].toString() + "!";
+            } else {
+                name = "set-" + structType.name + "-" + 'field' + index + "!";
+            }
+            var checkStruct = baselib.check.makeCheckArgumentType(structType.predicate,
+                                                                  structType.name);
+            return makePrimitiveProcedure(
+                name,
+                2,
+                function (M) {
+                    var aStruct = checkStruct(M, name, 0);
+                    structType.mutator(
+                        aStruct,
+                        baselib.numbers.toFixnum(index),
+                        M.e[M.e.length - 2]);
+                    return VOID;
+                });
+        });
+
+
+    installPrimitiveProcedure(
+        'make-placeholder',
+        1,
+        function(M) {
+            var v = M.e[M.e.length - 1];
+            return baselib.placeholders.makePlaceholder(v);
+        });
+
+
+    installPrimitiveProcedure(
+        'placeholder-set!',
+        2,
+        function(M) {
+            var placeholder = checkPlaceholder(M, 'placeholder-set!', 0);
+            var val = M.e[M.e.length - 2];
+            placeholder.set(val);
+            return VOID;
+        });
+
+
+    installPrimitiveProcedure(
+        'make-reader-graph',
+        1,
+        function(M) {
+            var x = M.e[M.e.length - 1];
+            return baselib.readergraph.readerGraph(x,
+                                                   baselib.hashes.makeLowLevelEqHash(),
+                                                   0);
+        });
+
+
+
+
+    installPrimitiveProcedure(
+        'srcloc',
+        5,
+        function(M) {
+            var source = M.e[M.e.length - 1];
+            var line = checkNaturalOrFalse(M, 'srcloc', 1);
+            var column = checkNaturalOrFalse(M, 'srcloc', 2);
+            var position = checkNaturalOrFalse(M, 'srcloc', 3);
+            var span = checkNaturalOrFalse(M, 'srcloc', 4);
+            return baselib.srclocs.makeSrcloc(source, line, column, position, span);
+        });
+
+    installPrimitiveProcedure(
+        'make-srcloc',
+        5,
+        function(M) {
+            var source = M.e[M.e.length - 1];
+            var line = checkNaturalOrFalse(M, 'make-srcloc', 1);
+            var column = checkNaturalOrFalse(M, 'make-srcloc', 2);
+            var position = checkNaturalOrFalse(M, 'make-srcloc', 3);
+            var span = checkNaturalOrFalse(M, 'make-srcloc', 4);
+            return baselib.srclocs.makeSrcloc(source, line, column, position, span);
+        });
+
+    installPrimitiveProcedure(
+        'srcloc?',
+        1,
+        function(M) {
+            return baselib.srclocs.isSrcloc(M.e[M.e.length - 1]);
+        });
+
+    installPrimitiveProcedure(
+        'srcloc-source',
+        1,
+        function(M) {
+            return baselib.srclocs.srclocSource(checkSrcloc(M, 'srcloc-source', 0));
+        });
+
+    installPrimitiveProcedure(
+        'srcloc-line',
+        1,
+        function(M) {
+            return baselib.srclocs.srclocLine(checkSrcloc(M, 'srcloc-line', 0));
+        });
+
+    installPrimitiveProcedure(
+        'srcloc-column',
+        1,
+        function(M) {
+            return baselib.srclocs.srclocColumn(checkSrcloc(M, 'srcloc-column', 0));
+        });
+
+
+    installPrimitiveProcedure(
+        'srcloc-position',
+        1,
+        function(M) {
+            return baselib.srclocs.srclocPosition(checkSrcloc(M, 'srcloc-position', 0));
+        });
+
+
+    installPrimitiveProcedure(
+        'srcloc-span',
+        1,
+        function(M) {
+            return baselib.srclocs.srclocSpan(checkSrcloc(M, 'srcloc-span', 0));
+        });
+
+
+
+    installPrimitiveProcedure(
+        'make-continuation-prompt-tag',
+        makeList(0, 1),
+        function(M) {
+            var sym;
+            if (M.a === 1) {
+                sym = checkSymbol(M, "make-continuation-prompt-tag", 0);
+                return new baselib.contmarks.ContinuationPromptTag(sym.toString());
+            }
+            return new baselib.contmarks.ContinuationPromptTag(false);
+        });
+
+    installPrimitiveProcedure(
+        'continuation-prompt-tag?',
+        1,
+        function(M) {
+            return baselib.contmarks.isContinuationPromptTag(M.e[M.e.length - 1]);
+        });
+
+
+
+    installPrimitiveProcedure(
+        'default-continuation-prompt-tag',
+        0,
+        function(M) {
+            return baselib.contmarks.DEFAULT_CONTINUATION_PROMPT_TAG;
+        });
+
+    installPrimitiveProcedure(
+        'current-inexact-milliseconds',
+        0,
+        function(M) {
+            return makeFloat((new Date()).valueOf());
+        });
+
+
+    installPrimitiveProcedure(
+        'current-seconds',
+        0,
+        function() {
+            return Math.floor( (new Date()).getTime() / 1000 );
+        });
+
+
+    // initializeHash: (listof pair) WhalesongHashtable -> WhalesongHashtable
+    var initializeHash = function(lst, hash) {
+	while (lst !== NULL) {
+	    hash.put(lst.first.first, lst.first.rest);
+	    lst = lst.rest;
+	}
+	return hash;
+    };
+
+    var initializeImmutableHash = function(lst, hash) {
+	while (lst !== NULL) {
+	    hash = hash.functionalPut(lst.first.first, lst.first.rest);
+	    lst = lst.rest;
+	}
+	return hash;
+    };
+
+
+    installPrimitiveProcedure(
+        'hash?',
+        1,
+        function(M) {
+            return baselib.hashes.isHash(checkAny(M, 'hash?', 0));
+        });
+    installPrimitiveProcedure(
+        'hash-equal?',
+        1,
+        function(M) {
+            return baselib.hashes.isHashEqual(checkAny(M, 'hash-equal?', 0));
+        });
+    installPrimitiveProcedure(
+        'hash-eq?',
+        1,
+        function(M) {
+            return baselib.hashes.isHashEq(checkAny(M, 'hash-eq?', 0));
+        });
+    installPrimitiveProcedure(
+        'hash-eqv?',
+        1,
+        function(M) {
+            return baselib.hashes.isHashEqv(checkAny(M, 'hash-eqv?', 0));
+        });
+
+
+    installPrimitiveProcedure(
+        'make-hasheq',
+        makeList(0, 1),
+        function(M) {
+            var lst = NULL;
+            if (M.a === 1) {
+                lst = checkListofPairs(M, 'make-hasheq', 0);
+            }
+            return initializeHash(lst, plt.baselib.hashes.makeEqHashtable());
+        });
+
+    installPrimitiveProcedure(
+        'make-hasheqv',
+        makeList(0, 1),
+        function(M) {
+            var lst = NULL;
+            if (M.a === 1) {
+                lst = checkListofPairs(M, 'make-hasheqv', 0);
+            }
+            return initializeHash(lst, plt.baselib.hashes.makeEqvHashtable());
+        });
+
+    installPrimitiveProcedure(
+        'make-hash',
+        makeList(0, 1),
+        function(M) {
+            var lst = NULL;
+            if (M.a === 1) {
+                lst = checkListofPairs(M, 'make-hash', 0);
+            }
+            return initializeHash(lst, plt.baselib.hashes.makeEqualHashtable());
+        });
+
+    installPrimitiveProcedure(
+        'hash-copy',
+        1,
+        function(M) {
+            var hash = checkMutableHash(M, 'hash-copy', 0);
+            return hash.clone();
+        });
+    
+    installPrimitiveProcedure(
+        'hash-count',
+        1,
+        function(M) {
+            return checkHash(M, 'hash-count', 0).size();
+        });
+
+    installPrimitiveProcedure(
+        'hash',
+        baselib.arity.makeArityAtLeast(0),
+        function(M) {
+            var lst = NULL, i;
+            for(i = 0; i < M.a; i+=2) {
+                if (i+1 < M.a) {
+                    lst = makePair(makePair(checkAny(M, 'hash', i), checkAny(M, 'hash', i + 1)),
+                                   lst);
+                } else {
+                    raiseContractError(
+                        M,
+                        baselib.format.format(
+                            "hash: key does not have a value (i.e., an odd number of arguments were provided): ~e",
+                            [checkAny(M, 'hash', i)]));
+                }
+            }
+            return initializeImmutableHash(lst, plt.baselib.hashes.makeImmutableEqualHashtable());
+        });
+
+    installPrimitiveProcedure(
+        'hasheq',
+        baselib.arity.makeArityAtLeast(0),
+        function(M) {
+            var lst = NULL, i;
+            for(i = 0; i < M.a; i+=2) {
+                if (i+1 < M.a) {
+                    lst = makePair(makePair(checkAny(M, 'hasheq', i), checkAny(M, 'hasheq', i + 1)),
+                                   lst);
+                } else {
+                    raiseContractError(
+                        M,
+                        baselib.format.format(
+                            "hasheq: key does not have a value (i.e., an odd number of arguments were provided): ~e",
+                            [checkAny(M, 'hasheq', i)]));
+                }
+            }
+            return initializeImmutableHash(lst, plt.baselib.hashes.makeImmutableEqHashtable());
+        });
+
+    installPrimitiveProcedure(
+        'hasheqv',
+        baselib.arity.makeArityAtLeast(0),
+        function(M) {
+            var lst = NULL, i;
+            for(i = 0; i < M.a; i+=2) {
+                if (i+1 < M.a) {
+                    lst = makePair(makePair(checkAny(M, 'hasheqv', i), checkAny(M, 'hasheqv', i + 1)),
+                                   lst);
+                } else {
+                    raiseContractError(
+                        M,
+                        baselib.format.format(
+                            "hasheqv: key does not have a value (i.e., an odd number of arguments were provided): ~e",
+                            [checkAny(M, 'hasheqv', i)]));
+                }
+            }
+            return initializeImmutableHash(lst, plt.baselib.hashes.makeImmutableEqvHashtable());
+        });
+
+    installPrimitiveProcedure(
+        'make-immutable-hasheq',
+        makeList(0, 1),
+        function(M) {
+            var lst = NULL;
+            if (M.a === 1) {
+                lst = checkListofPairs(M, 'make-immutable-hasheq', 0);
+            }
+            return initializeImmutableHash(lst, plt.baselib.hashes.makeImmutableEqHashtable());
+        });
+
+    installPrimitiveProcedure(
+        'make-immutable-hasheqv',
+        makeList(0, 1),
+        function(M) {
+            var lst = NULL;
+            if (M.a === 1) {
+                lst = checkListofPairs(M, 'make-immutable-hasheqv', 0);
+            }
+            return initializeImmutableHash(lst, plt.baselib.hashes.makeImmutableEqvHashtable());
+        });
+
+    installPrimitiveProcedure(
+        'make-immutable-hash',
+        makeList(0, 1),
+        function(M) {
+            var lst = NULL;
+            if (M.a === 1) {
+                lst = checkListofPairs(M, 'make-immutable-hash', 0);
+            }
+            return initializeImmutableHash(lst, plt.baselib.hashes.makeImmutableEqualHashtable());
+        });
+
+    installPrimitiveClosure(
+        'hash-ref',
+        makeList(2, 3),
+        function(M) {
+            var hash = checkHash(M, 'hash-ref', 0);
+            var key = checkAny(M, 'hash-ref', 1);
+            var thunkOrFailVal;
+            if (M.a === 3) {
+                thunkOrFailVal = checkAny(M, 'hash-ref', 2);
+            }
+            if (hash.containsKey(key)) {
+                finalizeClosureCall(M, hash.get(key));
+            } else {
+                if (M.a === 2) {
+                    raiseContractError(
+                        M,
+                        baselib.format.format("hash-ref: no value found for key: ~e",
+                                           [key]));
+                } else {
+                    if (isProcedure(thunkOrFailVal)) {
+                        M.p = thunkOrFailVal;
+                        M.e.length -= M.a;
+                        M.a = 0;
+                        baselib.functions.rawApply(M);
+                    } else {
+                        finalizeClosureCall(M, thunkOrFailVal);
+                    }
+                }
+            }
+        });
+
+    installPrimitiveProcedure(
+        'hash-has-key?',
+        2,
+        function(M) {
+            var hash = checkHash(M, 'hash-ref', 0);
+            var key = checkAny(M, 'hash-ref', 1);
+            return hash.containsKey(key);
+        });
+
+    installPrimitiveProcedure(
+        'hash-set!',
+        3,
+        function(M){ 
+            var hash = checkMutableHash(M, 'hash-set!', 0);
+            var key = checkAny(M, 'hash-set!', 1);
+            var value = checkAny(M, 'hash-set!', 2);
+            hash.put(key, value);
+            return VOID;
+        });
+
+    installPrimitiveProcedure(
+        'hash-set',
+        3,
+        function(M){ 
+            var hash = checkImmutableHash(M, 'hash-set', 0);
+            var key = checkAny(M, 'hash-set', 1);
+            var value = checkAny(M, 'hash-set', 2);
+            return hash.functionalPut(key, value);
+        });
+
+
+    installPrimitiveProcedure(
+        'hash-remove!',
+        2,
+        function(M){ 
+            var hash = checkMutableHash(M, 'hash-remove!', 0);
+            var key = checkAny(M, 'hash-remove!', 1);
+            hash.remove(key);
+            return VOID;
+        });
+
+
+    installPrimitiveProcedure(
+        'hash-remove',
+        2,
+        function(M){ 
+            var hash = checkImmutableHash(M, 'hash-remove', 0);
+            var key = checkAny(M, 'hash-remove', 1);
+            return hash.functionalRemove(key);
+        });
+
+    installPrimitiveProcedure(
+        'hash-keys',
+        1,
+        function(M) {
+            var hash = checkHash(M, 'hash-keys', 0);
+            return baselib.lists.arrayToList(hash.keys());
+        });
+
+    installPrimitiveProcedure(
+        'hash-values',
+        1,
+        function(M) {
+            var hash = checkHash(M, 'hash-values', 0);
+            return baselib.lists.arrayToList(hash.values());
+        });
+
+    installPrimitiveProcedure(
+        'hash-has-key?',
+        2,
+        function(M){
+            var hash = checkHash(M, 'hash-has-key?', 0);
+            var key = checkAny(M, 'hash-has-key?', 1);
+            return hash.containsKey(key);
+        });
+
+    installPrimitiveProcedure(
+        'equal-hash-code',
+        1,
+        function(M) {
+            return baselib.hashes.getEqualHashCode(checkAny(M, 'equal-hash-code', 0));
+        });
+
+
+    // The default prompt handler for a given prompt tag will assume
+    // it's consuming a zero-argument thunk, and will call it in a
+    // context where that prompt has been reestablished.
+    var makeDefaultPromptHandler = function(promptTag) {
+        return makeClosure(
+            "default-prompt-handler",
+            1,
+            function(M) {
+                var proc = checkProcedure(M, 'default-prompt-tag', 0);
+                M.e.pop();
+                M.p = proc;
+                M.a = 0;
+                M.addPrompt(promptTag, false, M.e.length);
+                baselib.functions.rawApply(M);
+            },
+            []);
+    };
+
+
+    // FIXME: we should be able to take in an arbitrary continuation
+    // as an optional second argument!
+    //
+   // I need to change the representation of continuations to be able to
+    // detect this at runtime.
+    installPrimitiveProcedure(
+        'continuation-prompt-available?',
+        1,
+        function(M) {
+            var promptTag = checkPromptTag(M, 'continuation-prompt-available?', 0);
+            var i;
+            for (i = 0; i < M.c.length; i++) {
+                var frame = M.c[i];
+                if (frame instanceof PromptFrame && frame.tag === promptTag) {
+                    return true;
+                }
+            }
+            return false;
+        });
+
+
+
+    // The default abort prompt handler consumes a thunk and applies
+    // it, in a context where a new prompt has been initialized.
+    var defaultPromptHandler =
+        makeDefaultPromptHandler(baselib.contmarks.DEFAULT_CONTINUATION_PROMPT_TAG);
+        
+
+    installPrimitiveClosure(
+        'abort-current-continuation',
+        baselib.arity.makeArityAtLeast(1),
+        function(M) {
+            var promptTag = checkPromptTag(M, 'abort-current-continuation', 0);
+            var vals = [];
+            var frame;
+            var i;
+            for(i = 1; i < M.a; i++) {
+                vals.push(M.e[M.e.length - 1 - i]);
+            }
+            
+            // First, find the continuation prompt.
+            while(true) {
+                frame = M.c.pop();
+                if (frame instanceof PromptFrame && frame.tag === promptTag) {
+                    break;
+                } else if (M.c.length === 0) {
+                    raiseContractError(
+                        M,
+                        baselib.format.format("continuation includes no prompt with the given tag", []));
+                }
+            }
+            // Shrink the environment to what was observed when the
+            // PromptFrame was installed, and then set up the call
+            // to the prompt's abort handler.
+            M.e.length = frame.envLength;
+            M.p = frame.handler || defaultPromptHandler;
+            M.a = vals.length;
+            for (i = 0; i < vals.length; i++) {
+                M.e.push(vals[vals.length - i - 1]);
+            }
+            baselib.functions.rawApply(M);
+        });
+
+ 
+    installPrimitiveClosure(
+        'call-with-continuation-prompt',
+        baselib.arity.makeArityAtLeast(1),
+        function(M) {
+            var proc, promptTag, handler, i;
+            proc = checkProcedure(M, 'call-with-continuation-prompt', 0);
+            if (M.a >= 2) {
+                promptTag = checkPromptTag(M, 'call-with-continuation-prompt', 1);
+            } else {
+                promptTag = baselib.contmarks.DEFAULT_CONTINUATION_PROMPT_TAG;
+            }
+            if (M.a >= 3) {
+                if (M.e[M.e.length - 1 - 3] === false) {
+                    handler = false;
+                } else {
+                    handler = checkProcedure(M, 'call-with-continuation-prompt', 2);
+                }
+            } else {
+                if (promptTag === baselib.contmarks.DEFAULT_CONTINUATION_PROMPT_TAG) {
+                    handler = defaultPromptHandler;
+                } else {
+                    handler = makeDefaultPromptHandler(promptTag);
+                }
+            }
+            M.p = proc;
+            if (M.a >= 1) { M.e.pop(); } // the test is redundant, but I want the parallelism.
+            if (M.a >= 2) { M.e.pop(); }
+            if (M.a >= 3) { M.e.pop(); }
+            M.a = Math.max(M.a - 3, 0);
+
+            // subtle: the prompt's environment is the one _after_ the current call!
+            // That's why we need to do M.e.length - M.a: the environment currently
+            // has extra values due to us calling the prompt's procedure here.
+            M.addPrompt(promptTag, handler, M.e.length - M.a); 
+
+            baselib.functions.rawApply(M);
+        });
+
+
+
+
+    exports['Primitives'] = Primitives;
+    exports['installPrimitiveProcedure'] = installPrimitiveProcedure;
+    exports['installPrimitiveClosure'] = installPrimitiveClosure;
+    exports['installPrimitiveConstant'] = installPrimitiveConstant;
+
+}(this.plt.baselib));
+/*jslint browser: true, undef: true, unparam: true, sub: true, vars: true, white: true, plusplus: true, maxerr: 50, indent: 4 */
+
+
+// runtime.js: the main runtime library for whalesong.
+//
+
+// All of the values here are namespaced under "plt.runtime".
+/*global $*/
+(function(plt, $) {
+    'use strict';
+    var runtime = {};
+    plt.runtime = runtime;
+
+
+    // abbreviation, since we'll be using the basic library a lot.
+    var baselib = plt.baselib;
+
+
+    //////////////////////////////////////////////////////////////////////
+    //////////////////////////////////////////////////////////////////////
+    // We try to isolate the effect of external modules: all the identifiers we
+    // pull from external modules should be listed here, and should otherwise not
+    // show up outside this section!
+    var isNumber = baselib.numbers.isNumber;
+    var isNatural = baselib.numbers.isNatural;
+    var isReal = baselib.numbers.isReal;
+    var isPair = baselib.lists.isPair;
+    var isCaarPair = function(x) { return isPair(x) && isPair(x.first); };
+    var isList = baselib.lists.isList;
+    var isVector = baselib.vectors.isVector;
+    var isString = baselib.strings.isString;
+    var isSymbol = baselib.symbols.isSymbol;
+    var isPath = baselib.paths.isPath;
+
+    var equals = baselib.equality.equals;
+
+    var NULL = baselib.lists.EMPTY;
+    var VOID = baselib.constants.VOID_VALUE;
+
+    var NEGATIVE_ZERO = baselib.numbers.negative_zero;
+    var INF = baselib.numbers.inf;
+    var NEGATIVE_INF = baselib.numbers.negative_inf;
+    var NAN = baselib.numbers.nan;
+
+    var makeFloat = baselib.numbers.makeFloat;
+    var makeRational = baselib.numbers.makeRational;
+    var makeBignum = baselib.numbers.makeBignum;
+    var makeComplex = baselib.numbers.makeComplex;
+
+
+    var makeSymbol = baselib.symbols.makeSymbol;
+    var makePath = baselib.paths.makePath;
+    var makeBytes = baselib.bytes.makeBytes;
+    var makeBytesFromBase64 = baselib.bytes.makeBytesFromBase64;
+
+    var makeBox = baselib.boxes.makeBox;
+    var isBox = baselib.boxes.isBox;
+
+    var makeVector = baselib.vectors.makeVector;
+    var makeList = baselib.lists.makeList;
+    var makePair = baselib.lists.makePair;
+    var makeChar = baselib.chars.makeChar;
+
+    var makeStructureType = baselib.structs.makeStructureType;
+
+
+    var Struct = baselib.structs.Struct;
+    var StructType = baselib.structs.StructType;
+
+    var Closure = baselib.functions.Closure;
+    var finalizeClosureCall = baselib.functions.finalizeClosureCall;
+    var makePrimitiveProcedure = baselib.functions.makePrimitiveProcedure;
+    var makeClosure = baselib.functions.makeClosure;
+
+    var ContinuationPromptTag = baselib.contmarks.ContinuationPromptTag;
+
+
+    // Other helpers
+    var heir = baselib.heir;
+    var makeClassPredicate = baselib.makeClassPredicate;
+    var toDomNode = baselib.format.toDomNode;
+    var toWrittenString = baselib.format.toWrittenString;
+    var toDisplayedString = baselib.format.toDisplayedString;
+
+
+
+    // Frame structures.
+    var Frame = baselib.frames.Frame;
+    var CallFrame = baselib.frames.CallFrame;
+    var PromptFrame = baselib.frames.PromptFrame;
+
+    // Module structure
+    var ModuleRecord = baselib.modules.ModuleRecord;
+
+
+
+    // Ports
+    var isOutputPort = baselib.ports.isOutputPort;
+    var StandardOutputPort = baselib.ports.StandardOutputPort;
+    var StandardErrorPort = baselib.ports.StandardErrorPort;
+    var StandardInputPort = baselib.ports.StandardInputPort;
+    var isOutputStringPort = baselib.ports.isOutputStringPort;
+
+
+
+
+    // Exceptions and error handling.
+    var raise = baselib.exceptions.raise;
+    var makeExnBreak = baselib.exceptions.makeExnBreak; 
+    var raiseUnboundToplevelError = baselib.exceptions.raiseUnboundToplevelError;
+    var raiseArgumentTypeError = baselib.exceptions.raiseArgumentTypeError;
+    var raiseContextExpectedValuesError = baselib.exceptions.raiseContextExpectedValuesError;
+    var raiseArityMismatchError = baselib.exceptions.raiseArityMismatchError;
+    var raiseOperatorApplicationError = baselib.exceptions.raiseOperatorApplicationError;
+    var raiseOperatorIsNotPrimitiveProcedure = baselib.exceptions.raiseOperatorIsNotPrimitiveProcedure;
+    var raiseUnimplementedPrimitiveError = baselib.exceptions.raiseUnimplementedPrimitiveError;
+    var raiseModuleLoadingError = baselib.exceptions.raiseModuleLoadingError;
+
+
+
+    var ArityAtLeast = baselib.arity.ArityAtLeast;
+    var makeArityAtLeast = baselib.arity.makeArityAtLeast;
+    var isArityMatching = baselib.arity.isArityMatching;
+
+
+    var testArgument = baselib.check.testArgument;
+    var testArity = baselib.check.testArity;
+    var makeCheckArgumentType = baselib.check.makeCheckArgumentType;
+
+
+    var Primitives = baselib.primitives.Primitives;
+    var installPrimitiveProcedure = baselib.primitives.installPrimitiveProcedure;
+
+
+
+    // This value used to be dynamically determined, but something on iOS5
+    // breaks badly when I try this.
+    // We're very conservative now.
+     var STACK_LIMIT_ESTIMATE = 200;
+
+
+
+    //////////////////////////////////////////////////////////////////////
+
+
+
+    var defaultCurrentPrintImplementation = function (MACHINE) {
+        if(--MACHINE.cbt < 0) {
+            throw defaultCurrentPrintImplementation;
+        }
+        var oldArgcount = MACHINE.a;
+
+	var elt = MACHINE.e[MACHINE.e.length - 1];
+	var outputPort =
+	    MACHINE.params.currentOutputPort;
+	if (elt !== VOID) {
+	    outputPort.writeDomNode(
+                MACHINE,
+                toDomNode(elt, MACHINE.params['print-mode']));
+	    outputPort.writeDomNode(MACHINE, toDomNode("\n", 'display'));
+	}
+        MACHINE.a = oldArgcount;
+        return finalizeClosureCall(MACHINE, VOID);
+    };
+    var defaultCurrentPrint = makeClosure(
+	"default-printer",
+	1,
+	defaultCurrentPrintImplementation);
+
+
+
+    // makeRandomNonce: -> string
+    // Creates a randomly-generated nonce.
+    var makeRandomNonce = function() {
+        var chars = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXTZabcdefghiklmnopqrstuvwxyz";
+        var LEN = 32;
+        var result = [];
+        var i;
+        for (i = 0; i < LEN; i++) {
+            result.push(chars.charAt(Math.floor(Math.random() * chars.length)));
+        }
+        return result.join('');
+    };
+
+
+    //////////////////////////////////////////////////////////////////////
+
+    // Exclusive Locks.  Even though JavaScript is a single-threaded
+    // evaluator, we still have a need to create exclusive regions
+    // of evaluation, since we might inadvertantly access some state
+    // with two computations, with use of setTimeout.
+    var ExclusiveLock = function() {
+        this.locked = false;  // (U false string)
+        this.alreadyReleased = false;
+        this.waiters = [];
+    };
+
+
+    ExclusiveLock.prototype.acquire = function(id, onAcquire) {
+        var that = this;
+        if (!id) {
+            id = makeRandomNonce();
+        }
+
+        this.alreadyReleased = false;
+
+        if (this.locked === false) {
+            this.locked = id;
+            onAcquire.call(
+                that,
+                // releaseLock
+                function() {
+                    var waiter;
+                    if (that.alreadyReleased) {
+                        throw new Error(
+                            "Internal error: trying to release the lock, but already released");
+                    }
+                    if (that.locked === false) {
+                        throw new Error(
+                            "Internal error: trying to unlock the lock, but already unlocked");
+                    }
+                    that.locked = false;
+                    that.alreadyReleased = true;
+                    if (that.waiters.length > 0) {
+                        waiter = that.waiters.shift();
+                        setTimeout(
+                            function() {
+                                that.acquire(waiter.id, waiter.onAcquire);
+                            },
+                            0);
+                    }
+                });
+        } else {
+            this.waiters.push({ id: id,
+                                onAcquire: onAcquire } );
+        }
+    };
+    //////////////////////////////////////////////////////////////////////
+
+
+
+
+
+    //////////////////////////////////////////////////////////////////////]
+    // The MACHINE
+
+    var Machine = function() {
+        // These are the modules that have been installed.  They are not
+        // necessarily invoked yet.
+        this.installedModules = {};  // String -> (-> ModuleRecord)
+        this.reset();
+    };
+
+
+    // Resets the state of the machine.  Almost all of the system's
+    // state is reset, except the installedModules, which should
+    // persist as an optimization to reduce loading code over and
+    // over.
+    Machine.prototype.reset = function() {
+	this.cbt = STACK_LIMIT_ESTIMATE;  // calls before trampoline
+	this.v = void(0);         // value register
+	this.p = void(0);        // procedure register
+	this.a = void(0);           // argument count
+	this.e = [];                // environment
+	this.c = [];            // control: Arrayof (U Frame CallFrame PromptFrame)
+	this.running = false;
+
+        // We do not initialize installedModules here because
+        // we want that to persist.
+
+        // These are the modules that have been invoked.
+	this.modules = {};     // String -> ModuleRecord
+        this.mainModules = []; // Arrayof String
+	this.params = {
+
+            // print-as-expression: boolean
+            'print-as-expression' : false,
+
+            // print-mode: (one-of "write" "print" "constructor")
+            'print-mode' : 'write',
+
+
+	    // currentDisplayer: DomNode -> Void
+	    // currentDisplayer is responsible for displaying to the browser.
+	    'currentDisplayer': function(MACHINE, domNode) {
+		$(domNode).appendTo(document.body);
+	    },
+
+	    // currentErrorDisplayer: DomNode -> Void
+	    // currentErrorDisplayer is responsible for displaying errors to the browser.
+	    'currentErrorDisplayer': function(MACHINE, domNode) {
+                $(domNode).appendTo(document.body);
+	    },
+
+            'currentInspector': baselib.inspectors.DEFAULT_INSPECTOR,
+
+	    'currentOutputPort': new StandardOutputPort(),
+	    'currentErrorPort': new StandardErrorPort(),
+            'currentInputPort': new StandardInputPort(),
+	    'currentErrorHandler': function(MACHINE, exn) {
+                MACHINE.params.currentErrorDisplayer(
+                    MACHINE,
+                    toDomNode(exn, MACHINE.params['print-mode']));
+            },
+
+	    'currentNamespace': { get: function() {}, 
+                                  set : function() {}, 
+                                  hasKey : function() { return false; }
+                                },
+
+	    // These parameters control how often
+	    // control yields back to the browser
+	    // for response.  The implementation is a
+	    // simple PID controller.
+	    //
+	    // To tune this, adjust desiredYieldsPerSecond.
+	    // Do no touch numBouncesBeforeYield or
+	    // maxNumBouncesBeforeYield, because those
+	    // are adjusted automatically by the
+	    // recomputeMaxNumBouncesBeforeYield
+	    // procedure.
+	    'desiredYieldsPerSecond': 5,
+	    'numBouncesBeforeYield': 2000,   // self-adjusting
+	    'maxNumBouncesBeforeYield': 2000, // self-adjusting
+
+	    'currentPrint': defaultCurrentPrint
+	};
+        this.globals = {};
+	this.primitives = Primitives;
+        this.exclusiveLock = new ExclusiveLock();
+        this.breakScheduled = false;      // (U boolean function)
+    };
+
+    // Schedule a break the next time the trampoline begins.
+    Machine.prototype.scheduleBreak = function(afterBreak) {
+        if (typeof afterBreak === 'function') {
+            this.breakScheduled = afterBreak;
+        } else {
+            this.breakScheduled = true;
+        }
+    };
+
+    
+    Machine.prototype.loadAndInvoke = function(moduleName, success, fail) {
+        var that = this;
+        runtime.currentModuleLoader(
+            that, 
+            moduleName,
+            function() {
+                that.modules[moduleName] = that.installedModules[moduleName]();
+                that.modules[moduleName].invoke(that,
+                                             function() {
+                                                 success();
+                                             },
+                                             function(M, err) {
+                                                 fail(err);
+                                             });
+            },
+            function(err) {
+                fail(err);
+            });
+    };
+
+
+    // Try to get the continuation mark key used for procedure application tracing.
+    var getTracedAppKey = function(MACHINE) {
+        if (MACHINE.modules['whalesong/lang/private/traced-app.rkt']) {
+            return MACHINE.modules['whalesong/lang/private/traced-app.rkt'].getExports().get('traced-app-key') || 'traced-app-key';
+        }
+        return void(0);
+    };
+
+    var getTracedCalleeKey = function(MACHINE) {
+        if (MACHINE.modules['whalesong/lang/private/traced-app.rkt']) {
+            return MACHINE.modules['whalesong/lang/private/traced-app.rkt'].getExports().get('traced-callee-key') || 'traced-callee-key';
+        }
+        return void(0);
+    };
+
+
+
+    // captureControl implements the continuation-capturing part of
+    // call/cc.  It grabs the control frames up to (but not including) the
+    // prompt tagged by the given tag.
+    Machine.prototype.captureControl = function(skip, tag) {
+	var MACHINE = this;
+	var i;
+	for (i = MACHINE.c.length - 1 - skip; i >= 0; i--) {
+	    if (MACHINE.c[i].tag === tag) {
+		return MACHINE.c.slice(i + 1,
+					     MACHINE.c.length - skip);
+	    }
+	}
+	raise(MACHINE, new Error("captureControl: unable to find tag " + tag));
+    };
+
+
+
+    // restoreControl clears the control stack (up to, but not including the
+    // prompt tagged by tag), and then appends the rest of the control frames.
+    // At the moment, the rest of the control frames is assumed to be in the
+    // top of the environment.
+    Machine.prototype.restoreControl = function(tag) {
+	var MACHINE = this;
+	var i;
+	for (i = MACHINE.c.length - 1; i >= 0; i--) {
+	    if (MACHINE.c[i].tag === tag) {
+		MACHINE.c =
+		    MACHINE.c.slice(0, i+1).concat(
+			MACHINE.e[MACHINE.e.length - 1]);
+		return;
+	    }
+	}
+	raise(MACHINE, new Error("restoreControl: unable to find tag " + tag));
+
+    };
+
+
+    // Splices the list argument in the environment.  Adjusts MACHINE.a
+    // appropriately.
+    Machine.prototype.spliceListIntoStack = function(depth) {
+	var MACHINE = this;
+	var lst = MACHINE.e[MACHINE.e.length - 1 - depth];
+	var vals = [];
+	while(lst !== NULL) {
+	    vals.push(lst.first);
+	    lst = lst.rest;
+	}
+	vals.reverse();
+	MACHINE.e.splice.apply(MACHINE.e,
+				 [MACHINE.e.length - 1 - depth, 1].concat(vals));
+	MACHINE.a = MACHINE.a + vals.length - 1;
+    };
+
+
+    // Unsplices a list from the MACHINE stack.
+    Machine.prototype.unspliceRestFromStack = function(depth, length) {
+	var MACHINE = this;
+	var lst = NULL;
+	var i;
+	for (i = 0; i < length; i++) {
+	    lst = makePair(MACHINE.e[MACHINE.e.length - depth - length + i],
+                           lst);
+	}
+	MACHINE.e.splice(MACHINE.e.length - depth - length,
+			   length,
+			   lst);
+	MACHINE.a = MACHINE.a - length + 1;
+    };
+
+
+    // Save the continuation mark on the top control frame.
+    Machine.prototype.installContinuationMarkEntry = function(key, value) {
+        var frame = this.c[this.c.length - 1];
+        var marks = frame.getMarks();
+        var i;
+        var l = marks.length;
+        for (i = 0; i < l; i++) {
+            if (key === marks[i][0]) {
+                marks[i][1] = value;
+                return;
+            }
+        }
+        marks.push([key, value]);
+    };
+
+
+    Machine.prototype.captureContinuationMarks = function(promptTag) {
+        var kvLists = [];
+        var i;
+        var control = this.c;
+        var tracedCalleeKey = getTracedCalleeKey(this);
+        for (i = control.length-1; i >= 0; i--) {
+            if (promptTag !== null &&
+                control[i] instanceof PromptFrame && control[i].tag === promptTag) {
+                break;
+            }
+            if (control[i].getMarks().length !== 0) {
+                kvLists.push(control[i].getMarks());
+            }
+
+            if (tracedCalleeKey !== null &&
+                control[i] instanceof CallFrame &&
+                control[i].p !== null) {
+                kvLists.push([[tracedCalleeKey, control[i].p]]);
+            }
+        }
+        return new baselib.contmarks.ContinuationMarkSet(kvLists);
+    };
+
+    
+    var justReturn = function(M) {
+        M.p=M.c[M.c.length-1].label;
+        M.c.pop();
+        return(M.p)(M);
+    };
+    justReturn.mvr = function(M) {
+        M.p=M.c[M.c.length-1].label;
+        M.c.pop();
+        return(M.p.mvr)(M);
+    };
+
+    Machine.prototype.addPrompt = function(promptTag, abortHandlerClosure, envLength) {
+        this.c.push(new PromptFrame(justReturn,
+                                    promptTag,
+                                    envLength,
+                                    abortHandlerClosure));
+    };
+
+
+
+
+
+
+    //////////////////////////////////////////////////////////////////////
+    //////////////////////////////////////////////////////////////////////
+    //////////////////////////////////////////////////////////////////////
+    //////////////////////////////////////////////////////////////////////
+    // The toplevel trampoline.
+    //
+    //
+    // trampoline: MACHINE (MACHINE -> void) -> void
+    //
+    // All evaluation in Racketland happens in the context of this
+    // trampoline.
+    //
+    var recomputeMaxNumBouncesBeforeYield;
+
+
+    // Checks to see if we need to handle break.  If so, returns true.
+    // Otherwise, returns false.
+    //
+    // FIXME: This logic is duplicated within one of the catch blocks
+    // in the trampoline.  Would be nice to refactor.
+    var maybeHandleBreakOutsideTrampoline = function(MACHINE) {
+        var breakScheduled = MACHINE.breakScheduled;
+        if (breakScheduled) {
+            MACHINE.breakScheduled = false;
+            MACHINE.running = false;
+            MACHINE.params.currentErrorHandler(
+                MACHINE,
+                new baselib.exceptions.RacketError(
+                    "User break",
+                    makeExnBreak("User break.",
+                                 MACHINE.captureContinuationMarks(),
+                                 // FIXME: capture the continuation as well,
+                                 // rather than just hold false.
+                                 false)));
+            if (typeof breakScheduled === 'function') {
+                setTimeout(breakScheduled, 0);
+            }
+            return true;
+        }
+        return false;
+    };
+
+    var scheduleTrampoline = function(MACHINE, f, release) {
+        setTimeout(
+	    function() {
+                if (maybeHandleBreakOutsideTrampoline(MACHINE)) {
+                    release(); 
+                    return; 
+                }
+                MACHINE._trampoline(f, false, release);
+            },
+            0);
+    };
+
+    // Creates a restarting function, that reschedules f in a context
+    // with the old argcount in place.
+    // Meant to be used only by the trampoline.
+    var makeRestartFunction = function(MACHINE, release, pauseLock) {
+        var oldArgcount = MACHINE.a;
+        return function(f) {
+            pauseLock.acquire(
+                void(0),
+                function(pauseReleaseLock) {
+                    MACHINE.a = oldArgcount;
+                    MACHINE._trampoline(f, false, release);
+                    pauseReleaseLock();
+                });
+        };
+    };
+
+
+    // These are exception values that are treated specially in the context
+    // of the trampoline.
+
+    var HaltError = function(onHalt) {
+        // onHalt: MACHINE -> void
+        this.onHalt = onHalt || function(MACHINE) {};
+    };
+
+
+    var Pause = function(onPause) {
+        // onPause: MACHINE -> void
+        this.onPause = onPause;
+    };
+    var THE_SINGLETON_PAUSE = new Pause();
+    var PAUSE = function(onPause) {
+        THE_SINGLETON_PAUSE.onPause = onPause;
+        throw(THE_SINGLETON_PAUSE);
+    };
+
+
+    // WARNING WARNING WARNING
+    //
+    // Make sure to get an exclusive lock before jumping into trampoline.
+    // Otherwise, Bad Things will happen.
+    //
+    // e.g. machine.lock.acquire('id', function(release) { machine.trampoline... release();});
+    Machine.prototype.trampoline = function(initialJump, noJumpingOff) {
+        var that = this;
+
+        that.exclusiveLock.acquire(
+            'trampoline',
+            function(release) {
+                that._trampoline(initialJump, noJumpingOff, release);
+            });
+    };
+
+    Machine.prototype._trampoline = function(initialJump, noJumpingOff, release) {
+        var that = this;
+        var thunk = initialJump;
+        var startTime = (new Date()).valueOf();
+        that.params.numBouncesBeforeYield =
+            that.params.maxNumBouncesBeforeYield;
+        that.running = true;
+
+        while(true) {
+            try {
+                thunk(that);
+                break;
+            } catch (e) {
+                // There are a few kinds of things that can get thrown
+                // during racket evaluation:
+                //
+                // functions: this gets thrown if the Racket code
+                // realizes that the number of bounces has grown too
+                // large.  The thrown function represents a restarter
+                // function.  The running flag remains true.
+                //
+                // Pause: causes the machine evaluation to pause, with
+                // the expectation that it will restart momentarily.
+                // The running flag on the machine will remain true.
+                //
+                // HaltError: causes evaluation to immediately halt.
+                // We schedule the onHalt function of the HaltError to
+                // call afterwards.  The running flag on the machine
+                // is set to false.
+                //
+                // Everything else: otherwise, we send the exception value
+                // to the current error handler and exit.
+                // The running flag is set to false.
+                if (typeof(e) === 'function') {
+                    thunk = e;
+                    that.cbt = STACK_LIMIT_ESTIMATE;
+
+
+                    // If we're running an a model that prohibits
+                    // jumping off the trampoline, continue.
+                    if (noJumpingOff) {
+                        continue;
+                    }
+
+                    if (that.params.numBouncesBeforeYield-- < 0) {
+                        recomputeMaxNumBouncesBeforeYield(
+                            that,
+                            (new Date()).valueOf() - startTime);
+                        scheduleTrampoline(that, thunk, release);
+                        return;
+                    }
+                } else if (e === THE_SINGLETON_PAUSE) {
+                    var pauseLock = new ExclusiveLock();
+                    var oldArgcount = that.a;
+                    var restarted = false;
+                    var restart = function(f) {
+                        pauseLock.acquire(
+                            void(0),
+                            function(releasePauseLock) {
+                                restarted = true;
+                                that.a = oldArgcount;
+                                that._trampoline(f, false, release);
+                                releasePauseLock();
+                            });
+                    };
+                    var internalCall = function(proc, success, fail) {
+                        var i;
+                        if (restarted) {
+                            return;
+                        }
+                        var args = [];
+                        for (i = 3; i < arguments.length; i++) {
+                            args.push(arguments[i]);
+                        }
+                        pauseLock.acquire(
+                            void(0),
+                            function(release) {
+                                var newSuccess = function() {
+                                    success.apply(null, arguments);
+                                    release();
+                                };
+                                var newFail = function() {
+                                    fail.apply(null, arguments);
+                                    release();
+                                };
+                                baselib.functions.internalCallDuringPause.apply(
+                                    null, [that, proc, newSuccess, newFail].concat(args));
+                            });
+                    };
+                    e.onPause(restart, internalCall);
+                    return;
+                } else if (e instanceof HaltError) {
+                    that.running = false;
+                    that.breakScheduled = false;
+                    e.onHalt(that);
+                    release();
+                    return;
+                } else if (e instanceof baselib.exceptions.RacketError &&
+                           baselib.exceptions.isExnBreak(e.racketError)) {
+                    var oldBreakScheduled = that.breakScheduled;
+                    if (typeof oldBreakScheduled === 'function') {
+                        setTimeout(oldBreakScheduled, 0);
+                    }
+                    that.running = false;
+                    that.breakScheduled = false;
+                    release();
+                    that.params.currentErrorHandler(that, e);
+                    return;
+                } else {
+                    // General error condition: if there's a exception
+                    // handler, use it.  Otherwise, just exit out of
+                    // the trampoline and call the current error
+                    // handler.
+                    var exceptionHandlerFunction = getDynamicExceptionHandlerFunction(that);
+                    if (e instanceof baselib.exceptions.RacketError && 
+                        exceptionHandlerFunction !== false) {
+                        that.p = exceptionHandlerFunction;
+                        that.a = 1;
+                        that.e.push(e.racketError);
+                        thunk = baselib.functions.rawApply;
+                    } else {
+                        that.running = false;
+                        that.breakScheduled = false;
+                        release();
+                        that.params.currentErrorHandler(that, e);
+                        return;
+                    }
+                }
+            }
+        }
+
+        that.running = false;
+        that.breakScheduled = false;
+        release();
+        return;
+
+    };
+
+    // getDynamicExceptionHandlerFunction: machine -> (U procedure #f)
+    //
+    // Scans for the nearest continuation mark value associated to
+    // baselib.paramz.exceptionHandlerKey.
+    //
+    // If it exists and the value is a closure, then return that closure's
+    // label.  Otherwise, return false.
+    var getDynamicExceptionHandlerFunction = function(M) {
+        var contMarks = M.captureContinuationMarks(promptTag);
+        var promptTag = baselib.contmarks.DEFAULT_CONTINUATION_PROMPT_TAG;
+        var procOrUndefined = contMarks.refFirst(baselib.paramz.exceptionHandlerKey,
+                                                 promptTag);
+        if (baselib.functions.isProcedure(procOrUndefined)) {
+            return procOrUndefined;
+        } else {
+            return false;
+        }
+    };
+
+
+
+    // recomputeGas: state number -> number
+    recomputeMaxNumBouncesBeforeYield = function(MACHINE, observedDelay) {
+	// We'd like to see a delay of DESIRED_DELAY_BETWEEN_BOUNCES so
+	// that we get MACHINE.params.desiredYieldsPerSecond bounces per
+	// second.
+	var DESIRED_DELAY_BETWEEN_BOUNCES =
+	    (1000 / MACHINE.params.desiredYieldsPerSecond);
+	var ALPHA = 50;
+	var delta = (ALPHA * ((DESIRED_DELAY_BETWEEN_BOUNCES -
+			       observedDelay) /
+			      DESIRED_DELAY_BETWEEN_BOUNCES));
+	MACHINE.params.maxNumBouncesBeforeYield =
+            Math.max(Math.floor(MACHINE.params.maxNumBouncesBeforeYield + delta),
+                     1);
+    };
+
+
+
+
+
+
+
+
+
+
+    //////////////////////////////////////////////////////////////////////
+    //////////////////////////////////////////////////////////////////////
+    //////////////////////////////////////////////////////////////////////
+
+
+
+
+
+
+
+
+
+    // There is a single, distinguished default continuation prompt tag
+    // that's used to wrap around toplevel prompts.
+    var DEFAULT_CONTINUATION_PROMPT_TAG =
+        baselib.contmarks.DEFAULT_CONTINUATION_PROMPT_TAG;
+
+
+
+
+
+
+
+
+    //////////////////////////////////////////////////////////////////////
+    //////////////////////////////////////////////////////////////////////
+    //////////////////////////////////////////////////////////////////////
+
+    var VariableReference = function(prefix, pos) {
+        this.prefix = prefix;
+        this.pos = pos;
+    };
+
+
+
+
+
+
+
+
+    //////////////////////////////////////////////////////////////////////
+    //////////////////////////////////////////////////////////////////////
+    //////////////////////////////////////////////////////////////////////
+
+    // Implementation of the ready function.  This will fire off when
+    // setReadyTrue is called.
+    var ready, setReadyTrue, setReadyFalse;
+    (function() {
+        var runtimeIsReady = true;
+        var readyWaiters = [];
+        var notifyWaiter = function(w) {
+            w();
+        };
+
+        ready = function(f) {
+            if (runtimeIsReady) {
+                notifyWaiter(f);
+            } else {
+                readyWaiters.push(f);
+            }
+        };
+
+        setReadyTrue = function() {
+            runtimeIsReady = true;
+            while(runtimeIsReady && readyWaiters.length > 0) {
+                notifyWaiter(readyWaiters.shift());
+            }
+        };
+
+        setReadyFalse = function() {
+            runtimeIsReady = false;
+        };
+
+    }());
+
+
+    //////////////////////////////////////////////////////////////////////
+    //////////////////////////////////////////////////////////////////////
+    //////////////////////////////////////////////////////////////////////
+
+    // Executes all programs that have been labeled as a main module
+    var invokeMains = function(machine, succ, fail) {
+        runtime.ready(function () {
+            setReadyFalse();
+            machine = machine || runtime.currentMachine;
+            var wrappedSucc = function() { if (succ) { succ.apply(null, arguments); } setReadyTrue(); }
+            var wrappedFail = function() { if (fail) { fail.apply(null, arguments); } setReadyTrue(); }
+            var mainModules = machine.mainModules.slice();
+            var loop = function() {
+                if (mainModules.length > 0) {
+                    var nextModuleName = mainModules.shift();
+                    machine.loadAndInvoke(nextModuleName, loop, wrappedFail);
+                } else {
+                    wrappedSucc();
+                }
+            };
+            setTimeout(loop, 0);
+        });
+    };
+
+    // Looks up a name in any of the machine's main modules.
+    var lookupInMains = function(name, machine) {
+        var i;
+        machine = machine || runtime.currentMachine;
+        for (i = 0; i < machine.mainModules.length; i++) {
+            var ns = machine.modules[machine.mainModules[i]].getExternalExports();
+            if(ns.hasKey(name)) {
+                return ns.get(name);
+            }
+        }
+    };
+
+
+
+    var checkClosureAndArity = function(M) {
+        if(!(M.p instanceof Closure)){
+            raiseOperatorApplicationError(M,M.p);
+        }
+        if(!isArityMatching(M.p.racketArity,M.a)) {
+            raiseArityMismatchError(M,M.p,M.a);
+        }
+    };
+
+    var checkPrimitiveArity = function(M) {
+        if(!isArityMatching(M.p.racketArity,M.a)) {
+            raiseArityMismatchError(M,M.p,M.a);
+        }
+    };
+
+
+    //////////////////////////////////////////////////////////////////////
+    // Superinstructions to try to reduce code size.
+    var si_context_expected = function(n) {
+        if (n === 1) { return si_context_expected_1; }
+        var f = function(M) { raiseContextExpectedValuesError(M, n); };
+        return f;
+    };
+    var si_context_expected_1 = function(M) { raiseContextExpectedValuesError(M, 1); }
+
+    // A block that omits the multiple values returned on the stack and
+    // continues on with the target function f.
+    var si_pop_multiple_values_and_continue = function(target) {
+        var f = function(M) {
+            if(--M.cbt<0) { throw f; }
+            M.e.length -= (M.a-1);
+            return target(M);
+        };
+        return f;
+    };
+
+
+    //////////////////////////////////////////////////////////////////////
+    var checkedIsZero = function(M, n) {
+        if (typeof(n) === 'number') { return n===0; }
+        return plt.baselib.numbers.equals(
+            testArgument(M, 'number', isNumber, n, 0, 'zero?'),
+            0);
+    };
+
+    var checkedAdd1 = function(M, n) {
+        if (typeof(n) === 'number' && n < 9e15) { return n+1; }
+        return plt.baselib.numbers.add(
+            testArgument(M, 'number', isNumber, n, 0, 'add1'),
+            1);
+    };
+
+    var checkedSub1 = function(M, n) {
+        if (typeof(n) === 'number' && n > -9e15) { return n-1; }
+        return plt.baselib.numbers.subtract(
+            testArgument(M, 'number', isNumber, n, 0, 'sub1'),
+            1);
+    };
+
+    var checkedNegate = function(M, n) {
+        if (typeof(n) === 'number') { return -n; }
+        return plt.baselib.numbers.subtract(
+            0,
+            testArgument(M, 'number', isNumber, n, 0, '-'));
+    };
+
+    var checkedAdd = function(M, x, y) {
+        var sum, i;
+        // fast path optimization: binop addition on fixnums
+        if (arguments.length === 3) {
+            if (typeof(x) === 'number' && typeof(y) === 'number') {
+                sum = x + y;
+                if (sum < -9e15 || sum > 9e15) {
+                    return plt.baselib.numbers.add(x, y);
+                }
+                return sum;
+            } else {
+                if (! isNumber(x)) {
+                    raiseArgumentTypeError(M, '+', 'number', 0, x);
+                }
+                if (! isNumber(y)) {
+                    raiseArgumentTypeError(M, '+', 'number', 1, y);
+                }
+                return plt.baselib.numbers.add(x, y);
+            }
+        }
+        // Secondary path: if everything is a fixnum...
+        sum = 0;
+        for (i = 1; i < arguments.length; i++) {
+            if (typeof(arguments[i]) === 'number') {
+                sum += arguments[i];
+                if (sum < -9e15 || sum > 9e15) {
+                    return checkedAddSlowPath(M, Array.prototype.slice.call(arguments, 1));
+                }
+            } else {
+                return checkedAddSlowPath(M, Array.prototype.slice.call(arguments, 1));
+            }
+        }
+        return sum;
+    };
+
+    var checkedAddSlowPath = function(M, args) {
+        var i;
+        var sum = 0;
+        for (i = 0; i < args.length; i++) {
+            if (! isNumber(args[i])) {
+                raiseArgumentTypeError(M, '+', 'number', i, args[i]);
+            }
+            sum = plt.baselib.numbers.add(sum, args[i]);
+        }
+        return sum;
+    };
+
+    var checkedMul = function(M, x, y) {
+        var prod, i;
+        // fast path optimization: binop addition on fixnums
+        if (arguments.length === 3) {
+            if (typeof(x) === 'number' && typeof(y) === 'number') {
+                prod = x * y;
+                if (prod < -9e15 || prod > 9e15) {
+                    return plt.baselib.numbers.multiply(x, y);
+                }
+                return prod;
+            } else {
+                if (! isNumber(x)) {
+                    raiseArgumentTypeError(M, '*', 'number', 0, x);
+                }
+                if (! isNumber(y)) {
+                    raiseArgumentTypeError(M, '*', 'number', 1, y);
+                }
+                return plt.baselib.numbers.multiply(x, y);
+            }
+        }
+        // Secondary path: if everything is a fixnum...
+        prod = 1;
+        for (i = 1; i < arguments.length; i++) {
+            if (typeof(arguments[i]) === 'number') {
+                prod *= arguments[i];
+                if (prod < -9e15 || prod > 9e15) {
+                    return checkedMulSlowPath(M, Array.prototype.slice.call(arguments, 1));
+                }
+            } else {
+                return checkedMulSlowPath(M, Array.prototype.slice.call(arguments, 1));
+            }
+        }
+        return prod;
+    };
+
+    var checkedMulSlowPath = function(M, args) {
+        var i, prod;
+        if (! isNumber(args[0])) {
+            raiseArgumentTypeError(M, '*', 'number', 0, args[0]);
+        }
+        var prod = args[0];
+        for (i = 1; i < args.length; i++) {
+            if (! isNumber(args[i])) {
+                raiseArgumentTypeError(M, '*', 'number', i, args[i]);
+            }
+            prod = plt.baselib.numbers.multiply(prod, args[i]);
+        }
+        return prod;
+    };
+
+
+    var checkedSub = function(M, x, y) {
+        // Assumption: at least two arguments to subtract.
+        var sum;
+        // fast path optimization: binop subtraction on fixnums
+        if (arguments.length === 3) {
+            if (typeof(x) === 'number' && typeof(y) === 'number') {
+                sum = x - y;
+                if (sum < -9e15 || sum > 9e15) {
+                    return checkedSubSlowPath(M, Array.prototype.slice.call(arguments, 1));
+                }
+                return sum;
+            } else {
+                if (! isNumber(x)) {
+                    raiseArgumentTypeError(M, '-', 'number', 0, x);
+                }
+                if (! isNumber(y)) {
+                    raiseArgumentTypeError(M, '-', 'number', 1, y);
+                }
+                return plt.baselib.numbers.subtract(x, y);
+            }
+        }
+        return checkedSubSlowPath(M, Array.prototype.slice.call(arguments, 1));
+    };
+
+    var checkedSubSlowPath = function(M, args) {
+        var i;
+        if (! isNumber(args[0])) {
+            raiseArgumentTypeError(M, '-', 'number', 0, args[0]);
+        }
+        var sum = args[0];
+        for (i = 1; i < args.length; i++) {
+            if (! isNumber(args[i])) {
+                raiseArgumentTypeError(M, '-', 'number', i, args[i]);
+            }
+            sum = plt.baselib.numbers.subtract(sum, args[i]);
+        }
+        return sum;
+    };
+
+    var checkedGreaterThan = function(M, x, y) {
+        // fast path optimization: binop comparison on fixnums
+        if (arguments.length === 3) {
+            if (typeof(x) === 'number' && typeof(y) === 'number') {
+                return x > y;
+            } else {
+                if (! isNumber(x)) {
+                    raiseArgumentTypeError(M, '>', 'number', 0, x);
+                }
+                if (! isNumber(y)) {
+                    raiseArgumentTypeError(M, '>', 'number', 1, y);
+                }
+                return plt.baselib.numbers.greaterThan(x, y);
+            }
+        }
+        return checkedGreaterThanSlowPath(M, Array.prototype.slice.call(arguments, 1));
+    };
+
+    var checkedGreaterThanSlowPath = function(M, args) {
+        var i;
+        if (! isNumber(args[0])) {
+            raiseArgumentTypeError(M, '>', 'number', 0, args[0]);
+        }
+        for (i = 1; i < args.length ; i++) {
+            if (! isNumber(args[i])) {
+                raiseArgumentTypeError(M, '>', 'number', i, args[i]);
+            }
+            if (! plt.baselib.numbers.greaterThan(args[i-1], args[i])) {
+                return false;
+            }
+        }
+        return true;
+    };
+
+
+    var checkedNumEquals = function(M, x, y) {
+        // Assumption: at least two arguments to compare
+        var i;
+
+        // fast path optimization: binop comparison on fixnums
+        if (arguments.length === 3) {
+            if (typeof(x) === 'number' && typeof(y) === 'number') {
+                return x === y;
+            } else {
+                if (! isNumber(x)) {
+                    raiseArgumentTypeError(M, '=', 'number', 0, x);
+                }
+                if (! isNumber(y)) {
+                    raiseArgumentTypeError(M, '=', 'number', 1, y);
+                }
+                return plt.baselib.numbers.equals(x, y);
+            }
+        }
+        if (typeof(arguments[1]) !== 'number') {
+            return checkedNumEqualsSlowPath(M, Array.prototype.slice.call(arguments, 1));
+        }
+        var n = arguments[1];
+        for (i = 2; i < arguments.length; i++) {
+            if (typeof(arguments[i]) === 'number') {
+                if (n !== arguments[i]) { return false; }
+            } else {
+                return checkedNumEqualsSlowPath(M, Array.prototype.slice.call(arguments, 1));
+            }
+        }
+        return true;
+    };
+
+    var checkedNumEqualsSlowPath = function(M, args) {
+        var i;
+        if (! isNumber(args[0])) {
+            raiseArgumentTypeError(M, '=', 'number', 0, args[0]);
+        }
+        var n = args[0];
+        for (i = 1; i < args.length; i++) {
+            if (! isNumber(args[i])) {
+                raiseArgumentTypeError(M, '=', 'number', i, args[i]);
+            }
+            if (! plt.baselib.numbers.equals(n, args[i])) {
+                return false;
+            }
+        }
+        return true;
+    };
+
+    var checkedCar = function(M, v) {
+        if (isPair(v)) { return v.first; }
+        raiseArgumentTypeError(M, 'car', 'pair', 0, v);
+    };
+
+    var checkedCdr = function(M, v) {
+        if (isPair(v)) { return v.rest; }
+        raiseArgumentTypeError(M, 'cdr', 'pair', 0, v);
+    };
+
+    var checkedVectorRef = function(M, vec, i) {
+        var expectedTypeName;
+        if (isVector(vec)) {
+            if (typeof(i) === 'number') {
+                if (i >= 0 && i < vec.elts.length) {
+                    return vec.elts[i];
+                }                
+            } else if (isNatural(i)) {
+                i = baselib.numbers.toFixnum(i);
+                if (i >= 0 && i < vec.elts.length) {
+                    return vec.elts[i];
+                }
+            }
+            expectedTypeName = baselib.format.format('natural between 0 and ~a', 
+                                                     [vec.elts.length]);
+            raiseArgumentTypeError(M, 'vector-ref', expectedTypeName, 1, i);
+        } else {
+            raiseArgumentTypeError(M, 'vector-ref', 'vector', 0, vec);
+        }
+    };
+
+
+    var checkedVectorSet = function(M, vec, i, val) {
+        var expectedTypeName;
+        if (isVector(vec)) {
+            if (typeof(i) === 'number') {
+                if (i >= 0 && i < vec.elts.length) {
+                    vec.elts[i] = val;
+                    return VOID;
+                }                
+            } else if (isNatural(i)) {
+                i = baselib.numbers.toFixnum(i);
+                if (i >= 0 && i < vec.elts.length) {
+                    vec.elts[i] = val;
+                    return VOID;
+                }
+            }
+            expectedTypeName = baselib.format.format('natural between 0 and ~a', 
+                                                     [vec.elts.length]);
+            raiseArgumentTypeError(M, 'vector-set!', expectedTypeName, 1, i);
+        } else {
+            raiseArgumentTypeError(M, 'vector-set!', 'vector', 0, vec);
+        }
+    };
+
+
+    // defaultModuleLoader: Machine string (-> any) (-> any) -> void
+    //
+    // The default module loader currently doesn't do anything dynamic.
+    // 
+    // Other module loader implementations may do more interesting
+    // things here, such as loading off the disk, or from the network.
+    var defaultModuleLoader = function(M, moduleName, success, fail) {
+        if (M.installedModules[moduleName] !== undefined) {
+            return success();
+        } else {
+            return fail();
+        }
+    };
+
+    
+    // makeLocalFileModuleLoader: (hashof string string) -> moduleLoader
+    // Given the manifest mapping module names to the files that implement them,
+    // produces a module loader that uses loadscript to get these modules
+    // into memory.
+    var makeLocalFileModuleLoader = function(moduleManifest) {
+        var loadScript = baselib.loadscript.loadScript;
+        return function(M, moduleName, success, fail) {
+
+            if (M.installedModules[moduleName] !== undefined) {
+                return success();
+            } else {
+                // The manifest should map module names to 
+                // their files.
+                if (moduleManifest[moduleName]) {
+                    var modulePath = moduleManifest[moduleName];
+                    return loadScript(modulePath+"?gensym="+Math.random(), success, fail);
+                }
+                return fail();
+            }
+        };
+    };
+
+
+
+
+
+    //////////////////////////////////////////////////////////////////////
+    //////////////////////////////////////////////////////////////////////
+    //////////////////////////////////////////////////////////////////////
+
+
+    // Exports
+    var exports = runtime;
+    exports['currentMachine'] = new Machine();
+
+    exports['currentModuleLoader'] = defaultModuleLoader;
+    exports['makeLocalFileModuleLoader'] = makeLocalFileModuleLoader;
+
+    exports['invokeMains'] = invokeMains;
+    exports['lookupInMains'] = lookupInMains;
+
+
+    // installing new primitives
+    exports['installPrimitiveProcedure'] = installPrimitiveProcedure;
+    exports['makePrimitiveProcedure'] = makePrimitiveProcedure;
+    exports['Primitives'] = Primitives;
+
+    exports['ready'] = ready;
+    // Private: the runtime library will set this flag to true when
+    // the library has finished loading.
+    exports['setReadyTrue'] = setReadyTrue;
+    exports['setReadyFalse'] = setReadyFalse;
+
+
+
+
+    exports['Machine'] = Machine;
+    exports['Frame'] = Frame;
+    exports['CallFrame'] = CallFrame;
+    exports['PromptFrame'] = PromptFrame;
+    exports['Closure'] = Closure;
+    exports['ModuleRecord'] = ModuleRecord;
+    exports['VariableReference'] = VariableReference;
+    exports['ContinuationPromptTag'] = ContinuationPromptTag;
+    exports['DEFAULT_CONTINUATION_PROMPT_TAG'] =
+	DEFAULT_CONTINUATION_PROMPT_TAG;
+    exports['NULL'] = NULL;
+    exports['VOID'] = VOID;
+
+    exports['NEGATIVE_ZERO'] = NEGATIVE_ZERO;
+    exports['INF'] = INF;
+    exports['NEGATIVE_INF'] = NEGATIVE_INF;
+    exports['NAN'] = NAN;
+
+
+
+
+
+    exports['testArgument'] = testArgument;
+    exports['testArity'] = testArity;
+    exports['makeCheckArgumentType'] = makeCheckArgumentType;
+
+
+    exports['raise'] = raise;
+    exports['raiseUnboundToplevelError'] = raiseUnboundToplevelError;
+    exports['raiseArgumentTypeError'] = raiseArgumentTypeError;
+    exports['raiseContextExpectedValuesError'] = raiseContextExpectedValuesError;
+    exports['raiseArityMismatchError'] = raiseArityMismatchError;
+    exports['raiseOperatorApplicationError'] = raiseOperatorApplicationError;
+    exports['raiseOperatorIsNotPrimitiveProcedure'] = raiseOperatorIsNotPrimitiveProcedure;
+    exports['raiseUnimplementedPrimitiveError'] = raiseUnimplementedPrimitiveError;
+    exports['raiseModuleLoadingError'] = raiseModuleLoadingError;
+
+
+    exports['finalizeClosureCall'] = finalizeClosureCall;
+
+
+    //////////////////////////////////////////////////////////////////////
+
+
+    // Type constructors
+
+    // numbers
+    exports['makeList'] = makeList;
+    exports['makePair'] = makePair;
+    exports['makeChar'] = makeChar;
+    exports['makeVector'] = makeVector;
+    exports['makeBox'] = makeBox;
+    exports['makeFloat'] = makeFloat;
+    exports['makeRational'] = makeRational;
+    exports['makeBignum'] = makeBignum;
+    exports['makeComplex'] = makeComplex;
+    exports['makeSymbol'] = makeSymbol;
+    exports['makePath'] = makePath;
+    exports['makeBytes'] = makeBytes;
+    exports['makeBytesFromBase64'] = makeBytesFromBase64;
+
+
+    exports['checkPair'] = baselib.check.checkPair;
+    exports['checkNumber'] = baselib.check.checkNumber;
+    exports['checkString'] = baselib.check.checkString;
+
+
+
+    // Type predicates
+    exports['isPair'] = isPair;
+    exports['isCaarPair'] = isCaarPair;
+    exports['isList'] = isList;
+    exports['isVector'] = isVector;
+    exports['isOutputPort'] = isOutputPort;
+    exports['isOutputStringPort'] = isOutputStringPort;
+    exports['isBox'] = isBox;
+    exports['isString'] = isString;
+    exports['isSymbol'] = isSymbol;
+    exports['isPath'] = isPath;
+    exports['isNumber'] = isNumber;
+    exports['isNatural'] = isNatural;
+    exports['isReal'] = isReal;
+    exports['isProcedure'] = plt.baselib.functions.isProcedure;
+    exports['equals'] = equals;
+
+    exports['toDomNode'] = toDomNode;
+    exports['toWrittenString'] = toWrittenString;
+    exports['toDisplayedString'] = toDisplayedString;
+
+    exports['ArityAtLeast'] = ArityAtLeast;
+    exports['makeArityAtLeast'] = makeArityAtLeast;
+    exports['isArityMatching'] = isArityMatching;
+
+    exports['heir'] = heir;
+    exports['makeClassPredicate'] = makeClassPredicate;
+
+    exports['PAUSE'] = PAUSE;
+    exports['HaltError'] = HaltError;
+
+
+
+    exports['makeStructureType'] = makeStructureType;
+    exports['Struct'] = Struct;
+    exports['StructType'] = StructType;
+
+    exports['getTracedAppKey'] = getTracedAppKey;
+    exports['getTracedCalleeKey'] = getTracedCalleeKey;
+
+    exports['si_context_expected'] = si_context_expected;
+    exports['si_context_expected_1'] = si_context_expected_1;
+    exports['checkClosureAndArity'] = checkClosureAndArity;
+    exports['checkPrimitiveArity'] = checkPrimitiveArity;
+
+    exports['checkedIsZero'] = checkedIsZero;
+    exports['checkedAdd1'] = checkedAdd1;
+    exports['checkedSub1'] = checkedSub1;
+    exports['checkedNegate'] = checkedNegate;
+    exports['checkedAdd'] = checkedAdd;
+    exports['checkedAddSlowPath'] = checkedAddSlowPath;
+    exports['checkedMul'] = checkedMul;
+    exports['checkedMulSlowPath'] = checkedMulSlowPath;
+    exports['checkedSub'] = checkedSub;
+    exports['checkedSubSlowPath'] = checkedSubSlowPath;
+    exports['checkedNumEquals'] = checkedNumEquals;
+    exports['checkedNumEqualsSlowPath'] = checkedNumEqualsSlowPath;
+    exports['checkedGreaterThan'] = checkedGreaterThan;
+    exports['checkedGreaterThanSlowPath'] = checkedGreaterThanSlowPath;
+    exports['checkedCar'] = checkedCar;
+    exports['checkedCdr'] = checkedCdr;
+    exports['checkedVectorRef'] = checkedVectorRef;
+    exports['checkedVectorSet'] = checkedVectorSet;
+
+
+    exports['makeRandomNonce'] = makeRandomNonce;
+}(this.plt, jQuery));
+
+(function(M, SUCCESS, FAIL, PARAMS) {(function(M, success, fail, params) {
+"use strict";
+var param;
+var RT = plt.runtime;
+var _247=function(M){if(--M.cbt<0){throw _247;}
+
+//"lambda body for memq"
+
+M.e.push(M.p.closedVals[0]);
+M.v=(M.e[M.e.length-3]===RT.NULL);
+if(M.v===false){return(_251)(M);}else{M.v=false;
+M.e.length-=3;
+M.p=M.c[M.c.length-1].label;
+M.c.pop();
+return(M.p)(M);}};
+
+var _248=function(M){M.c.push(new RT.CallFrame(_250,M.p)); M.addPrompt(RT.DEFAULT_CONTINUATION_PROMPT_TAG,false,M.e.length);
+M.e.push([]);M.e[M.e.length-1].names=[];
+M.e.push(void(0));
+M.e[M.e.length-1]=new RT.Closure(_247,2,void(0),"memq");
+M.e[M.e.length-1].closedVals=[M.e[M.e.length-1]];
+M.v=M.e[M.e.length-1];
+M.a=1;
+M.e.splice(M.e.length-((M.a-1)+1),1);
+M.v=M.v;
+M.e.splice(M.e.length-((M.a-1)+1),1);
+M.p=M.c[M.c.length-1].label;
+M.c.pop();
+return(M.p)(M);};
+
+
+var _184=function(M){if(--M.cbt<0){throw _184;}
+
+//"lambda body for loop"
+
+M.e.push(M.p.closedVals[0]);
+M.e.push(M.e[M.e.length-3]);
+M.p=_185_c;
+M.a=1;
+M.c.push(new RT.CallFrame(_199,M.p));
+return(_185)(M);};
+
+var _306=function(M){M.c.push(new RT.CallFrame(_308,M.p)); M.addPrompt(RT.DEFAULT_CONTINUATION_PROMPT_TAG,false,M.e.length);
+M.e.push([]);M.e[M.e.length-1].names=[];
+M.e.push(void(0));
+M.e[M.e.length-1]=new RT.Closure(_305,2,void(0),"assv");
+M.e[M.e.length-1].closedVals=[M.e[M.e.length-1]];
+M.v=M.e[M.e.length-1];
+M.a=1;
+M.e.splice(M.e.length-((M.a-1)+1),1);
+M.v=M.v;
+M.e.splice(M.e.length-((M.a-1)+1),1);
+M.p=M.c[M.c.length-1].label;
+M.c.pop();
+return(M.p)(M);};
+
+var _32=function(M){M.p=_3_c;
+M.a=2;
+M.c.push(new RT.CallFrame(_37,M.p));
+return(_3)(M);};
+
+var _243=function(M){if(--M.cbt<0){throw _243;}
+
+//"lambda body for unknown"
+
+M.e.push(void(0));
+M.e[M.e.length-1]=RT.checkedCar(M, M.e[M.e.length-2]);
+M.v=RT.checkedCar(M, M.e[M.e.length-1]);
+M.e.length-=2;
+M.p=M.c[M.c.length-1].label;
+M.c.pop();
+return(M.p)(M);};
+
+var _244=function(M){M.c.push(new RT.CallFrame(_246,M.p)); M.addPrompt(RT.DEFAULT_CONTINUATION_PROMPT_TAG,false,M.e.length);
+M.e.push([]);M.e[M.e.length-1].names=[];
+M.v=_243_c;
+M.a=1;
+M.v=M.v;
+M.e.splice(M.e.length-((M.a-1)+1),1);
+M.p=M.c[M.c.length-1].label;
+M.c.pop();
+return(M.p)(M);};
+
+var _321=function(M){if(--M.cbt<0){throw _321;}
+M.e.length-=(M.a-1);
+return(_322)(M);};
+
+var _325=function(M){M.e.push(void(0),void(0));
+M.e[M.e.length-1]=M.e[M.e.length-4];
+M.e[M.e.length-2]=RT.checkedCdr(M, M.e[M.e.length-5]);
+M.p=M.e[M.e.length-3];
+M.a=2;
+M.e.splice(M.e.length-5,3);
+M.c[M.c.length-1].p=M.p;
+return(_319)(M);};
+
+var _323=function(M){M.e.push(void(0),void(0));
+M.e[M.e.length-1]=M.e[M.e.length-4];
+M.e[M.e.length-2]=(RT.testArgument(M,"caarpair",RT.isCaarPair,M.e[M.e.length-5],0,"caar")).first.first;
+M.v=M.primitives["equal?"]._i(M);
+M.e.length-=2;
+if(M.v===false){return(_325)(M);}else{M.v=RT.checkedCar(M, M.e[M.e.length-3]);
+M.e.length-=3;
+M.p=M.c[M.c.length-1].label;
+M.c.pop();
+return(M.p)(M);}};
+
+var _319=function(M){if(--M.cbt<0){throw _319;}
+
+//"lambda body for assoc"
+
+M.e.push(M.p.closedVals[0]);
+M.v=(M.e[M.e.length-3]===RT.NULL);
+if(M.v===false){return(_323)(M);}else{M.v=false;
+M.e.length-=3;
+M.p=M.c[M.c.length-1].label;
+M.c.pop();
+return(M.p)(M);}};
+
+var _320=function(M){M.c.push(new RT.CallFrame(_322,M.p)); M.addPrompt(RT.DEFAULT_CONTINUATION_PROMPT_TAG,false,M.e.length);
+M.e.push([]);M.e[M.e.length-1].names=[];
+M.e.push(void(0));
+M.e[M.e.length-1]=new RT.Closure(_319,2,void(0),"assoc");
+M.e[M.e.length-1].closedVals=[M.e[M.e.length-1]];
+M.v=M.e[M.e.length-1];
+M.a=1;
+M.e.splice(M.e.length-((M.a-1)+1),1);
+M.v=M.v;
+M.e.splice(M.e.length-((M.a-1)+1),1);
+M.p=M.c[M.c.length-1].label;
+M.c.pop();
+return(M.p)(M);};
+
+var _384=function(M){RT.Primitives["values"]=RT.Primitives["values"]||_385_c;
+return(_388)(M);};
+
+var _292=function(M){M.c.push(new RT.CallFrame(_294,M.p)); M.addPrompt(RT.DEFAULT_CONTINUATION_PROMPT_TAG,false,M.e.length);
+M.e.push([]);M.e[M.e.length-1].names=[];
+M.e.push(void(0));
+M.e[M.e.length-1]=new RT.Closure(_291,2,void(0),"assq");
+M.e[M.e.length-1].closedVals=[M.e[M.e.length-1]];
+M.v=M.e[M.e.length-1];
+M.a=1;
+M.e.splice(M.e.length-((M.a-1)+1),1);
+M.v=M.v;
+M.e.splice(M.e.length-((M.a-1)+1),1);
+M.p=M.c[M.c.length-1].label;
+M.c.pop();
+return(M.p)(M);};
+
+var _9=function(M){if(--M.cbt<0){throw _9;}
+M.e.length-=(M.a-1);
+return(_10)(M);};
+
+var _59=function(M){M.v=RT.makePair(M.e[M.e.length-1],M.e[M.e.length-2]);
+M.e.length-=3;
+M.p=M.c[M.c.length-1].label;
+M.c.pop();
+return(M.p)(M);};
+
+
+var _57=function(M){M.e.push(void(0),void(0));
+M.e.push(void(0));
+M.e[M.e.length-1]=RT.checkedCar(M, M.e[M.e.length-4]);
+M.e[M.e.length-2]=RT.checkedCdr(M, M.e[M.e.length-1]);
+M.e.pop();
+M.e.push(void(0));
+M.e.push(M.e[M.e.length-4]);
+M.v=M.primitives["unsafe-cdr"]._i(M);
+M.e.pop();
+M.e[M.e.length-1]=M.v;
+M.p=_7_c;
+M.a=1;
+M.c.push(new RT.CallFrame(_61,M.p));
+return(_7)(M);};
+
+var _54=function(M){M.v=RT.makePair(M.e[M.e.length-1],M.e[M.e.length-2]);
+M.e.length-=3;
+M.p=M.c[M.c.length-1].label;
+M.c.pop();
+return(M.p)(M);};
+
+
+var _52=function(M){M.e.push(void(0),void(0));
+M.e.push(void(0));
+M.e[M.e.length-1]=RT.checkedCar(M, M.e[M.e.length-4]);
+M.e[M.e.length-2]=RT.checkedCar(M, M.e[M.e.length-1]);
+M.e.pop();
+M.e.push(void(0));
+M.e.push(M.e[M.e.length-4]);
+M.v=M.primitives["unsafe-cdr"]._i(M);
+M.e.pop();
+M.e[M.e.length-1]=M.v;
+M.p=_6_c;
+M.a=1;
+M.c.push(new RT.CallFrame(_56,M.p));
+return(_6)(M);};
+
+var _195=function(M){M.e.push(M.e[M.e.length-3]);
+M.p=_186_c;
+M.a=1;
+M.c.push(new RT.CallFrame(_204,M.p));
+return(_186)(M);};
+
+var _47=function(M){M.e.push(void(0));
+M.e.push(M.e[M.e.length-2]);
+M.v=M.primitives["unsafe-cdr"]._i(M);
+M.e.pop();
+M.e[M.e.length-1]=M.v;
+M.p=_5_c;
+M.a=1;
+M.e.splice(M.e.length-2,1);
+M.c[M.c.length-1].p=M.p;
+return(_5)(M);};
+
+var _45=function(M){M.e.push(void(0));
+M.e[M.e.length-1]=RT.checkedCar(M, M.e[M.e.length-2]);
+M.v=(M.e[M.e.length-1]===RT.NULL);
+M.e.pop();
+if(M.v===false){return(_47)(M);}else{M.v=true;
+M.e.pop();
+M.p=M.c[M.c.length-1].label;
+M.c.pop();
+return(M.p)(M);}};
+
+var _309=function(M){M.e.push(void(0),void(0));
+M.e[M.e.length-1]=M.e[M.e.length-4];
+M.e[M.e.length-2]=(RT.testArgument(M,"caarpair",RT.isCaarPair,M.e[M.e.length-5],0,"caar")).first.first;
+M.v=M.primitives["eqv?"]._i(M);
+M.e.length-=2;
+if(M.v===false){return(_311)(M);}else{M.v=RT.checkedCar(M, M.e[M.e.length-3]);
+M.e.length-=3;
+M.p=M.c[M.c.length-1].label;
+M.c.pop();
+return(M.p)(M);}};
+
+var _40=function(M){M.v=false;
+M.e.pop();
+M.p=M.c[M.c.length-1].label;
+M.c.pop();
+return(M.p)(M);};
+
+var _38=function(M){M.e.push(void(0));
+M.e[M.e.length-1]=RT.checkedCar(M, M.e[M.e.length-2]);
+M.v=(M.e[M.e.length-1]===RT.NULL);
+M.e.pop();
+if(M.v===false){return(_40)(M);}else{M.e.push(void(0));
+M.e.push(M.e[M.e.length-2]);
+M.v=M.primitives["unsafe-cdr"]._i(M);
+M.e.pop();
+M.e[M.e.length-1]=M.v;
+M.p=_4_c;
+M.a=1;
+M.e.splice(M.e.length-2,1);
+M.c[M.c.length-1].p=M.p;
+return(_4)(M);}};
+
+var _35=function(M){M.v=RT.makePair(M.e[M.e.length-1],M.e[M.e.length-2]);
+M.e.length-=4;
+M.p=M.c[M.c.length-1].label;
+M.c.pop();
+return(M.p)(M);};
+
+
+var _245=function(M){if(--M.cbt<0){throw _245;}
+M.e.length-=(M.a-1);
+return(_246)(M);};
+
+
+var _7=function(M){if(--M.cbt<0){throw _7;}
+
+//"lambda body for rest-lists"
+
+M.v=(M.e[M.e.length-1]===RT.NULL);
+if(M.v===false){return(_57)(M);}else{M.v=RT.NULL;
+M.e.pop();
+M.p=M.c[M.c.length-1].label;
+M.c.pop();
+return(M.p)(M);}};
+
+
+var _27=function(M){M.p=M.e[M.e.length-2];
+M.e[M.e.length-2]=M.v;
+M.a=2;
+RT.checkClosureAndArity(M);
+M.c.push(new RT.CallFrame(_31,M.p));
+return((M.p).label)(M);};
+
+
+var _6=function(M){if(--M.cbt<0){throw _6;}
+
+//"lambda body for first-tuple"
+
+M.v=(M.e[M.e.length-1]===RT.NULL);
+if(M.v===false){return(_52)(M);}else{M.v=RT.NULL;
+M.e.pop();
+M.p=M.c[M.c.length-1].label;
+M.c.pop();
+return(M.p)(M);}};
+
+var _22=function(M){M.e.push(void(0),void(0));
+M.e.push(void(0),void(0));
+M.e[M.e.length-2]=M.primitives["apply"];
+M.e[M.e.length-1]=M.e[M.e.length-5];
+M.e.push(M.e[M.e.length-6]);
+M.p=_6_c;
+M.a=1;
+M.c.push(new RT.CallFrame(_29,M.p));
+return(_6)(M);};
+
+var _24=function(M){if(M.v===false){return(_22)(M);}else{M.v=M.e[M.e.length-2];
+M.v=M.e[M.e.length-1];
+M.e.push(void(0),void(0));
+M.e[M.e.length-1]=sym74;
+M.e[M.e.length-2]="all lists must have the same size";
+M.a=2;
+M.v=M.primitives["error"]._i(M);
+M.e.length-=4;
+M.p=M.c[M.c.length-1].label;
+M.c.pop();
+return(M.p)(M);}};
+
+
+var _5=function(M){if(--M.cbt<0){throw _5;}
+
+//"lambda body for some-empty?"
+
+M.v=(M.e[M.e.length-1]===RT.NULL);
+if(M.v===false){return(_45)(M);}else{M.v=false;
+M.e.pop();
+M.p=M.c[M.c.length-1].label;
+M.c.pop();
+return(M.p)(M);}};
+
+var _17=function(M){M.e.push(M.e[M.e.length-2]);
+M.p=_5_c;
+M.a=1;
+M.c.push(new RT.CallFrame(_26,M.p));
+return(_5)(M);};
+
+var _19=function(M){if(M.v===false){return(_17)(M);}else{M.v=RT.NULL;
+M.e.length-=2;
+M.p=M.c[M.c.length-1].label;
+M.c.pop();
+return(M.p)(M);}};
+
+
+var _4=function(M){if(--M.cbt<0){throw _4;}
+
+//"lambda body for all-empty?"
+
+M.v=(M.e[M.e.length-1]===RT.NULL);
+if(M.v===false){return(_38)(M);}else{M.v=true;
+M.e.pop();
+M.p=M.c[M.c.length-1].label;
+M.c.pop();
+return(M.p)(M);}};
+
+var _3=function(M){if(--M.cbt<0){throw _3;}
+
+//"lambda body for loop"
+
+M.e.push(M.e[M.e.length-2]);
+M.p=_4_c;
+M.a=1;
+M.c.push(new RT.CallFrame(_21,M.p));
+return(_4)(M);};
+
+var _2=function(M){if(--M.cbt<0){throw _2;}
+
+//"lambda body for do-it"
+
+M.e.push(void(0),void(0));
+M.e[M.e.length-1]=M.e[M.e.length-3];
+M.e[M.e.length-2]=M.e[M.e.length-4];
+M.p=_3_c;
+M.a=2;
+M.e.splice(M.e.length-4,2);
+M.c[M.c.length-1].p=M.p;
+return(_3)(M);};
+
+var _1=function(M){if(--M.cbt<0){throw _1;}
+
+//"lambda body for unknown"
+
+M.unspliceRestFromStack(1,(M.a-1));
+M.e.push(void(0),void(0));
+M.e[M.e.length-1]=M.e[M.e.length-3];
+M.e[M.e.length-2]=M.e[M.e.length-4];
+M.p=_2_c;
+M.a=2;
+M.e.splice(M.e.length-4,2);
+M.c[M.c.length-1].p=M.p;
+return(_2)(M);};
+
+var _8=function(M){M.c.push(new RT.CallFrame(_10,M.p)); M.addPrompt(RT.DEFAULT_CONTINUATION_PROMPT_TAG,false,M.e.length);
+M.e.push([]);M.e[M.e.length-1].names=[];
+M.v=_1_c;
+M.a=1;
+M.v=M.v;
+M.e.splice(M.e.length-((M.a-1)+1),1);
+M.p=M.c[M.c.length-1].label;
+M.c.pop();
+return(M.p)(M);};
+
+var _191=function(M){if(--M.cbt<0){throw _191;}
+M.e.length-=(M.a-1);
+return(_192)(M);};
+
+var _189=function(M){if(--M.cbt<0){throw _189;}
+
+//"lambda body for unknown"
+
+M.unspliceRestFromStack(1,(M.a-1));
+M.e.push(M.p.closedVals[0]);
+M.e.push(void(0),void(0));
+//"Constant toplevel ref: ?"
+
+M.p=M.e[M.e.length-3][2];
+M.e[M.e.length-1]=M.e[M.e.length-4];
+M.e[M.e.length-2]=M.e[M.e.length-5];
+M.a=2;
+RT.checkClosureAndArity(M);
+M.e.splice(M.e.length-5,3);
+M.c[M.c.length-1].p=M.p;
+return((M.p).label)(M);};
+
+var _238=function(M){M.v=RT.makePair(M.e[M.e.length-1],M.e[M.e.length-2]);
+M.e.length-=3;
+M.p=M.c[M.c.length-1].label;
+M.c.pop();
+return(M.p)(M);};
+
+
+var _236=function(M){M.e.push(void(0),void(0));
+M.e.push(void(0));
+M.e[M.e.length-1]=RT.checkedCar(M, M.e[M.e.length-4]);
+M.e[M.e.length-2]=RT.checkedCdr(M, M.e[M.e.length-1]);
+M.e.pop();
+M.e.push(void(0));
+M.e.push(M.e[M.e.length-4]);
+M.v=M.primitives["unsafe-cdr"]._i(M);
+M.e.pop();
+M.e[M.e.length-1]=M.v;
+M.p=_188_c;
+M.a=1;
+M.c.push(new RT.CallFrame(_240,M.p));
+return(_188)(M);};
+
+var _233=function(M){M.v=RT.makePair(M.e[M.e.length-1],M.e[M.e.length-2]);
+M.e.length-=3;
+M.p=M.c[M.c.length-1].label;
+M.c.pop();
+return(M.p)(M);};
+
+
+var _231=function(M){M.e.push(void(0),void(0));
+M.e.push(void(0));
+M.e[M.e.length-1]=RT.checkedCar(M, M.e[M.e.length-4]);
+M.e[M.e.length-2]=RT.checkedCar(M, M.e[M.e.length-1]);
+M.e.pop();
+M.e.push(void(0));
+M.e.push(M.e[M.e.length-4]);
+M.v=M.primitives["unsafe-cdr"]._i(M);
+M.e.pop();
+M.e[M.e.length-1]=M.v;
+M.p=_187_c;
+M.a=1;
+M.c.push(new RT.CallFrame(_235,M.p));
+return(_187)(M);};
+
+var _226=function(M){M.e.push(void(0));
+M.e.push(M.e[M.e.length-2]);
+M.v=M.primitives["unsafe-cdr"]._i(M);
+M.e.pop();
+M.e[M.e.length-1]=M.v;
+M.p=_186_c;
+M.a=1;
+M.e.splice(M.e.length-2,1);
+M.c[M.c.length-1].p=M.p;
+return(_186)(M);};
+
+var _224=function(M){M.e.push(void(0));
+M.e[M.e.length-1]=RT.checkedCar(M, M.e[M.e.length-2]);
+M.v=(M.e[M.e.length-1]===RT.NULL);
+M.e.pop();
+if(M.v===false){return(_226)(M);}else{M.v=true;
+M.e.pop();
+M.p=M.c[M.c.length-1].label;
+M.c.pop();
+return(M.p)(M);}};
+
+var _219=function(M){M.v=false;
+M.e.pop();
+M.p=M.c[M.c.length-1].label;
+M.c.pop();
+return(M.p)(M);};
+
+var _217=function(M){M.e.push(void(0));
+M.e[M.e.length-1]=RT.checkedCar(M, M.e[M.e.length-2]);
+M.v=(M.e[M.e.length-1]===RT.NULL);
+M.e.pop();
+if(M.v===false){return(_219)(M);}else{M.e.push(void(0));
+M.e.push(M.e[M.e.length-2]);
+M.v=M.primitives["unsafe-cdr"]._i(M);
+M.e.pop();
+M.e[M.e.length-1]=M.v;
+M.p=_185_c;
+M.a=1;
+M.e.splice(M.e.length-2,1);
+M.c[M.c.length-1].p=M.p;
+return(_185)(M);}};
+
+
+var _210=function(M){M.p=M.e[M.e.length-2];
+M.e[M.e.length-2]=M.v;
+M.a=2;
+RT.checkClosureAndArity(M);
+M.c.push(new RT.CallFrame(_214,M.p));
+return((M.p).label)(M);};
+
+
+var _188=function(M){if(--M.cbt<0){throw _188;}
+
+//"lambda body for rest-lists"
+
+M.v=(M.e[M.e.length-1]===RT.NULL);
+if(M.v===false){return(_236)(M);}else{M.v=RT.NULL;
+M.e.pop();
+M.p=M.c[M.c.length-1].label;
+M.c.pop();
+return(M.p)(M);}};
+
+
+var _205=function(M){M.p=M.e[M.e.length-2];
+M.e[M.e.length-2]=M.v;
+M.a=2;
+RT.checkClosureAndArity(M);
+M.c.push(new RT.CallFrame(_209,M.p));
+return((M.p).label)(M);};
+
+
+var _187=function(M){if(--M.cbt<0){throw _187;}
+
+//"lambda body for first-tuple"
+
+M.v=(M.e[M.e.length-1]===RT.NULL);
+if(M.v===false){return(_231)(M);}else{M.v=RT.NULL;
+M.e.pop();
+M.p=M.c[M.c.length-1].label;
+M.c.pop();
+return(M.p)(M);}};
+
+var _200=function(M){M.e.push(void(0),void(0));
+if (M.globals["or"]===void(0)&&M.params.currentNamespace.get("or")===void(0)){ RT.raiseUnboundToplevelError(M,"or"); }
+M.e[M.e.length-2]=(M.globals["or"]!==void(0)?M.globals["or"]:M.params.currentNamespace.get("or"));
+M.e.push(void(0),void(0));
+M.e[M.e.length-2]=M.primitives["apply"];
+M.e[M.e.length-1]=M.e[M.e.length-6];
+M.e.push(M.e[M.e.length-7]);
+M.p=_187_c;
+M.a=1;
+M.c.push(new RT.CallFrame(_207,M.p));
+return(_187)(M);};
+
+var _202=function(M){if(M.v===false){return(_200)(M);}else{M.e.push(void(0),void(0));
+M.e[M.e.length-1]=sym75;
+M.e[M.e.length-2]="all lists must have the same size";
+M.a=2;
+M.v=M.primitives["error"]._i(M);
+M.e.length-=5;
+M.p=M.c[M.c.length-1].label;
+M.c.pop();
+return(M.p)(M);}};
+
+
+var _186=function(M){if(--M.cbt<0){throw _186;}
+
+//"lambda body for some-empty?"
+
+M.v=(M.e[M.e.length-1]===RT.NULL);
+if(M.v===false){return(_224)(M);}else{M.v=false;
+M.e.pop();
+M.p=M.c[M.c.length-1].label;
+M.c.pop();
+return(M.p)(M);}};
+
+var _307=function(M){if(--M.cbt<0){throw _307;}
+M.e.length-=(M.a-1);
+return(_308)(M);};
+
+var _197=function(M){if(M.v===false){return(_195)(M);}else{M.v=RT.NULL;
+M.e.length-=3;
+M.p=M.c[M.c.length-1].label;
+M.c.pop();
+return(M.p)(M);}};
+
+var _311=function(M){M.e.push(void(0),void(0));
+M.e[M.e.length-1]=M.e[M.e.length-4];
+M.e[M.e.length-2]=RT.checkedCdr(M, M.e[M.e.length-5]);
+M.p=M.e[M.e.length-3];
+M.a=2;
+M.e.splice(M.e.length-5,3);
+M.c[M.c.length-1].p=M.p;
+return(_305)(M);};
+
+var _185=function(M){if(--M.cbt<0){throw _185;}
+
+//"lambda body for all-empty?"
+
+M.v=(M.e[M.e.length-1]===RT.NULL);
+if(M.v===false){return(_217)(M);}else{M.v=true;
+M.e.pop();
+M.p=M.c[M.c.length-1].label;
+M.c.pop();
+return(M.p)(M);}};
+
+var _305=function(M){if(--M.cbt<0){throw _305;}
+
+//"lambda body for assv"
+
+M.e.push(M.p.closedVals[0]);
+M.v=(M.e[M.e.length-3]===RT.NULL);
+if(M.v===false){return(_309)(M);}else{M.v=false;
+M.e.length-=3;
+M.p=M.c[M.c.length-1].label;
+M.c.pop();
+return(M.p)(M);}};
+
+var _183=function(M){if(--M.cbt<0){throw _183;}
+
+//"lambda body for do-it"
+
+M.e.push(M.p.closedVals[0]);
+M.e.push(void(0),void(0));
+//"Constant toplevel ref: ?"
+
+M.p=M.e[M.e.length-3][1];
+M.e[M.e.length-1]=M.e[M.e.length-4];
+M.e[M.e.length-2]=M.e[M.e.length-5];
+M.a=2;
+RT.checkClosureAndArity(M);
+M.e.splice(M.e.length-5,3);
+M.c[M.c.length-1].p=M.p;
+return((M.p).label)(M);};
+
+var _190=function(M){M.c.push(new RT.CallFrame(_192,M.p)); M.addPrompt(RT.DEFAULT_CONTINUATION_PROMPT_TAG,false,M.e.length);
+M.e.push([M.globals["or"]!==void(0)?M.globals["or"]:M.params.currentNamespace.get("or"),false,false]);M.e[M.e.length-1].names=["or",false,false];
+M.v=new RT.Closure(_183,2,[M.e[M.e.length-1]],"do-it");
+M.e[M.e.length-1][2]=M.v;
+M.v=RT.VOID;
+M.v=new RT.Closure(_184,2,[M.e[M.e.length-1]],"loop");
+M.e[M.e.length-1][1]=M.v;
+M.v=RT.VOID;
+M.v=new RT.Closure(_189,(RT.makeArityAtLeast(1)),[M.e[M.e.length-1]],"unknown");
+M.a=1;
+M.v=M.v;
+M.e.splice(M.e.length-((M.a-1)+1),1);
+M.p=M.c[M.c.length-1].label;
+M.c.pop();
+return(M.p)(M);};
+
+var _92=function(M){if(--M.cbt<0){throw _92;}
+M.e.push(void(0),void(0));
+M.e[M.e.length-1]=M.e[M.e.length-3];
+M.e.push(M.e[M.e.length-4]);
+M.p=_68_c;
+M.a=1;
+M.c.push(new RT.CallFrame(_95,M.p));
+return(_68)(M);};
+
+var _367=function(M){M.v=RT.makePair(M.e[M.e.length-1],M.e[M.e.length-2]);
+M.e.length-=4;
+M.p=M.c[M.c.length-1].label;
+M.c.pop();
+return(M.p)(M);};
+
+var _93=function(M){M.p=_64_c;
+M.a=2;
+M.e.splice(M.e.length-4,2);
+M.c[M.c.length-1].p=M.p;
+return(_64)(M);};
+
+var _348=function(M){if(--M.cbt<0){throw _348;}
+
+//"lambda body for append-2"
+
+M.v=(M.e[M.e.length-1]===RT.NULL);
+if(M.v===false){return(_365)(M);}else{M.v=M.e[M.e.length-2];
+M.e.length-=2;
+M.p=M.c[M.c.length-1].label;
+M.c.pop();
+return(M.p)(M);}};
+
+var _359=function(M){M.p=_348_c;
+M.a=2;
+M.e.splice(M.e.length-3,1);
+M.c[M.c.length-1].p=M.p;
+return(_348)(M);};
+
+var _88=function(M){M.p=M.e[M.e.length-2];
+M.e[M.e.length-2]=M.v;
+M.a=2;
+RT.checkClosureAndArity(M);
+M.c.push(new RT.CallFrame(_92,M.p));
+return((M.p).label)(M);};
+
+
+var _67=function(M){if(--M.cbt<0){throw _67;}
+
+//"lambda body for first-tuple"
+
+M.v=(M.e[M.e.length-1]===RT.NULL);
+if(M.v===false){return(_113)(M);}else{M.v=RT.NULL;
+M.e.pop();
+M.p=M.c[M.c.length-1].label;
+M.c.pop();
+return(M.p)(M);}};
+
+var _392=function(M){return(_8)(M);};
+
+var _389=function(M){if(--M.cbt<0){throw _389;}
+M.p=M.e[M.e.length-1];
+M.e.pop();
+M.a=(M.a-1);
+M.spliceListIntoStack((M.a-1));
+RT.checkClosureAndArity(M);
+M.e.splice(M.e.length-(M.a+0),0);
+M.c[M.c.length-1].p=M.p;
+return((M.p).label)(M);};
+
+var _388=function(M){RT.Primitives["apply"]=RT.Primitives["apply"]||_389_c;
+};
+
+var _385=function(M){if(--M.cbt<0){throw _385;}
+if(M.a===1){return(_387)(M);}else{if(M.a===0){return(_386)(M);}else{M.v=M.e[M.e.length-1];
+M.e.pop();
+M.p=(M.c[M.c.length-1].label.mvr||RT.si_context_expected_1);
+M.c.pop();
+return(M.p)(M);}}};
+
+var _386=function(M){M.p=(M.c[M.c.length-1].label.mvr||RT.si_context_expected_1);
+M.c.pop();
+return(M.p)(M);};
+
+var _387=function(M){M.v=M.e[M.e.length-1];
+M.e.pop();
+M.p=M.c[M.c.length-1].label;
+M.c.pop();
+return(M.p)(M);};
+
+var _293=function(M){if(--M.cbt<0){throw _293;}
+M.e.length-=(M.a-1);
+return(_294)(M);};
+
+var _callCCClosureEntry=function(M){if(--M.cbt<0){throw _callCCClosureEntry;}
+M.v=M.e[M.e.length-1];
+M.e.push(M.p.closedVals[0],M.p.closedVals[1]);
+M.restoreControl(RT.DEFAULT_CONTINUATION_PROMPT_TAG);
+M.e=M.e[M.e.length-2].slice(0);
+M.p=M.c[M.c.length-1].label;
+M.c.pop();
+return(M.p)(M);};
+
+var _381=function(M){return(_384)(M);};
+
+var _callCCEntry=function(M){if(--M.cbt<0){throw _callCCEntry;}
+M.p=M.e[M.e.length-1];
+M.e.push(void(0),void(0));
+M.e[M.e.length-1]=M.captureControl(0,RT.DEFAULT_CONTINUATION_PROMPT_TAG);
+M.e[M.e.length-2]=M.e.slice(0, M.e.length-3);
+M.e[M.e.length-3]=new RT.Closure(_callCCClosureEntry,1,[M.e[M.e.length-2],M.e[M.e.length-1]],"call/cc");
+M.e.length-=2;
+M.a=1;
+RT.checkClosureAndArity(M);
+M.e.splice(M.e.length-1,0);
+M.c[M.c.length-1].p=M.p;
+return((M.p).label)(M);};
+
+var _373=function(M){if(--M.cbt<0){throw _373;}
+RT.Primitives["call-with-values"]=RT.Primitives["call-with-values"]||M.v;
+RT.Primitives["call/cc"]=RT.Primitives["call/cc"]||_callCCEntry_c;
+RT.Primitives["call-with-current-continuation"]=RT.Primitives["call-with-current-continuation"]||_callCCEntry_c;
+return(_384)(M);};
+
+var _377=function(M){if(--M.cbt<0){throw _377;}
+M.a=1;
+return(_378)(M);};
+
+var _351=function(M){if(--M.cbt<0){throw _351;}
+RT.Primitives["append"]=RT.Primitives["append"]||M.v;
+return(_371)(M);};
+
+var _369=function(M){if(--M.cbt<0){throw _369;}
+M.e[M.e.length-2]=M.v;
+return(_367)(M);};
+
+var _361=function(M){if(--M.cbt<0){throw _361;}
+M.e[M.e.length-2]=M.v;
+return(_359)(M);};
+
+var _337=function(M){if(--M.cbt<0){throw _337;}
+RT.Primitives["length"]=RT.Primitives["length"]||M.v;
+return(_349)(M);};
+
+var _322=function(M){if(--M.cbt<0){throw _322;}
+RT.Primitives["assoc"]=RT.Primitives["assoc"]||M.v;
+return(_335)(M);};
+
+var _308=function(M){if(--M.cbt<0){throw _308;}
+RT.Primitives["assv"]=RT.Primitives["assv"]||M.v;
+return(_320)(M);};
+
+var _294=function(M){if(--M.cbt<0){throw _294;}
+RT.Primitives["assq"]=RT.Primitives["assq"]||M.v;
+return(_306)(M);};
+
+var _278=function(M){if(--M.cbt<0){throw _278;}
+RT.Primitives["memf"]=RT.Primitives["memf"]||M.v;
+return(_292)(M);};
+
+var _284=function(M){if(--M.cbt<0){throw _284;}
+if(M.v===false){return(_281)(M);}else{M.v=M.e[M.e.length-4];
+M.e.length-=4;
+M.p=M.c[M.c.length-1].label;
+M.c.pop();
+return(M.p)(M);}};
+
+var _264=function(M){if(--M.cbt<0){throw _264;}
+RT.Primitives["memv"]=RT.Primitives["memv"]||M.v;
+return(_276)(M);};
+
+var _250=function(M){if(--M.cbt<0){throw _250;}
+RT.Primitives["memq"]=RT.Primitives["memq"]||M.v;
+return(_262)(M);};
+
+var _246=function(M){if(--M.cbt<0){throw _246;}
+RT.Primitives["caar"]=RT.Primitives["caar"]||M.v;
+return(_248)(M);};
+
+var _192=function(M){if(--M.cbt<0){throw _192;}
+RT.Primitives["ormap"]=RT.Primitives["ormap"]||M.v;
+return(_244)(M);};
+
+var _240=function(M){if(--M.cbt<0){throw _240;}
+M.e[M.e.length-2]=M.v;
+return(_238)(M);};
+
+var _235=function(M){if(--M.cbt<0){throw _235;}
+M.e[M.e.length-2]=M.v;
+return(_233)(M);};
+
+var _214=function(M){if(--M.cbt<0){throw _214;}
+M.p=M.e[M.e.length-2];
+M.e[M.e.length-2]=M.v;
+M.a=2;
+RT.checkClosureAndArity(M);
+M.e.splice(M.e.length-5,3);
+M.c[M.c.length-1].p=M.p;
+return((M.p).label)(M);};
+
+var _212=function(M){if(--M.cbt<0){throw _212;}
+return(_210)(M);};
+
+var _209=function(M){if(--M.cbt<0){throw _209;}
+M.e[M.e.length-1]=M.v;
+M.e.push(void(0),void(0));
+//"Constant toplevel ref: ?"
+
+M.e[M.e.length-2]=M.e[M.e.length-5][1];
+M.e[M.e.length-1]=M.e[M.e.length-6];
+M.e.push(M.e[M.e.length-7]);
+M.p=_188_c;
+M.a=1;
+M.c.push(new RT.CallFrame(_212,M.p));
+return(_188)(M);};
+
+var _207=function(M){if(--M.cbt<0){throw _207;}
+return(_205)(M);};
+
+var _204=function(M){if(--M.cbt<0){throw _204;}
+return(_202)(M);};
+
+var _199=function(M){if(--M.cbt<0){throw _199;}
+return(_197)(M);};
+
+var _132=function(M){if(--M.cbt<0){throw _132;}
+RT.Primitives["andmap"]=RT.Primitives["andmap"]||M.v;
+return(_190)(M);};
+
+var _180=function(M){if(--M.cbt<0){throw _180;}
+M.e[M.e.length-2]=M.v;
+return(_178)(M);};
+
+var _175=function(M){if(--M.cbt<0){throw _175;}
+M.e[M.e.length-2]=M.v;
+return(_173)(M);};
+
+var _154=function(M){if(--M.cbt<0){throw _154;}
+M.p=M.e[M.e.length-2];
+M.e[M.e.length-2]=M.v;
+M.a=2;
+RT.checkClosureAndArity(M);
+M.e.splice(M.e.length-5,3);
+M.c[M.c.length-1].p=M.p;
+return((M.p).label)(M);};
+
+var _152=function(M){if(--M.cbt<0){throw _152;}
+return(_150)(M);};
+
+var _149=function(M){if(--M.cbt<0){throw _149;}
+M.e[M.e.length-1]=M.v;
+M.e.push(void(0),void(0));
+//"Constant toplevel ref: ?"
+
+M.e[M.e.length-2]=M.e[M.e.length-5][1];
+M.e[M.e.length-1]=M.e[M.e.length-6];
+M.e.push(M.e[M.e.length-7]);
+M.p=_128_c;
+M.a=1;
+M.c.push(new RT.CallFrame(_152,M.p));
+return(_128)(M);};
+
+var _147=function(M){if(--M.cbt<0){throw _147;}
+return(_145)(M);};
+
+var _144=function(M){if(--M.cbt<0){throw _144;}
+return(_142)(M);};
+
+var _139=function(M){if(--M.cbt<0){throw _139;}
+return(_137)(M);};
+
+var _71=function(M){if(--M.cbt<0){throw _71;}
+RT.Primitives["for-each"]=RT.Primitives["for-each"]||M.v;
+return(_130)(M);};
+
+var _122=function(M){if(--M.cbt<0){throw _122;}
+M.e[M.e.length-2]=M.v;
+return(_120)(M);};
+
+var _117=function(M){if(--M.cbt<0){throw _117;}
+M.e[M.e.length-2]=M.v;
+return(_115)(M);};
+
+var _95=function(M){if(--M.cbt<0){throw _95;}
+M.e[M.e.length-2]=M.v;
+return(_93)(M);};
+
+var _101=function(M){M.v=false;
+M.e.pop();
+M.p=M.c[M.c.length-1].label;
+M.c.pop();
+return(M.p)(M);};
+
+var _90=function(M){if(--M.cbt<0){throw _90;}
+return(_88)(M);};
+
+var _87=function(M){if(--M.cbt<0){throw _87;}
+return(_85)(M);};
+
+var _82=function(M){if(--M.cbt<0){throw _82;}
+return(_80)(M);};
+
+var _10=function(M){if(--M.cbt<0){throw _10;}
+RT.Primitives["map"]=RT.Primitives["map"]||M.v;
+return(_69)(M);};
+
+var _61=function(M){if(--M.cbt<0){throw _61;}
+M.e[M.e.length-2]=M.v;
+return(_59)(M);};
+
+var _56=function(M){if(--M.cbt<0){throw _56;}
+M.e[M.e.length-2]=M.v;
+return(_54)(M);};
+
+var _37=function(M){if(--M.cbt<0){throw _37;}
+M.e[M.e.length-2]=M.v;
+return(_35)(M);};
+
+var _34=function(M){if(--M.cbt<0){throw _34;}
+M.e[M.e.length-2]=M.v;
+return(_32)(M);};
+
+var _31=function(M){if(--M.cbt<0){throw _31;}
+M.e[M.e.length-1]=M.v;
+M.e.push(void(0),void(0));
+M.e[M.e.length-1]=M.e[M.e.length-5];
+M.e.push(M.e[M.e.length-6]);
+M.p=_7_c;
+M.a=1;
+M.c.push(new RT.CallFrame(_34,M.p));
+return(_7)(M);};
+
+var _29=function(M){if(--M.cbt<0){throw _29;}
+return(_27)(M);};
+
+var _347=function(M){if(--M.cbt<0){throw _347;}
+
+//"lambda body for append-many"
+
+M.v=(M.e[M.e.length-1]===RT.NULL);
+if(M.v===false){return(_355)(M);}else{M.v=RT.NULL;
+M.e.pop();
+M.p=M.c[M.c.length-1].label;
+M.c.pop();
+return(M.p)(M);}};
+
+var _346=function(M){if(--M.cbt<0){throw _346;}
+
+//"lambda body for unknown"
+
+M.unspliceRestFromStack(0,M.a);
+M.e.push(M.e[M.e.length-1]);
+M.p=_347_c;
+M.a=1;
+M.e.splice(M.e.length-2,1);
+M.c[M.c.length-1].p=M.p;
+return(_347)(M);};
+
+var _349=function(M){M.c.push(new RT.CallFrame(_351,M.p)); M.addPrompt(RT.DEFAULT_CONTINUATION_PROMPT_TAG,false,M.e.length);
+M.e.push([]);M.e[M.e.length-1].names=[];
+M.v=_346_c;
+M.a=1;
+M.v=M.v;
+M.e.splice(M.e.length-((M.a-1)+1),1);
+M.p=M.c[M.c.length-1].label;
+M.c.pop();
+return(M.p)(M);};
+
+var _26=function(M){if(--M.cbt<0){throw _26;}
+return(_24)(M);};
+
+var _21=function(M){if(--M.cbt<0){throw _21;}
+return(_19)(M);};
+
+var _297=function(M){M.e.push(void(0),void(0));
+M.e[M.e.length-1]=M.e[M.e.length-4];
+M.e[M.e.length-2]=RT.checkedCdr(M, M.e[M.e.length-5]);
+M.p=M.e[M.e.length-3];
+M.a=2;
+M.e.splice(M.e.length-5,3);
+M.c[M.c.length-1].p=M.p;
+return(_291)(M);};
+
+var _295=function(M){M.e.push(void(0),void(0));
+M.e[M.e.length-1]=M.e[M.e.length-4];
+M.e[M.e.length-2]=(RT.testArgument(M,"caarpair",RT.isCaarPair,M.e[M.e.length-5],0,"caar")).first.first;
+M.v=(M.e[M.e.length-1]===M.e[M.e.length-2]);
+M.e.length-=2;
+if(M.v===false){return(_297)(M);}else{M.v=RT.checkedCar(M, M.e[M.e.length-3]);
+M.e.length-=3;
+M.p=M.c[M.c.length-1].label;
+M.c.pop();
+return(M.p)(M);}};
+
+var _291=function(M){if(--M.cbt<0){throw _291;}
+
+//"lambda body for assq"
+
+M.e.push(M.p.closedVals[0]);
+M.v=(M.e[M.e.length-3]===RT.NULL);
+if(M.v===false){return(_295)(M);}else{M.v=false;
+M.e.length-=3;
+M.p=M.c[M.c.length-1].label;
+M.c.pop();
+return(M.p)(M);}};
+
+var _372=function(M){if(--M.cbt<0){throw _372;}
+M.e.length-=(M.a-1);
+return(_373)(M);};
+
+var _375=function(M){M.p=M.c[M.c.length-1].pendingApplyValuesProc;
+M.c.pop();
+RT.checkClosureAndArity(M);
+M.e.splice(M.e.length-(M.a+2),2);
+M.c[M.c.length-1].p=M.p;
+return((M.p).label)(M);};
+
+var _370=function(M){if(--M.cbt<0){throw _370;}
+
+//"lambda body for unknown"
+
+M.c.push(new RT.Frame());
+M.c[M.c.length-1].pendingApplyValuesProc=M.e[M.e.length-2];
+M.p=M.e[M.e.length-1];
+M.a=0;
+RT.checkClosureAndArity(M);
+M.c.push(new RT.CallFrame(_377,M.p));
+return((M.p).label)(M);};
+
+var _371=function(M){M.c.push(new RT.CallFrame(_373,M.p)); M.addPrompt(RT.DEFAULT_CONTINUATION_PROMPT_TAG,false,M.e.length);
+M.e.push([]);M.e[M.e.length-1].names=[];
+M.v=_370_c;
+M.a=1;
+M.v=M.v;
+M.e.splice(M.e.length-((M.a-1)+1),1);
+M.p=M.c[M.c.length-1].label;
+M.c.pop();
+return(M.p)(M);};
+
+var _378=function(M){if(--M.cbt<0){throw _378;}
+if(M.a===0){return(_375)(M);}else{M.e.push(M.v);
+return(_375)(M);}};
+
+var _70=function(M){if(--M.cbt<0){throw _70;}
+M.e.length-=(M.a-1);
+return(_71)(M);};
+
+var _120=function(M){M.v=RT.makePair(M.e[M.e.length-1],M.e[M.e.length-2]);
+M.e.length-=3;
+M.p=M.c[M.c.length-1].label;
+M.c.pop();
+return(M.p)(M);};
+
+
+var _118=function(M){M.e.push(void(0),void(0));
+M.e.push(void(0));
+M.e[M.e.length-1]=RT.checkedCar(M, M.e[M.e.length-4]);
+M.e[M.e.length-2]=RT.checkedCdr(M, M.e[M.e.length-1]);
+M.e.pop();
+M.e.push(void(0));
+M.e.push(M.e[M.e.length-4]);
+M.v=M.primitives["unsafe-cdr"]._i(M);
+M.e.pop();
+M.e[M.e.length-1]=M.v;
+M.p=_68_c;
+M.a=1;
+M.c.push(new RT.CallFrame(_122,M.p));
+return(_68)(M);};
+
+var _115=function(M){M.v=RT.makePair(M.e[M.e.length-1],M.e[M.e.length-2]);
+M.e.length-=3;
+M.p=M.c[M.c.length-1].label;
+M.c.pop();
+return(M.p)(M);};
+
+
+var _113=function(M){M.e.push(void(0),void(0));
+M.e.push(void(0));
+M.e[M.e.length-1]=RT.checkedCar(M, M.e[M.e.length-4]);
+M.e[M.e.length-2]=RT.checkedCar(M, M.e[M.e.length-1]);
+M.e.pop();
+M.e.push(void(0));
+M.e.push(M.e[M.e.length-4]);
+M.v=M.primitives["unsafe-cdr"]._i(M);
+M.e.pop();
+M.e[M.e.length-1]=M.v;
+M.p=_67_c;
+M.a=1;
+M.c.push(new RT.CallFrame(_117,M.p));
+return(_67)(M);};
+
+var _108=function(M){M.e.push(void(0));
+M.e.push(M.e[M.e.length-2]);
+M.v=M.primitives["unsafe-cdr"]._i(M);
+M.e.pop();
+M.e[M.e.length-1]=M.v;
+M.p=_66_c;
+M.a=1;
+M.e.splice(M.e.length-2,1);
+M.c[M.c.length-1].p=M.p;
+return(_66)(M);};
+
+var _106=function(M){M.e.push(void(0));
+M.e[M.e.length-1]=RT.checkedCar(M, M.e[M.e.length-2]);
+M.v=(M.e[M.e.length-1]===RT.NULL);
+M.e.pop();
+if(M.v===false){return(_108)(M);}else{M.v=true;
+M.e.pop();
+M.p=M.c[M.c.length-1].label;
+M.c.pop();
+return(M.p)(M);}};
+
+var _350=function(M){if(--M.cbt<0){throw _350;}
+M.e.length-=(M.a-1);
+return(_351)(M);};
+
+var _99=function(M){M.e.push(void(0));
+M.e[M.e.length-1]=RT.checkedCar(M, M.e[M.e.length-2]);
+M.v=(M.e[M.e.length-1]===RT.NULL);
+M.e.pop();
+if(M.v===false){return(_101)(M);}else{M.e.push(void(0));
+M.e.push(M.e[M.e.length-2]);
+M.v=M.primitives["unsafe-cdr"]._i(M);
+M.e.pop();
+M.e[M.e.length-1]=M.v;
+M.p=_65_c;
+M.a=1;
+M.e.splice(M.e.length-2,1);
+M.c[M.c.length-1].p=M.p;
+return(_65)(M);}};
+
+
+var _365=function(M){M.e.push(void(0),void(0));
+M.e[M.e.length-1]=RT.checkedCar(M, M.e[M.e.length-3]);
+M.e.push(void(0),void(0));
+M.e.push(M.e[M.e.length-5]);
+M.v=M.primitives["unsafe-cdr"]._i(M);
+M.e.pop();
+M.e[M.e.length-1]=M.v;
+M.e[M.e.length-2]=M.e[M.e.length-6];
+M.p=_348_c;
+M.a=2;
+M.c.push(new RT.CallFrame(_369,M.p));
+return(_348)(M);};
+
+
+var _68=function(M){if(--M.cbt<0){throw _68;}
+
+//"lambda body for rest-lists"
+
+M.v=(M.e[M.e.length-1]===RT.NULL);
+if(M.v===false){return(_118)(M);}else{M.v=RT.NULL;
+M.e.pop();
+M.p=M.c[M.c.length-1].label;
+M.c.pop();
+return(M.p)(M);}};
+
+var _91=function(M){if(--M.cbt<0){throw _91;}
+M.e.length-=(M.a-1);
+return(_92)(M);};
+
+
+var _357=function(M){M.e.push(void(0),void(0));
+M.e.push(M.e[M.e.length-3]);
+M.v=M.primitives["unsafe-car"]._i(M);
+M.e.pop();
+M.e[M.e.length-1]=M.v;
+M.e.push(void(0));
+M.e.push(M.e[M.e.length-4]);
+M.v=M.primitives["unsafe-cdr"]._i(M);
+M.e.pop();
+M.e[M.e.length-1]=M.v;
+M.p=_347_c;
+M.a=1;
+M.c.push(new RT.CallFrame(_361,M.p));
+return(_347)(M);};
+
+var _355=function(M){M.e.push(void(0));
+M.e[M.e.length-1]=RT.checkedCdr(M, M.e[M.e.length-2]);
+M.v=(M.e[M.e.length-1]===RT.NULL);
+M.e.pop();
+if(M.v===false){return(_357)(M);}else{M.e.push(M.e[M.e.length-1]);
+M.v=M.primitives["unsafe-car"]._i(M);
+M.e.length-=2;
+M.p=M.c[M.c.length-1].label;
+M.c.pop();
+return(M.p)(M);}};
+
+var _83=function(M){M.e.push(void(0),void(0));
+M.e[M.e.length-2]=M.primitives["apply"];
+M.e[M.e.length-1]=M.e[M.e.length-3];
+M.e.push(M.e[M.e.length-4]);
+M.p=_67_c;
+M.a=1;
+M.c.push(new RT.CallFrame(_90,M.p));
+return(_67)(M);};
+
+var _85=function(M){if(M.v===false){return(_83)(M);}else{M.v=M.e[M.e.length-2];
+M.v=M.e[M.e.length-1];
+M.e.push(void(0),void(0));
+M.e[M.e.length-1]=sym76;
+M.e[M.e.length-2]="all lists must have the same size";
+M.a=2;
+M.v=M.primitives["error"]._i(M);
+M.e.length-=4;
+M.p=M.c[M.c.length-1].label;
+M.c.pop();
+return(M.p)(M);}};
+
+
+var _66=function(M){if(--M.cbt<0){throw _66;}
+
+//"lambda body for some-empty?"
+
+M.v=(M.e[M.e.length-1]===RT.NULL);
+if(M.v===false){return(_106)(M);}else{M.v=false;
+M.e.pop();
+M.p=M.c[M.c.length-1].label;
+M.c.pop();
+return(M.p)(M);}};
+
+var _78=function(M){M.e.push(M.e[M.e.length-2]);
+M.p=_66_c;
+M.a=1;
+M.c.push(new RT.CallFrame(_87,M.p));
+return(_66)(M);};
+
+var _80=function(M){if(M.v===false){return(_78)(M);}else{M.v=RT.NULL;
+M.e.length-=2;
+M.p=M.c[M.c.length-1].label;
+M.c.pop();
+return(M.p)(M);}};
+
+
+var _65=function(M){if(--M.cbt<0){throw _65;}
+
+//"lambda body for all-empty?"
+
+M.v=(M.e[M.e.length-1]===RT.NULL);
+if(M.v===false){return(_99)(M);}else{M.v=true;
+M.e.pop();
+M.p=M.c[M.c.length-1].label;
+M.c.pop();
+return(M.p)(M);}};
+
+var _64=function(M){if(--M.cbt<0){throw _64;}
+
+//"lambda body for loop"
+
+M.e.push(M.e[M.e.length-2]);
+M.p=_65_c;
+M.a=1;
+M.c.push(new RT.CallFrame(_82,M.p));
+return(_65)(M);};
+
+var _63=function(M){if(--M.cbt<0){throw _63;}
+
+//"lambda body for do-it"
+
+M.e.push(void(0),void(0));
+M.e[M.e.length-1]=M.e[M.e.length-3];
+M.e[M.e.length-2]=M.e[M.e.length-4];
+M.p=_64_c;
+M.a=2;
+M.e.splice(M.e.length-4,2);
+M.c[M.c.length-1].p=M.p;
+return(_64)(M);};
+
+var _62=function(M){if(--M.cbt<0){throw _62;}
+
+//"lambda body for unknown"
+
+M.unspliceRestFromStack(1,(M.a-1));
+M.e.push(void(0),void(0));
+M.e[M.e.length-1]=M.e[M.e.length-3];
+M.e[M.e.length-2]=M.e[M.e.length-4];
+M.p=_63_c;
+M.a=2;
+M.e.splice(M.e.length-4,2);
+M.c[M.c.length-1].p=M.p;
+return(_63)(M);};
+
+var _69=function(M){M.c.push(new RT.CallFrame(_71,M.p)); M.addPrompt(RT.DEFAULT_CONTINUATION_PROMPT_TAG,false,M.e.length);
+M.e.push([]);M.e[M.e.length-1].names=[];
+M.v=_62_c;
+M.a=1;
+M.v=M.v;
+M.e.splice(M.e.length-((M.a-1)+1),1);
+M.p=M.c[M.c.length-1].label;
+M.c.pop();
+return(M.p)(M);};
+
+var _277=function(M){if(--M.cbt<0){throw _277;}
+M.e.length-=(M.a-1);
+return(_278)(M);};
+
+var _281=function(M){M.e.push(void(0),void(0),void(0));
+M.e[M.e.length-1]=M.e[M.e.length-5];
+M.e[M.e.length-2]=M.e[M.e.length-6];
+M.e[M.e.length-3]=RT.checkedCdr(M, M.e[M.e.length-7]);
+M.p=M.e[M.e.length-4];
+M.a=3;
+M.e.splice(M.e.length-7,4);
+M.c[M.c.length-1].p=M.p;
+return(_275)(M);};
+
+
+var _279=function(M){M.e.push(void(0));
+M.p=M.e[M.e.length-4];
+M.e[M.e.length-1]=M.e[M.e.length-3];
+M.a=1;
+RT.checkClosureAndArity(M);
+M.c.push(new RT.CallFrame(_284,M.p));
+return((M.p).label)(M);};
+
+var _275=function(M){if(--M.cbt<0){throw _275;}
+
+//"lambda body for memf"
+
+M.e.push(M.p.closedVals[0]);
+M.v=(M.e[M.e.length-4]===RT.NULL);
+if(M.v===false){return(_279)(M);}else{M.v=false;
+M.e.length-=4;
+M.p=M.c[M.c.length-1].label;
+M.c.pop();
+return(M.p)(M);}};
+
+var _276=function(M){M.c.push(new RT.CallFrame(_278,M.p)); M.addPrompt(RT.DEFAULT_CONTINUATION_PROMPT_TAG,false,M.e.length);
+M.e.push([]);M.e[M.e.length-1].names=[];
+M.e.push(void(0));
+M.e[M.e.length-1]=new RT.Closure(_275,3,void(0),"memf");
+M.e[M.e.length-1].closedVals=[M.e[M.e.length-1]];
+M.v=M.e[M.e.length-1];
+M.a=1;
+M.e.splice(M.e.length-((M.a-1)+1),1);
+M.v=M.v;
+M.e.splice(M.e.length-((M.a-1)+1),1);
+M.p=M.c[M.c.length-1].label;
+M.c.pop();
+return(M.p)(M);};
+
+var _336=function(M){if(--M.cbt<0){throw _336;}
+M.e.length-=(M.a-1);
+return(_337)(M);};
+
+var _140=function(M){M.e.push(void(0),void(0));
+if (M.globals["and"]===void(0)&&M.params.currentNamespace.get("and")===void(0)){ RT.raiseUnboundToplevelError(M,"and"); }
+M.e[M.e.length-2]=(M.globals["and"]!==void(0)?M.globals["and"]:M.params.currentNamespace.get("and"));
+M.e.push(void(0),void(0));
+M.e[M.e.length-2]=M.primitives["apply"];
+M.e[M.e.length-1]=M.e[M.e.length-6];
+M.e.push(M.e[M.e.length-7]);
+M.p=_127_c;
+M.a=1;
+M.c.push(new RT.CallFrame(_147,M.p));
+return(_127)(M);};
+
+var _334=function(M){if(--M.cbt<0){throw _334;}
+
+//"lambda body for length-iter"
+
+M.v=(M.e[M.e.length-1]===RT.NULL);
+if(M.v===false){return(_341)(M);}else{M.v=M.e[M.e.length-2];
+M.e.length-=2;
+M.p=M.c[M.c.length-1].label;
+M.c.pop();
+return(M.p)(M);}};
+
+var _333=function(M){if(--M.cbt<0){throw _333;}
+
+//"lambda body for unknown"
+
+M.e.push(void(0),void(0));
+M.e[M.e.length-1]=M.e[M.e.length-3];
+M.e[M.e.length-2]=0;
+M.p=_334_c;
+M.a=2;
+M.e.splice(M.e.length-3,1);
+M.c[M.c.length-1].p=M.p;
+return(_334)(M);};
+
+var _335=function(M){M.c.push(new RT.CallFrame(_337,M.p)); M.addPrompt(RT.DEFAULT_CONTINUATION_PROMPT_TAG,false,M.e.length);
+M.e.push([]);M.e[M.e.length-1].names=[];
+M.v=_333_c;
+M.a=1;
+M.v=M.v;
+M.e.splice(M.e.length-((M.a-1)+1),1);
+M.p=M.c[M.c.length-1].label;
+M.c.pop();
+return(M.p)(M);};
+
+var _263=function(M){if(--M.cbt<0){throw _263;}
+M.e.length-=(M.a-1);
+return(_264)(M);};
+
+var _267=function(M){M.e.push(void(0),void(0));
+M.e[M.e.length-1]=M.e[M.e.length-4];
+M.e.push(M.e[M.e.length-5]);
+M.v=M.primitives["unsafe-cdr"]._i(M);
+M.e.pop();
+M.e[M.e.length-2]=M.v;
+M.p=M.e[M.e.length-3];
+M.a=2;
+M.e.splice(M.e.length-5,3);
+M.c[M.c.length-1].p=M.p;
+return(_261)(M);};
+
+var _265=function(M){M.e.push(void(0),void(0));
+M.e[M.e.length-1]=M.e[M.e.length-4];
+M.e[M.e.length-2]=RT.checkedCar(M, M.e[M.e.length-5]);
+M.v=M.primitives["eqv?"]._i(M);
+M.e.length-=2;
+if(M.v===false){return(_267)(M);}else{M.v=M.e[M.e.length-3];
+M.e.length-=3;
+M.p=M.c[M.c.length-1].label;
+M.c.pop();
+return(M.p)(M);}};
+
+var _261=function(M){if(--M.cbt<0){throw _261;}
+
+//"lambda body for memv"
+
+M.e.push(M.p.closedVals[0]);
+M.v=(M.e[M.e.length-3]===RT.NULL);
+if(M.v===false){return(_265)(M);}else{M.v=false;
+M.e.length-=3;
+M.p=M.c[M.c.length-1].label;
+M.c.pop();
+return(M.p)(M);}};
+
+var _262=function(M){M.c.push(new RT.CallFrame(_264,M.p)); M.addPrompt(RT.DEFAULT_CONTINUATION_PROMPT_TAG,false,M.e.length);
+M.e.push([]);M.e[M.e.length-1].names=[];
+M.e.push(void(0));
+M.e[M.e.length-1]=new RT.Closure(_261,2,void(0),"memv");
+M.e[M.e.length-1].closedVals=[M.e[M.e.length-1]];
+M.v=M.e[M.e.length-1];
+M.a=1;
+M.e.splice(M.e.length-((M.a-1)+1),1);
+M.v=M.v;
+M.e.splice(M.e.length-((M.a-1)+1),1);
+M.p=M.c[M.c.length-1].label;
+M.c.pop();
+return(M.p)(M);};
+
+var _131=function(M){if(--M.cbt<0){throw _131;}
+M.e.length-=(M.a-1);
+return(_132)(M);};
+
+var _129=function(M){if(--M.cbt<0){throw _129;}
+
+//"lambda body for unknown"
+
+M.unspliceRestFromStack(1,(M.a-1));
+M.e.push(M.p.closedVals[0]);
+M.e.push(void(0),void(0));
+//"Constant toplevel ref: ?"
+
+M.p=M.e[M.e.length-3][2];
+M.e[M.e.length-1]=M.e[M.e.length-4];
+M.e[M.e.length-2]=M.e[M.e.length-5];
+M.a=2;
+RT.checkClosureAndArity(M);
+M.e.splice(M.e.length-5,3);
+M.c[M.c.length-1].p=M.p;
+return((M.p).label)(M);};
+
+var _178=function(M){M.v=RT.makePair(M.e[M.e.length-1],M.e[M.e.length-2]);
+M.e.length-=3;
+M.p=M.c[M.c.length-1].label;
+M.c.pop();
+return(M.p)(M);};
+
+
+var _176=function(M){M.e.push(void(0),void(0));
+M.e.push(void(0));
+M.e[M.e.length-1]=RT.checkedCar(M, M.e[M.e.length-4]);
+M.e[M.e.length-2]=RT.checkedCdr(M, M.e[M.e.length-1]);
+M.e.pop();
+M.e.push(void(0));
+M.e.push(M.e[M.e.length-4]);
+M.v=M.primitives["unsafe-cdr"]._i(M);
+M.e.pop();
+M.e[M.e.length-1]=M.v;
+M.p=_128_c;
+M.a=1;
+M.c.push(new RT.CallFrame(_180,M.p));
+return(_128)(M);};
+
+var _173=function(M){M.v=RT.makePair(M.e[M.e.length-1],M.e[M.e.length-2]);
+M.e.length-=3;
+M.p=M.c[M.c.length-1].label;
+M.c.pop();
+return(M.p)(M);};
+
+
+var _171=function(M){M.e.push(void(0),void(0));
+M.e.push(void(0));
+M.e[M.e.length-1]=RT.checkedCar(M, M.e[M.e.length-4]);
+M.e[M.e.length-2]=RT.checkedCar(M, M.e[M.e.length-1]);
+M.e.pop();
+M.e.push(void(0));
+M.e.push(M.e[M.e.length-4]);
+M.v=M.primitives["unsafe-cdr"]._i(M);
+M.e.pop();
+M.e[M.e.length-1]=M.v;
+M.p=_127_c;
+M.a=1;
+M.c.push(new RT.CallFrame(_175,M.p));
+return(_127)(M);};
+
+var _166=function(M){M.e.push(void(0));
+M.e.push(M.e[M.e.length-2]);
+M.v=M.primitives["unsafe-cdr"]._i(M);
+M.e.pop();
+M.e[M.e.length-1]=M.v;
+M.p=_126_c;
+M.a=1;
+M.e.splice(M.e.length-2,1);
+M.c[M.c.length-1].p=M.p;
+return(_126)(M);};
+
+var _164=function(M){M.e.push(void(0));
+M.e[M.e.length-1]=RT.checkedCar(M, M.e[M.e.length-2]);
+M.v=(M.e[M.e.length-1]===RT.NULL);
+M.e.pop();
+if(M.v===false){return(_166)(M);}else{M.v=true;
+M.e.pop();
+M.p=M.c[M.c.length-1].label;
+M.c.pop();
+return(M.p)(M);}};
+
+var _159=function(M){M.v=false;
+M.e.pop();
+M.p=M.c[M.c.length-1].label;
+M.c.pop();
+return(M.p)(M);};
+
+var _157=function(M){M.e.push(void(0));
+M.e[M.e.length-1]=RT.checkedCar(M, M.e[M.e.length-2]);
+M.v=(M.e[M.e.length-1]===RT.NULL);
+M.e.pop();
+if(M.v===false){return(_159)(M);}else{M.e.push(void(0));
+M.e.push(M.e[M.e.length-2]);
+M.v=M.primitives["unsafe-cdr"]._i(M);
+M.e.pop();
+M.e[M.e.length-1]=M.v;
+M.p=_125_c;
+M.a=1;
+M.e.splice(M.e.length-2,1);
+M.c[M.c.length-1].p=M.p;
+return(_125)(M);}};
+
+
+var _150=function(M){M.p=M.e[M.e.length-2];
+M.e[M.e.length-2]=M.v;
+M.a=2;
+RT.checkClosureAndArity(M);
+M.c.push(new RT.CallFrame(_154,M.p));
+return((M.p).label)(M);};
+
+
+var _128=function(M){if(--M.cbt<0){throw _128;}
+
+//"lambda body for rest-lists"
+
+M.v=(M.e[M.e.length-1]===RT.NULL);
+if(M.v===false){return(_176)(M);}else{M.v=RT.NULL;
+M.e.pop();
+M.p=M.c[M.c.length-1].label;
+M.c.pop();
+return(M.p)(M);}};
+
+
+var _145=function(M){M.p=M.e[M.e.length-2];
+M.e[M.e.length-2]=M.v;
+M.a=2;
+RT.checkClosureAndArity(M);
+M.c.push(new RT.CallFrame(_149,M.p));
+return((M.p).label)(M);};
+
+
+var _127=function(M){if(--M.cbt<0){throw _127;}
+
+//"lambda body for first-tuple"
+
+M.v=(M.e[M.e.length-1]===RT.NULL);
+if(M.v===false){return(_171)(M);}else{M.v=RT.NULL;
+M.e.pop();
+M.p=M.c[M.c.length-1].label;
+M.c.pop();
+return(M.p)(M);}};
+
+var _341=function(M){M.e.push(void(0),void(0));
+M.e[M.e.length-1]=RT.checkedCdr(M, M.e[M.e.length-3]);
+M.e[M.e.length-2]=RT.checkedAdd1(M, M.e[M.e.length-4]);
+M.p=_334_c;
+M.a=2;
+M.e.splice(M.e.length-4,2);
+M.c[M.c.length-1].p=M.p;
+return(_334)(M);};
+
+var _142=function(M){if(M.v===false){return(_140)(M);}else{M.e.push(void(0),void(0));
+M.e[M.e.length-1]=sym77;
+M.e[M.e.length-2]="all lists must have the same size";
+M.a=2;
+M.v=M.primitives["error"]._i(M);
+M.e.length-=5;
+M.p=M.c[M.c.length-1].label;
+M.c.pop();
+return(M.p)(M);}};
+
+
+var _126=function(M){if(--M.cbt<0){throw _126;}
+
+//"lambda body for some-empty?"
+
+M.v=(M.e[M.e.length-1]===RT.NULL);
+if(M.v===false){return(_164)(M);}else{M.v=false;
+M.e.pop();
+M.p=M.c[M.c.length-1].label;
+M.c.pop();
+return(M.p)(M);}};
+
+var _135=function(M){M.e.push(M.e[M.e.length-3]);
+M.p=_126_c;
+M.a=1;
+M.c.push(new RT.CallFrame(_144,M.p));
+return(_126)(M);};
+
+var _137=function(M){if(M.v===false){return(_135)(M);}else{M.v=RT.NULL;
+M.e.length-=3;
+M.p=M.c[M.c.length-1].label;
+M.c.pop();
+return(M.p)(M);}};
+
+
+var _125=function(M){if(--M.cbt<0){throw _125;}
+
+//"lambda body for all-empty?"
+
+M.v=(M.e[M.e.length-1]===RT.NULL);
+if(M.v===false){return(_157)(M);}else{M.v=true;
+M.e.pop();
+M.p=M.c[M.c.length-1].label;
+M.c.pop();
+return(M.p)(M);}};
+
+var _124=function(M){if(--M.cbt<0){throw _124;}
+
+//"lambda body for loop"
+
+M.e.push(M.p.closedVals[0]);
+M.e.push(M.e[M.e.length-3]);
+M.p=_125_c;
+M.a=1;
+M.c.push(new RT.CallFrame(_139,M.p));
+return(_125)(M);};
+
+var _123=function(M){if(--M.cbt<0){throw _123;}
+
+//"lambda body for do-it"
+
+M.e.push(M.p.closedVals[0]);
+M.e.push(void(0),void(0));
+//"Constant toplevel ref: ?"
+
+M.p=M.e[M.e.length-3][1];
+M.e[M.e.length-1]=M.e[M.e.length-4];
+M.e[M.e.length-2]=M.e[M.e.length-5];
+M.a=2;
+RT.checkClosureAndArity(M);
+M.e.splice(M.e.length-5,3);
+M.c[M.c.length-1].p=M.p;
+return((M.p).label)(M);};
+
+var _130=function(M){M.c.push(new RT.CallFrame(_132,M.p)); M.addPrompt(RT.DEFAULT_CONTINUATION_PROMPT_TAG,false,M.e.length);
+M.e.push([M.globals["and"]!==void(0)?M.globals["and"]:M.params.currentNamespace.get("and"),false,false]);M.e[M.e.length-1].names=["and",false,false];
+M.v=new RT.Closure(_123,2,[M.e[M.e.length-1]],"do-it");
+M.e[M.e.length-1][2]=M.v;
+M.v=RT.VOID;
+M.v=new RT.Closure(_124,2,[M.e[M.e.length-1]],"loop");
+M.e[M.e.length-1][1]=M.v;
+M.v=RT.VOID;
+M.v=new RT.Closure(_129,(RT.makeArityAtLeast(1)),[M.e[M.e.length-1]],"unknown");
+M.a=1;
+M.v=M.v;
+M.e.splice(M.e.length-((M.a-1)+1),1);
+M.p=M.c[M.c.length-1].label;
+M.c.pop();
+return(M.p)(M);};
+
+var _249=function(M){if(--M.cbt<0){throw _249;}
+M.e.length-=(M.a-1);
+return(_250)(M);};
+
+var _253=function(M){M.e.push(void(0),void(0));
+M.e[M.e.length-1]=M.e[M.e.length-4];
+M.e.push(M.e[M.e.length-5]);
+M.v=M.primitives["unsafe-cdr"]._i(M);
+M.e.pop();
+M.e[M.e.length-2]=M.v;
+M.p=M.e[M.e.length-3];
+M.a=2;
+M.e.splice(M.e.length-5,3);
+M.c[M.c.length-1].p=M.p;
+return(_247)(M);};
+
+var _251=function(M){M.e.push(void(0),void(0));
+M.e[M.e.length-1]=M.e[M.e.length-4];
+M.e[M.e.length-2]=RT.checkedCar(M, M.e[M.e.length-5]);
+M.v=(M.e[M.e.length-1]===M.e[M.e.length-2]);
+M.e.length-=2;
+if(M.v===false){return(_253)(M);}else{M.v=M.e[M.e.length-3];
+M.e.length-=3;
+M.p=M.c[M.c.length-1].label;
+M.c.pop();
+return(M.p)(M);}};
+
+_10.mvr=_9;
+_92.mvr=_91;
+_71.mvr=_70;
+_132.mvr=_131;
+_192.mvr=_191;
+_246.mvr=_245;
+_250.mvr=_249;
+_264.mvr=_263;
+_278.mvr=_277;
+_294.mvr=_293;
+_308.mvr=_307;
+_322.mvr=_321;
+_337.mvr=_336;
+_351.mvr=_350;
+_377.mvr=_378;
+_373.mvr=_372;
+var sym74=RT.makeSymbol("map");
+var sym75=RT.makeSymbol("ormap");
+var sym77=RT.makeSymbol("andmap");
+var sym76=RT.makeSymbol("for-each");var _188_c=new RT.Closure(_188,1,void(0),"rest-lists");
+var _187_c=new RT.Closure(_187,1,void(0),"first-tuple");
+var _186_c=new RT.Closure(_186,1,void(0),"some-empty?");
+var _128_c=new RT.Closure(_128,1,void(0),"rest-lists");
+var _185_c=new RT.Closure(_185,1,void(0),"all-empty?");
+var _127_c=new RT.Closure(_127,1,void(0),"first-tuple");
+var _334_c=new RT.Closure(_334,2,void(0),"length-iter");
+var _333_c=new RT.Closure(_333,1,void(0),"unknown");
+var _243_c=new RT.Closure(_243,1,void(0),"unknown");
+var _348_c=new RT.Closure(_348,2,void(0),"append-2");
+var _125_c=new RT.Closure(_125,1,void(0),"all-empty?");
+var _68_c=new RT.Closure(_68,1,void(0),"rest-lists");
+var _6_c=new RT.Closure(_6,1,void(0),"first-tuple");
+var _7_c=new RT.Closure(_7,1,void(0),"rest-lists");
+var _346_c=new RT.Closure(_346,(RT.makeArityAtLeast(0)),void(0),"unknown");
+var _5_c=new RT.Closure(_5,1,void(0),"some-empty?");
+var _347_c=new RT.Closure(_347,1,void(0),"append-many");
+var _67_c=new RT.Closure(_67,1,void(0),"first-tuple");
+var _66_c=new RT.Closure(_66,1,void(0),"some-empty?");
+var _4_c=new RT.Closure(_4,1,void(0),"all-empty?");
+var _64_c=new RT.Closure(_64,2,void(0),"loop");
+var _65_c=new RT.Closure(_65,1,void(0),"all-empty?");
+var _2_c=new RT.Closure(_2,2,void(0),"do-it");
+var _389_c=new RT.Closure(_389,(RT.makeArityAtLeast(2)),void(0),"apply");
+var _126_c=new RT.Closure(_126,1,void(0),"some-empty?");
+var _385_c=new RT.Closure(_385,(RT.makeArityAtLeast(0)),void(0),"values");
+var _1_c=new RT.Closure(_1,(RT.makeArityAtLeast(1)),void(0),"unknown");
+var _63_c=new RT.Closure(_63,2,void(0),"do-it");
+var _3_c=new RT.Closure(_3,2,void(0),"loop");
+var _callCCEntry_c=new RT.Closure(_callCCEntry,1,void(0),"call/cc");
+var _370_c=new RT.Closure(_370,2,void(0),"unknown");
+var _62_c=new RT.Closure(_62,(RT.makeArityAtLeast(1)),void(0),"unknown");M.params.currentErrorHandler = fail;
+for (param in params) {
+    if (Object.hasOwnProperty.call(params, param)) {
+        M.params[param] = params[param];
+    }
+}M.c.push(new RT.CallFrame(function(M){ setTimeout(success, 0); },M.p));
+M.trampoline(_392, true); })(M, function() { SUCCESS(); }, FAIL, PARAMS);})(plt.runtime.currentMachine,
+function(){ plt.runtime.setReadyTrue(); },
+function(){},
+{});

--- a/whalesong/parameters.rkt
+++ b/whalesong/parameters.rkt
@@ -88,7 +88,7 @@
 
 
 (: current-report-port (Parameterof Output-Port))
-(define current-report-port (make-parameter (current-output-port)))
+(define current-report-port (make-parameter (current-error-port)))
 
 
 (: current-timing-port (Parameterof Output-Port))

--- a/whalesong/parser/parse-bytecode-5.3.3.7.rkt
+++ b/whalesong/parser/parse-bytecode-5.3.3.7.rkt
@@ -228,6 +228,7 @@
            (make-ModuleLocator (rewrite-path resolved-path-name)
                                (normalize-path resolved-path-name))]
           [else
+           (displayln (list 'wrap-module-name resolved-path-name rewritten-path))
            (error 'wrap-module-name "Unable to resolve module path ~s."
                   resolved-path-name)]))]))
    

--- a/whalesong/scribblings/manual.scrbl
+++ b/whalesong/scribblings/manual.scrbl
@@ -76,11 +76,11 @@ document lives in @url{http://hashcollision.org/whalesong}.}}
        @centered{@smaller{Current commit head is @tt{@git-head}.}})
      "")
 
-
-
 @;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 @section{Introduction}
 @;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+@defmodule[whalesong #:lang]
 
 Whalesong is a compiler from Racket to JavaScript; it takes Racket
 programs and translates them so that they can run stand-alone on a

--- a/whalesong/selfhost/base64.rkt
+++ b/whalesong/selfhost/base64.rkt
@@ -1,0 +1,74 @@
+#lang whalesong
+(require whalesong/lang/for)
+
+; Implements http://en.wikipedia.org/wiki/Base64
+
+(provide base64-encode) ; string -> string
+
+(define (bytes-ref bs i)
+  (define c (string-ref bs i))
+  (char->integer c))
+
+(define (string->bytes s)
+  (for/list ([c (in-string s)])
+    (char->integer c)))
+
+; 
+(define ranges '(["AZ" 0]    ;  0 to 25
+                 ["az" 26]   ; 16 to 51
+                 ["09" 52]   ; 52 to 61
+                 ["++" 62]   ; 62 
+                 ["//" 63])) ; 63
+
+; > (vector-ref base64-digit (char->integer #\A)) 
+; 0
+; > (vector-ref digit-base64 0) 
+; 65 (which is #\A)
+
+(define-values (base64-digit digit-base64)
+  (let ([bd (make-vector 256 #f)] 
+        [db (make-vector 64 #f)]) 
+    (for ([r ranges] #:when #t
+                     [i (in-range (bytes-ref (car r) 0) (add1 (bytes-ref (car r) 1)))]
+                     [n (in-naturals (cadr r))])
+      (vector-set! bd i n)
+      (vector-set! db n i))
+    (values bd db)))
+
+(define (3bytes->24bit a b c)
+  ; convert 3 bytes into  a single 24 bit number
+  (+ (* a 65536) (* b 256) c))
+
+(define (24bit->base64 n)
+  ; convert a 24 bit number into base 64
+  (define a  (remainder n      64))
+  (define n1 (quotient  n      64))
+  (define b  (remainder n1     64))
+  (define n2 (quotient  n1     64))
+  (define c  (remainder n2     64))
+  (define d  (quotient  n2     64))
+  (list d c b a))
+
+(define =byte (bytes-ref "=" 0))
+
+(define (base64-encode s)
+  (define sn (string-length s))
+  (define (encode s)
+    (define n sn)
+    (define ds
+      (for/list ([i (in-range 0 n 3)])
+        (define a (bytes-ref s i))
+        (define b (bytes-ref s (+ i 1)))
+        (define c (bytes-ref s (+ i 2)))
+        (for/list ([digit (24bit->base64 (3bytes->24bit a b c))])
+          (integer->char (vector-ref digit-base64 digit)))))
+    (define padding  (case (remainder sn 3) [(0) 0]   [(1) 2]              [(2) 1]))
+    (define padding= (case (remainder sn 3) [(0) '()] [(1) (list #\= #\=)] [(2) (list #\=)]))
+    (define ds* (apply append ds))
+    (list->string (reverse (append padding= (drop (reverse ds*) padding)))))
+
+  (case (remainder sn 3)
+    [(0) (encode s)]
+    [(1) (encode (string-append s (string (integer->char 0) (integer->char 0))))]
+    [(2) (encode (string-append s (string (integer->char 0))))]))
+

--- a/whalesong/selfhost/compiler/analyzer-structs.rkt
+++ b/whalesong/selfhost/compiler/analyzer-structs.rkt
@@ -1,0 +1,45 @@
+#lang whalesong (require "../selfhost-lang.rkt")
+
+
+(require "arity-structs.rkt"
+         "expression-structs.rkt"
+         "lexical-structs.rkt"
+         "kernel-primitives.rkt"
+         "il-structs.rkt")
+
+
+(provide (all-defined-out))
+
+
+;; Static knowledge about an expression.
+;;
+;; We try to keep at compile time a mapping from environment positions to
+;; statically known things, to generate better code.
+
+
+(define-type CompileTimeEnvironment (Listof CompileTimeEnvironmentEntry))
+
+(define-type CompileTimeEnvironmentEntry 
+  (U '?          ;; no knowledge
+     Prefix      ;; placeholder: necessary since the toplevel lives in the environment too
+     StaticallyKnownLam     ;; The value is a known lam
+     ModuleVariable         ;; The value is a variable from a module
+     PrimitiveKernelValue
+     Const
+     ))
+
+
+(define-struct: StaticallyKnownLam ([name : (U Symbol LamPositionalName)]
+                                    [entry-point : Symbol]
+                                    [arity : Arity]) #:transparent)
+
+
+
+
+
+(define-struct: Analysis ([ht : (HashTable Expression CompileTimeEnvironmentEntry)]))
+
+
+(: empty-analysis (-> Analysis))
+(define (empty-analysis)
+  (make-Analysis (make-hash)))

--- a/whalesong/selfhost/compiler/analyzer.rkt
+++ b/whalesong/selfhost/compiler/analyzer.rkt
@@ -1,0 +1,352 @@
+#lang whalesong (require "../selfhost-lang.rkt")
+
+(require "expression-structs.rkt"
+         "analyzer-structs.rkt"
+         "arity-structs.rkt"
+         "lexical-structs.rkt"
+         "il-structs.rkt"
+         "compiler-structs.rkt"
+         ; racket/list
+         )
+
+(require "compiler-helper.rkt")
+
+
+
+(provide collect-all-lambdas-with-bodies
+         collect-lam-applications
+         extract-static-knowledge
+         ensure-prefix)
+
+;; Holds helper functions we use for different analyses.
+
+;; Given a lambda body, collect all the applications that exist within
+;; it.  We'll use this to determine what procedures can safely be
+;; transformed into primitives.
+(: collect-lam-applications (Lam CompileTimeEnvironment -> (Listof CompileTimeEnvironmentEntry)))
+(define (collect-lam-applications lam cenv)
+  
+  (let loop 
+    ([exp  (Lam-body lam)]  ; : Expression
+     [cenv  cenv]           ; : CompileTimeEnvironment
+     [acc  '()])            ; : (Listof CompileTimeEnvironmentEntry)
+    
+    (cond
+      [(Top? exp)
+       (loop (Top-code exp)
+             (cons (Top-prefix exp) cenv)
+             acc)]
+      
+      [(Module? exp)
+       (loop (Module-code exp)
+             (cons (Module-prefix exp) cenv)
+             acc)]
+      
+      [(Constant? exp)
+       acc]
+      
+      [(LocalRef? exp)
+       acc]
+      
+      [(ToplevelRef? exp)
+       acc]
+      
+      [(ToplevelSet? exp)
+       (loop (ToplevelSet-value exp) cenv acc)]
+      
+      [(Branch? exp)
+       (define acc-1 (loop (Branch-predicate exp) cenv acc))
+       (define acc-2 (loop (Branch-consequent exp) cenv acc-1))
+       (define acc-3 (loop (Branch-alternative exp) cenv acc-2))
+       acc-3]
+      
+      [(Lam? exp)
+       acc]
+      
+      [(CaseLam? exp)
+       acc]
+      
+      [(EmptyClosureReference? exp)
+       acc]
+      
+      [(Seq? exp)
+       (foldl (lambda  (e   ; [e : Expression]
+                        acc ; [acc : (Listof CompileTimeEnvironmentEntry)]
+                        )
+                (loop e cenv acc))
+              acc
+              (Seq-actions exp))]
+      
+      [(Splice? exp)
+       (foldl (lambda  (e   ; [e : Expression]
+                        acc ; [acc : (Listof CompileTimeEnvironmentEntry)]
+                        )
+                (loop e cenv acc))
+              acc
+              (Splice-actions exp))]
+      
+      [(Begin0? exp)
+       (foldl (lambda (e   ; [e : Expression]
+                       acc ; [acc : (Listof CompileTimeEnvironmentEntry)]
+                       )
+                (loop e cenv acc))
+              acc
+              (Begin0-actions exp))]
+      
+      [(App? exp)
+       (define new-cenv
+         (append (build-list (length (App-operands exp)) (lambda (i #;[i : Natural]) '?))
+                 cenv))
+       (foldl (lambda (e #;[e : Expression]
+                         acc #;[acc : (Listof CompileTimeEnvironmentEntry)])
+                (loop e new-cenv acc))
+              (cons (extract-static-knowledge (App-operator exp) new-cenv)
+                    (loop (App-operator exp) new-cenv acc))
+              (App-operands exp))]
+      
+      [(Let1? exp)
+       (define acc-1 (loop (Let1-rhs exp) (cons '? cenv) acc))
+       (define acc-2 (loop (Let1-body exp) 
+                           (cons (extract-static-knowledge (Let1-rhs exp) (cons '? cenv)) 
+                                 cenv)
+                           acc-1))
+       acc-2]
+      
+      [(LetVoid? exp)
+       (loop (LetVoid-body exp) 
+             (append (build-list (LetVoid-count exp) (lambda (i #;[i : Natural]) '?))
+                     cenv)
+             acc)]
+      
+      [(InstallValue? exp)
+       (loop (InstallValue-body exp) cenv acc)]
+      
+      [(BoxEnv? exp)
+       (loop (BoxEnv-body exp) cenv acc)]
+      
+      [(LetRec? exp)
+       (let ([n (length (LetRec-procs exp))])
+         (let ([new-cenv (append (map (lambda (p #;[p : Lam]) 
+                                        (extract-static-knowledge 
+                                         p 
+                                         (append (build-list (length (LetRec-procs exp))
+                                                             (lambda (i #;[i : Natural]) '?))
+                                                 (drop cenv n))))
+                                      (LetRec-procs exp))
+                                 (drop cenv n))])
+           (loop (LetRec-body exp) new-cenv acc)))]
+      
+      [(WithContMark? exp)
+       (define acc-1 (loop (WithContMark-key exp) cenv acc))
+       (define acc-2 (loop (WithContMark-value exp) cenv acc-1))
+       (define acc-3 (loop (WithContMark-body exp) cenv acc-2))
+       acc-3]
+      
+      [(ApplyValues? exp)
+       (define acc-1 (loop (ApplyValues-proc exp) cenv acc))
+       (define acc-2 (loop (ApplyValues-args-expr exp) cenv acc-1))
+       acc-2]
+      
+      [(DefValues? exp)
+       (loop (DefValues-rhs exp) cenv acc)]
+      
+      [(PrimitiveKernelValue? exp)
+       acc]
+      
+      [(VariableReference? exp)
+       (loop (VariableReference-toplevel exp) cenv acc)]
+      
+      [(Require? exp)
+       acc])))
+
+
+
+
+
+(: extract-static-knowledge (Expression CompileTimeEnvironment ->  
+                                        CompileTimeEnvironmentEntry))
+;; Statically determines what we know about the expression, given the compile time environment.
+;; We should do more here eventually, including things like type inference or flow analysis, so that
+;; we can generate better code.
+(define (extract-static-knowledge exp cenv)
+  (cond
+    [(Lam? exp)
+     ;(log-debug "known to be a lambda")
+     (make-StaticallyKnownLam (Lam-name exp)
+                              (Lam-entry-label exp)
+                              (if (Lam-rest? exp)
+                                  (make-ArityAtLeast (Lam-num-parameters exp))
+                                  (Lam-num-parameters exp)))]
+    [(and (LocalRef? exp) 
+          (not (LocalRef-unbox? exp)))
+     (let ([entry (list-ref cenv (LocalRef-depth exp))])
+       ;(log-debug (format "known to be ~s" entry))
+       entry)]
+    
+    [(EmptyClosureReference? exp)
+     (make-StaticallyKnownLam (EmptyClosureReference-name exp)
+                              (EmptyClosureReference-entry-label exp)
+                              (if (EmptyClosureReference-rest? exp)
+                                  (make-ArityAtLeast (EmptyClosureReference-num-parameters exp))
+                                  (EmptyClosureReference-num-parameters exp)))]
+    [(ToplevelRef? exp)
+     ;(log-debug (format "toplevel reference of ~a" exp))
+     ;(when (ToplevelRef-constant? exp)
+     ;  (log-debug (format "toplevel reference ~a should be known constant" exp)))
+     (let ([name ; : (U Symbol False GlobalBucket ModuleVariable)
+            (list-ref (Prefix-names (ensure-prefix (list-ref cenv (ToplevelRef-depth exp))))
+                      (ToplevelRef-pos exp))])
+       (cond
+         [(ModuleVariable? name)
+          ;(log-debug (format "toplevel reference is to ~s" name))
+          name]
+         [(GlobalBucket? name)
+          '?]
+         [else
+          ;(log-debug (format "nothing statically known about ~s" exp))
+          '?]))]
+    
+    [(Constant? exp)
+     (make-Const (ensure-const-value (Constant-v exp)))]
+    
+    [(PrimitiveKernelValue? exp)
+     exp]
+    
+    [else
+     ;(log-debug (format "nothing statically known about ~s" exp))
+     '?]))
+
+
+
+
+
+
+
+
+
+(: collect-all-lambdas-with-bodies (Expression -> (Listof lam+cenv)))
+;; Finds all the lambdas in the expression.
+(define (collect-all-lambdas-with-bodies exp)
+  (let loop      ; : (Listof lam+cenv)
+    ([exp  exp]  ; : Expression
+     [cenv '()]) ; : CompileTimeEnvironment
+    
+    (cond
+      [(Top? exp)
+       (loop (Top-code exp) (cons (Top-prefix exp) cenv))]
+      [(Module? exp)
+       (loop (Module-code exp) (cons (Module-prefix exp) cenv))]
+      [(Constant? exp)
+       '()]
+      [(LocalRef? exp)
+       '()]
+      [(ToplevelRef? exp)
+       '()]
+      [(ToplevelSet? exp)
+       (loop (ToplevelSet-value exp) cenv)]
+      [(Branch? exp)
+       (append (loop (Branch-predicate exp) cenv)
+               (loop (Branch-consequent exp) cenv)
+               (loop (Branch-alternative exp) cenv))]
+      [(Lam? exp)
+       (cons (make-lam+cenv exp (extract-lambda-cenv exp cenv))
+             (loop (Lam-body exp) 
+                   (extract-lambda-cenv exp cenv)))]
+      [(CaseLam? exp)
+       (cons (make-lam+cenv exp cenv)
+             (apply append (map (lambda (lam #;[lam : (U Lam EmptyClosureReference)])
+                                  (loop lam cenv))
+                                (CaseLam-clauses exp))))]
+      
+      [(EmptyClosureReference? exp)
+       '()]
+      
+      [(Seq? exp)
+       (apply append (map (lambda (e #;[e : Expression]) (loop e cenv))
+                          (Seq-actions exp)))]
+      [(Splice? exp)
+       (apply append (map (lambda (e #;[e : Expression]) (loop e cenv))
+                          (Splice-actions exp)))]
+      [(Begin0? exp)
+       (apply append (map (lambda (e #;[e : Expression]) (loop e cenv))
+                          (Begin0-actions exp)))]
+      [(App? exp)
+       (let ([new-cenv (append (build-list (length (App-operands exp)) (lambda (i #;[i : Natural]) '?))
+                               cenv)])
+         (append (loop (App-operator exp) new-cenv)
+                 (apply append (map (lambda (e #;[e : Expression]) (loop e new-cenv)) (App-operands exp)))))]
+      [(Let1? exp)
+       (append (loop (Let1-rhs exp)
+                     (cons '? cenv))
+               (loop (Let1-body exp) 
+                     (cons (extract-static-knowledge (Let1-rhs exp) (cons '? cenv)) 
+                           cenv)))]
+      [(LetVoid? exp)
+       (loop (LetVoid-body exp) 
+             (append (build-list (LetVoid-count exp) (lambda (i #;[i : Natural]) '?))
+                     cenv))]
+      [(InstallValue? exp)
+       (loop (InstallValue-body exp) cenv)]
+      [(BoxEnv? exp)
+       (loop (BoxEnv-body exp) cenv)]
+      [(LetRec? exp)
+       (let ([n (length (LetRec-procs exp))])
+         (let ([new-cenv (append (map (lambda (p #;[p : Lam]) 
+                                        (extract-static-knowledge 
+                                         p 
+                                         (append (build-list (length (LetRec-procs exp))
+                                                             (lambda (i #;[i : Natural]) '?))
+                                                 (drop cenv n))))
+                                      (LetRec-procs exp))
+                                 (drop cenv n))])
+           (append (apply append 
+                          (map (lambda (lam #;[lam : Lam])
+                                 (loop lam new-cenv))
+                               (LetRec-procs exp)))
+                   (loop (LetRec-body exp) new-cenv))))]
+      [(WithContMark? exp)
+       (append (loop (WithContMark-key exp) cenv)
+               (loop (WithContMark-value exp) cenv)
+               (loop (WithContMark-body exp) cenv))]
+      [(ApplyValues? exp)
+       (append (loop (ApplyValues-proc exp) cenv)
+               (loop (ApplyValues-args-expr exp) cenv))]
+      [(DefValues? exp)
+       (append (loop (DefValues-rhs exp) cenv))]
+      [(PrimitiveKernelValue? exp)
+       '()]
+      [(VariableReference? exp)
+       (loop (VariableReference-toplevel exp) cenv)]
+      [(Require? exp)
+       '()]
+      [else (error 'here (list exp cenv))]
+      )))
+
+
+
+(: extract-lambda-cenv (Lam CompileTimeEnvironment -> CompileTimeEnvironment))
+;; Given a Lam and the ambient environment, produces the compile time environment for the
+;; body of the lambda.
+(define (extract-lambda-cenv lam cenv)
+  (append (map (lambda (d #;[d : Natural])
+                 (list-ref cenv d))
+               (Lam-closure-map lam))
+          (build-list (if (Lam-rest? lam)
+                          (add1 (Lam-num-parameters lam))
+                          (Lam-num-parameters lam))
+                      (lambda (i #;[i : Natural]) '?))))
+
+
+
+
+
+
+
+
+
+
+(: ensure-prefix (CompileTimeEnvironmentEntry -> Prefix))
+(define (ensure-prefix x)
+  (if (Prefix? x)
+      x
+      (error 'ensure-prefix "Not a prefix: ~s" x)))

--- a/whalesong/selfhost/compiler/arity-structs.rkt
+++ b/whalesong/selfhost/compiler/arity-structs.rkt
@@ -1,0 +1,13 @@
+#lang whalesong (require "../selfhost-lang.rkt")
+(provide (all-defined-out))
+
+;; Arity
+(define-type Arity (U AtomicArity (Listof (U AtomicArity))))
+(define-type AtomicArity (U Natural ArityAtLeast))
+(define-struct ArityAtLeast (value) #:transparent)
+; (define-predicate AtomicArity? AtomicArity)
+(define (AtomicArity? o) (or (natural? o) (ArityAtLeast? o)))
+; (define-predicate listof-atomic-arity? (Listof AtomicArity))
+(define (listof-atomic-arity? o)
+  (and (list? o) (andmap AtomicArity? o)))
+

--- a/whalesong/selfhost/compiler/bootstrapped-primitives.rkt
+++ b/whalesong/selfhost/compiler/bootstrapped-primitives.rkt
@@ -1,0 +1,346 @@
+#lang typed/racket/base
+(require "arity-structs.rkt"
+         "expression-structs.rkt"
+         "lexical-structs.rkt"
+         "il-structs.rkt"
+         (except-in "compiler.rkt" compile)
+         "compiler-structs.rkt")
+
+(require (rename-in "compiler.rkt"
+                     [compile whalesong-compile]))
+
+
+
+(require/typed "../parameters.rkt"
+               (current-defined-name (Parameterof (U Symbol LamPositionalName))))
+(require/typed "../parser/parse-bytecode.rkt"
+               (parse-bytecode (Compiled-Expression -> Expression)))
+
+
+
+(provide get-bootstrapping-code)
+
+
+
+
+
+
+
+;; The primitive code necessary to do call/cc
+
+(: call/cc-label Symbol)
+(define call/cc-label 'callCCEntry)
+(define call/cc-closure-entry 'callCCClosureEntry)
+
+
+;; (call/cc f)
+;; Tail-calls f, providing it a special object that knows how to do the low-level
+;; manipulation of the environment and control stack.
+(define (make-call/cc-code)
+  (statements
+   (append-instruction-sequences
+    call/cc-label
+    ;; Precondition: the environment holds the f function that we want to jump into.
+    
+    ;; First, move f to the proc register
+    (make-AssignImmediate 'proc (make-EnvLexicalReference 0 #f))
+    
+    ;; Next, capture the envrionment and the current continuation closure,.
+    (make-PushEnvironment 2 #f)
+    (make-AssignPrimOp (make-EnvLexicalReference 0 #f) 
+                                (make-CaptureControl 0 default-continuation-prompt-tag))
+    (make-AssignPrimOp (make-EnvLexicalReference 1 #f)
+                                ;; When capturing, skip over f and the two slots we just added.
+                                (make-CaptureEnvironment 3 default-continuation-prompt-tag))
+    (make-AssignPrimOp (make-EnvLexicalReference 2 #f)
+                                 (make-MakeCompiledProcedure call/cc-closure-entry
+                                                             1 ;; the continuation consumes a single value
+                                                             (list 0 1)
+                                                             'call/cc))
+    (make-PopEnvironment (make-Const 2) 
+                          (make-Const 0))
+       
+    ;; Finally, do a tail call into f.
+    (make-AssignImmediate 'argcount (make-Const 1))
+    (compile-general-procedure-call '()
+                                    (make-Const 1) ;; the stack at this point holds a single argument
+                                    'val
+                                    return-linkage)
+    
+    ;; The code for the continuation code follows.  It's supposed to
+    ;; abandon the current continuation, initialize the control and environment, and then jump.
+    call/cc-closure-entry
+    (make-AssignImmediate 'val (make-EnvLexicalReference 0 #f))
+    (make-Perform (make-InstallClosureValues! 2))
+    (make-Perform (make-RestoreControl! default-continuation-prompt-tag))
+    (make-Perform (make-RestoreEnvironment!))
+    (make-AssignImmediate 'proc (make-ControlStackLabel))
+    (make-PopControlFrame)
+    (make-Goto (make-Reg 'proc)))))
+
+
+
+(: make-bootstrapped-primitive-code (Symbol Any -> (Listof Statement)))
+;; Generates the bootstrapped code for some of the primitives.  Note: the source must compile
+;; under #%kernel, or else!
+(define make-bootstrapped-primitive-code
+  (let ([ns (make-base-empty-namespace)])
+    (parameterize ([current-namespace ns]) (namespace-require ''#%kernel))
+    (lambda (name src)
+      (parameterize ([current-defined-name name])
+        (append
+         (whalesong-compile (parameterize ([current-namespace ns])
+                              (parse-bytecode (compile src)))
+                            (make-PrimitivesReference name) next-linkage/drop-multiple))))))
+
+
+
+
+(: make-map-src (Symbol Symbol -> Any))
+;; Generates the code for map.
+(define (make-map-src name combiner)
+  `(letrec-values ([(first-tuple) (lambda (lists)
+                                   (if (null? lists)
+                                       '()
+                                       (cons (car (car lists))
+                                             (first-tuple (cdr lists)))))]
+                  [(rest-lists) (lambda (lists)
+                                  (if (null? lists)
+                                      '()
+                                      (cons (cdr (car lists))
+                                            (rest-lists (cdr lists)))))]
+                  [(all-empty?) (lambda (lists)
+                                  (if (null? lists)
+                                      #t
+                                      (if (null? (car lists))
+                                          (all-empty? (cdr lists))
+                                          #f)))]
+                  [(some-empty?) (lambda (lists)
+                                   (if (null? lists)
+                                       #f
+                                       (if (null? (car lists))
+                                           #t
+                                           
+                                           (some-empty? (cdr lists)))))]
+                  [(do-it) (lambda (f lists)
+                             (letrec-values ([(loop) (lambda (lists)
+                                                       (if (all-empty? lists)
+                                                           null
+                                                           (if (some-empty? lists)
+                                                               (error 
+                                                                ',name 
+                                                                "all lists must have the same size")
+                                                               (,combiner (apply f (first-tuple lists))
+                                                                          (loop (rest-lists lists))))))])
+                                            (loop lists)))])
+                 (lambda (f . args)
+                   (do-it f args))))
+
+
+
+
+
+
+(: get-bootstrapping-code (-> (Listof Statement)))
+(define (get-bootstrapping-code)
+  
+  (append
+
+   
+   ;; Other primitives
+   (make-bootstrapped-primitive-code 
+    'map 
+    (make-map-src 'map 'cons))
+
+   (make-bootstrapped-primitive-code
+    'for-each
+    (make-map-src 'for-each 'begin))
+
+   (make-bootstrapped-primitive-code
+    'andmap
+    (make-map-src 'andmap 'and))
+
+   (make-bootstrapped-primitive-code
+    'ormap
+    (make-map-src 'ormap 'or))
+
+   
+   
+   (make-bootstrapped-primitive-code
+    'caar
+    '(lambda (x)
+       (car (car x))))
+
+
+   (make-bootstrapped-primitive-code
+    'memq
+    '(letrec-values ([(memq) (lambda (x l)
+                               (if (null? l)
+                                   #f
+                                   (if (eq? x (car l))
+                                       l
+                                       (memq x (cdr l)))))])
+                    memq))
+   (make-bootstrapped-primitive-code
+    'memv
+    '(letrec-values ([(memv) (lambda (x l)
+                               (if (null? l)
+                                   #f
+                                   (if (eqv? x (car l))
+                                       l
+                                       (memv x (cdr l)))))])
+                    memv))
+   
+   (make-bootstrapped-primitive-code
+    'memf
+    '(letrec-values ([(memf) (lambda (x f l)
+                               (if (null? l)
+                                   #f
+                                   (if (f x)
+                                       l
+                                       (memf x f (cdr l)))))])
+                    memf))
+   
+   (make-bootstrapped-primitive-code
+    'assq
+    '(letrec-values ([(assq) (lambda (x l)
+                               (if (null? l)
+                                   #f
+                                   (if (eq? x (caar l))
+                                       (car l)
+                                       (assq x (cdr l)))))])
+                    assq))
+   (make-bootstrapped-primitive-code
+    'assv
+    '(letrec-values ([(assv) (lambda (x l)
+                               (if (null? l)
+                                   #f
+                                   (if (eqv? x (caar l))
+                                       (car l)
+                                       (assv x (cdr l)))))])
+                    assv))
+   (make-bootstrapped-primitive-code
+    'assoc
+    '(letrec-values ([(assoc) (lambda (x l)
+                               (if (null? l)
+                                   #f
+                                   (if (equal? x (caar l))
+                                       (car l)
+                                       (assoc x (cdr l)))))])
+                    assoc))   
+   (make-bootstrapped-primitive-code
+    'length
+    '(letrec-values ([(length-iter) (lambda (l i)
+                                      (if (null? l)
+                                          i
+                                          (length-iter (cdr l) (add1 i))))])
+                    (lambda (l) (length-iter l 0))))
+   
+
+   (make-bootstrapped-primitive-code
+    'append
+    '(letrec-values ([(append-many) (lambda (lsts)
+                                      (if (null? lsts)
+                                          null
+                                          (if (null? (cdr lsts))
+                                              (car lsts)
+                                              (append-2 (car lsts)
+                                                        (append-many (cdr lsts))))))]
+                     [(append-2) (lambda (l1 l2)
+                                   (if (null? l1) 
+                                       l2
+                                       (cons (car l1) (append-2 (cdr l1) l2))))])
+                    (lambda args (append-many args))))
+
+
+   (make-bootstrapped-primitive-code
+    'call-with-values
+    '(lambda (producer consumer)
+       (call-with-values (lambda () (producer)) consumer)))
+      
+   
+   
+   ;; The call/cc code is special:
+   (let ([after-call/cc-code (make-label 'afterCallCCImplementation)])
+     (append 
+
+      `(,(make-AssignPrimOp (make-PrimitivesReference 'call/cc) 
+                                     (make-MakeCompiledProcedure call/cc-label 1 '() 'call/cc))
+        ,(make-AssignPrimOp (make-PrimitivesReference 'call-with-current-continuation) 
+                                     (make-MakeCompiledProcedure call/cc-label 1 '() 'call/cc))
+        ,(make-Goto (make-Label after-call/cc-code)))
+      (make-call/cc-code)
+      `(,after-call/cc-code)))
+   
+  
+   
+   ;; values
+   ;; values simply keeps all (but the first) value on the stack, preserves the argcount, and does a return
+   ;; to the multiple-value-return address.
+   (let ([after-values-body-defn (make-label 'afterValues)]
+         [values-entry (make-label 'valuesEntry)]
+         [on-zero-values (make-label 'onZeroValues)]
+         [on-single-value (make-label 'onSingleValue)])
+     `(,(make-Goto (make-Label after-values-body-defn))
+       ,values-entry
+       ,(make-TestAndJump (make-TestOne (make-Reg 'argcount)) on-single-value)
+       ,(make-TestAndJump (make-TestZero (make-Reg 'argcount)) on-zero-values)
+
+       ;; Common case: we're running multiple values.  Put the first in the val register
+       ;; and go to the multiple value return.
+       ,(make-AssignImmediate 'val (make-EnvLexicalReference 0 #f))
+       ,(make-PopEnvironment (make-Const 1) (make-Const 0))
+       ,(make-AssignImmediate 'proc (make-ControlStackLabel/MultipleValueReturn))
+       ,(make-PopControlFrame)
+       ,(make-Goto (make-Reg 'proc))
+
+       ;; Special case: on a single value, just use the regular return address
+       ,on-single-value
+       ,(make-AssignImmediate 'val (make-EnvLexicalReference 0 #f))
+       ,(make-PopEnvironment (make-Const 1) (make-Const 0))
+       ,(make-AssignImmediate 'proc (make-ControlStackLabel))
+       ,(make-PopControlFrame)
+       ,(make-Goto (make-Reg 'proc))
+
+       ;; On zero values, leave things be and just return.
+       ,on-zero-values
+       ,(make-AssignImmediate 'proc (make-ControlStackLabel/MultipleValueReturn))
+       ,(make-PopControlFrame)
+       ,(make-Goto (make-Reg 'proc))
+       
+       ,after-values-body-defn
+       ,(make-AssignPrimOp (make-PrimitivesReference 'values)
+                                    (make-MakeCompiledProcedure values-entry
+                                                                (make-ArityAtLeast 0) 
+                                                                '() 
+                                                                'values))))
+   
+   
+   
+   
+   ;; As is apply:
+   (let ([after-apply-code (make-label 'afterApplyCode)]
+         [apply-entry (make-label 'applyEntry)])
+     `(,(make-Goto (make-Label after-apply-code))
+       ,apply-entry
+       
+       ;; Push the procedure into proc.
+       ,(make-AssignImmediate 'proc (make-EnvLexicalReference 0 #f))
+       ,(make-PopEnvironment (make-Const 1) (make-Const 0))
+       ;; Correct the number of arguments to be passed.
+       ,(make-AssignImmediate 'argcount (make-SubtractArg (make-Reg 'argcount)
+                                                                   (make-Const 1)))
+       ;; Splice in the list argument.
+       ,(make-Perform (make-SpliceListIntoStack! (make-SubtractArg (make-Reg 'argcount)
+                                                                            (make-Const 1))))
+       
+       ;; Finally, jump into the procedure body
+       ,@(statements (compile-general-procedure-call '()
+                                                     (make-Reg 'argcount) ;; the stack contains only the argcount elements.
+                                                     'val
+                                                     return-linkage))
+       
+       
+       ,after-apply-code
+       ,(make-AssignPrimOp (make-PrimitivesReference 'apply)
+                                    (make-MakeCompiledProcedure apply-entry (make-ArityAtLeast 2) '() 'apply))))))

--- a/whalesong/selfhost/compiler/compiler-helper.rkt
+++ b/whalesong/selfhost/compiler/compiler-helper.rkt
@@ -1,0 +1,38 @@
+#lang whalesong (require "../selfhost-lang.rkt")
+
+(provide ensure-const-value)
+
+(define (ensure-const-value x)
+  (cond
+   [(symbol? x)
+    x]
+   [(boolean? x)
+    x]
+   [(string? x)
+    x]
+   [(number? x)
+    x]
+   [(void? x)
+    x]
+   [(null? x)
+    x]
+   [(char? x)
+    x]
+   [(bytes? x)
+    x]
+   [(path? x)
+    x]
+   [(pair? x)
+    (begin (ensure-const-value (car x))
+           (ensure-const-value (cdr x))
+           x)]
+   [(vector? x)
+    (begin (for-each ensure-const-value (vector->list x)))
+    x]
+   [(box? x)
+    (ensure-const-value (unbox x))
+    x]
+   [else
+    (error 'ensure-const-value "Not a const value: ~s\n" x)]))
+         
+    

--- a/whalesong/selfhost/compiler/compiler-structs.rkt
+++ b/whalesong/selfhost/compiler/compiler-structs.rkt
@@ -1,0 +1,47 @@
+#lang whalesong (require "../selfhost-lang.rkt")
+(require "expression-structs.rkt"
+         "analyzer-structs.rkt")
+
+
+(provide (all-defined-out))
+
+
+;; A ValuesContext describes if a context either
+;;    * accepts any number multiple values by dropping them from the stack.
+;;    * accepts any number of multiple values by maintaining them on the stack.
+;;    * accepts exactly n values, erroring out
+(define-type ValuesContext (U 'tail
+                              'drop-multiple 
+                              'keep-multiple
+			      Natural))
+
+
+;; Linkage
+(define-struct: NextLinkage ([context : ValuesContext]))
+(define next-linkage/drop-multiple (make-NextLinkage 'drop-multiple))
+(define next-linkage/expects-single (make-NextLinkage 1))
+(define next-linkage/keep-multiple-on-stack (make-NextLinkage 'keep-multiple))
+
+
+
+;; LabelLinkage is a labeled GOTO.
+(define-struct: LabelLinkage ([label : Symbol]
+			      [context : ValuesContext]))
+
+
+
+;; Both ReturnLinkage and ReturnLinkage/NonTail deal with multiple
+;; values indirectly, through the alternative multiple-value-return
+;; address in the LinkedLabel of their call frame.
+(define-struct: ReturnLinkage ([tail? : Boolean]))
+(define return-linkage (make-ReturnLinkage #t))
+(define return-linkage/nontail (make-ReturnLinkage #f))
+
+(define-type Linkage (U NextLinkage
+                        LabelLinkage
+                        ReturnLinkage))
+
+
+;; Lambda and compile-time environment
+(define-struct: lam+cenv ([lam : (U Lam CaseLam)]
+                          [cenv : CompileTimeEnvironment]))

--- a/whalesong/selfhost/compiler/compiler.rkt
+++ b/whalesong/selfhost/compiler/compiler.rkt
@@ -1,0 +1,2392 @@
+#lang whalesong (require "../selfhost-lang.rkt")
+
+(require "arity-structs.rkt"
+         "expression-structs.rkt"
+         "lexical-structs.rkt"
+         "il-structs.rkt"
+         "compiler-structs.rkt"
+         "kernel-primitives.rkt"
+         "optimize-il.rkt"
+         "analyzer-structs.rkt"
+         "../parameters.rkt"
+         "../sets.rkt"
+         "analyzer.rkt"
+         ; racket/list
+         ; racket/match
+         )
+
+; (require/typed "../logger.rkt" [log-debug (String -> Void)])
+
+(require "compiler-helper.rkt")
+
+
+; (require/typed "../parser/modprovide.rkt" [get-provided-names (Expression -> (Listof ModuleProvide))])
+(require (only-in "../parser/modprovide.rkt" get-provided-names))
+
+
+(provide (rename-out [-compile compile]
+                     [compile raw-compile])
+         compile-for-repl
+         compile-general-procedure-call)
+
+
+;; We keep track of which lambda is currently being compiled for potential optimizations
+;; e.g. self tail calls.
+(: current-lambda-being-compiled (Parameterof (U #f Lam)))
+(define current-lambda-being-compiled (make-parameter #f))
+
+
+
+
+(: -compile (Expression Target Linkage -> (Listof Statement)))
+;; Generates the instruction-sequence stream.
+;; Note: the toplevel generates the lambda body streams at the head, and then the
+;; rest of the instruction stream.
+(define (-compile exp target linkage)
+  (define lambda-bodies (collect-all-lambdas-with-bodies exp))
+  (define after-lam-bodies (make-label 'afterLamBodies))
+  (define-values (before-pop-prompt-multiple before-pop-prompt)
+    (new-linked-labels 'beforePopPrompt))
+  (optimize-il
+   (statements
+    (append-instruction-sequences 
+     
+     ;; Layout the lambda bodies...
+     (make-Goto (make-Label after-lam-bodies))
+     (compile-lambda-bodies lambda-bodies)
+     after-lam-bodies
+     
+     ;; Begin a prompted evaluation:
+     (make-PushControlFrame/Prompt default-continuation-prompt-tag
+                                   before-pop-prompt)
+     (compile exp '() 'val return-linkage/nontail)
+     before-pop-prompt-multiple
+     (make-PopEnvironment (make-SubtractArg (make-Reg 'argcount) (make-Const 1))
+                          (make-Const 0))
+     before-pop-prompt
+     (if (eq? target 'val)
+         empty-instruction-sequence
+         (make-AssignImmediate target (make-Reg 'val)))))))
+
+
+;; Compiles an expression for the REPL.
+;; The result of the repl evaluation will be a list in the var register.
+(: compile-for-repl (Expression -> (Listof Statement)))
+(define (compile-for-repl exp)
+  (define lambda-bodies (collect-all-lambdas-with-bodies exp))
+  (define after-lam-bodies: (make-label 'afterLamBodies))
+  (define bundle-values-into-list: (make-label 'bundleValuesIntoList))
+  (define abort-with-multiple-values: (make-label 'abortWithMultipleValues))
+  (define last: (make-label 'last))
+  (define-values (handle-multiple-return: handle-return:)
+    (new-linked-labels 'afterPopPrompt))
+  
+  (optimize-il
+   (statements
+    (append-instruction-sequences
+     ;; Layout the lambda bodies...
+     (make-Goto (make-Label after-lam-bodies:))
+     (compile-lambda-bodies lambda-bodies)
+     
+     after-lam-bodies:
+     
+     ;; Begin a prompted evaluation:
+     (make-PushControlFrame/Prompt default-continuation-prompt-tag
+                                   handle-return:)
+     (compile exp '() 'val return-linkage/nontail)
+     
+     handle-multiple-return:
+     ;; After coming back from the evaluation, rearrange the return
+     ;; values, to call the continuation with those as arguments.
+     (make-TestAndJump (make-TestZero (make-Reg 'argcount)) 
+                       bundle-values-into-list:)
+     handle-return:
+     (make-PushImmediateOntoEnvironment (make-Reg 'val) #f)     
+     bundle-values-into-list:
+     (make-Goto (make-Label last:))
+     
+     last:
+     ;; Finally, return to the success continuation on the stack.
+     (make-AssignImmediate 'proc (make-ControlStackLabel))
+     (make-PopControlFrame)
+     (make-Goto (make-Reg 'proc))))))
+
+
+
+
+
+
+(: end-with-linkage (Linkage CompileTimeEnvironment InstructionSequence -> InstructionSequence))
+;; Add linkage for expressions.
+(define (end-with-linkage linkage cenv instruction-sequence)
+  (append-instruction-sequences instruction-sequence
+                                (compile-linkage cenv linkage)))
+
+
+
+
+(: compile-linkage (CompileTimeEnvironment Linkage -> InstructionSequence))
+;; Generates the code necessary to drive the rest of the computation (represented as the linkage).
+(define (compile-linkage cenv linkage)
+  (cond
+    [(ReturnLinkage? linkage)
+     (cond
+       [(ReturnLinkage-tail? linkage)
+        ;; Under tail calls, clear the environment of the current stack frame (represented by cenv)
+        ;; and do the jump.
+        (append-instruction-sequences
+         (make-PopEnvironment (make-Const (length cenv)) 
+                              (make-Const 0))
+         (make-AssignImmediate 'proc (make-ControlStackLabel))
+         (make-PopControlFrame)
+         (make-Goto (make-Reg 'proc)))]
+       [else
+        ;; Under non-tail calls, leave the stack as is and just do the jump.
+        (append-instruction-sequences
+         (make-AssignImmediate 'proc (make-ControlStackLabel))
+         (make-PopControlFrame)
+         (make-Goto (make-Reg 'proc)))])]
+    
+    [(NextLinkage? linkage)
+     empty-instruction-sequence]
+    
+    [(LabelLinkage? linkage)
+     (make-Goto (make-Label (LabelLinkage-label linkage)))]))
+
+
+
+
+
+
+(: compile (Expression CompileTimeEnvironment Target Linkage -> InstructionSequence))
+;; The main dispatching function for compilation.
+;; Compiles an expression into an instruction sequence.
+(define (compile exp cenv target linkage)
+  (cond
+    [(Top? exp)
+     (compile-top exp cenv target linkage)]
+    [(Module? exp)
+     (compile-module exp cenv target linkage)]
+    [(Constant? exp)
+     (compile-constant exp cenv target linkage)]
+    [(LocalRef? exp)
+     (compile-local-reference exp cenv target linkage)]
+    [(ToplevelRef? exp)
+     (compile-toplevel-reference exp cenv target linkage)]
+    [(ToplevelSet? exp)
+     (compile-toplevel-set exp cenv target linkage)]
+    [(Branch? exp)
+     (compile-branch exp cenv target linkage)]
+    [(Lam? exp)
+     (compile-lambda exp cenv target linkage)]
+    [(CaseLam? exp)
+     (compile-case-lambda exp cenv target linkage)]
+    [(EmptyClosureReference? exp)
+     (compile-empty-closure-reference exp cenv target linkage)]
+    [(Seq? exp)
+     (compile-sequence (Seq-actions exp)
+                       cenv
+                       target
+                       linkage)]
+    [(Splice? exp)
+     (compile-splice (Splice-actions exp)
+                     cenv
+                     target
+                     linkage)]
+    [(Begin0? exp)
+     (compile-begin0 (Begin0-actions exp)
+                     cenv
+                     target
+                     linkage)]
+    [(App? exp)
+     (compile-application exp cenv target linkage)]
+    [(Let1? exp)
+     (compile-let1 exp cenv target linkage)]
+    [(LetVoid? exp)
+     (compile-let-void exp cenv target linkage)]
+    [(InstallValue? exp)
+     (compile-install-value exp cenv target linkage)]
+    [(BoxEnv? exp)
+     (compile-box-environment-value exp cenv target linkage)]
+    [(LetRec? exp)
+     (compile-let-rec exp cenv target linkage)]
+    [(WithContMark? exp)
+     (compile-with-cont-mark exp cenv target linkage)]
+    [(ApplyValues? exp)
+     (compile-apply-values exp cenv target linkage)]
+    [(DefValues? exp)
+     (compile-def-values exp cenv target linkage)]
+    [(PrimitiveKernelValue? exp)
+     (compile-primitive-kernel-value exp cenv target linkage)]
+    [(VariableReference? exp)
+     (compile-variable-reference exp cenv target linkage)]
+    [(Require? exp)
+     (compile-require exp cenv target linkage)]))
+
+
+
+
+(: compile-top (Top CompileTimeEnvironment Target Linkage -> InstructionSequence))
+;; Generates code to write out the top prefix, evaluate the rest of the body,
+;; and then pop the top prefix off afterwards.
+(define (compile-top top cenv target linkage)
+  (let* ([names (Prefix-names (Top-prefix top))]) ;:(Listof (U False Symbol GlobalBucket ModuleVariable))
+    (end-with-linkage 
+     linkage cenv
+     (append-instruction-sequences
+      (make-Perform (make-ExtendEnvironment/Prefix! names))
+      (compile (Top-code top) 
+               (cons (Top-prefix top) cenv)
+               'val
+               next-linkage/keep-multiple-on-stack)
+      (make-AssignImmediate target (make-Reg 'val))
+      (make-PopEnvironment (make-Const 1) 
+                           (new-SubtractArg (make-Reg 'argcount)
+                                            (make-Const 1)))))))
+
+
+
+
+
+(: compile-module (Module CompileTimeEnvironment Target Linkage -> InstructionSequence))
+;; Generates code to write out the top prefix, evaluate the rest of the body,
+;; and then pop the top prefix off.
+(define (compile-module mod cenv target linkage)
+  (unless (Module? mod) (error 'compile-module "expected Module?"))
+  (define name (Module-name mod))
+  (define path (Module-path mod))
+  (define prefix (Module-prefix mod))
+  (define requires (Module-requires mod))
+  (define provides (Module-provides mod))
+  (define code (Module-code mod))
+  ; (match mod [(struct Module (name path prefix requires provides code))
+     (let* ([after-module-body (make-label 'afterModuleBody)]
+            [module-entry (make-label 'module-entry)]
+            [names (Prefix-names prefix)] ; : (Listof (U False Symbol GlobalBucket ModuleVariable))
+            [module-cenv (list prefix)])  ; : CompileTimeEnvironment
+       
+       (end-with-linkage 
+        linkage cenv
+        (append-instruction-sequences
+         (make-Perform (make-InstallModuleEntry! name path module-entry))
+         (make-Goto (make-Label after-module-body))
+         
+         
+         module-entry
+         (make-Perform (make-MarkModuleInvoked! path))
+         ;; Module body definition:
+         ;; 1.  First invoke all the modules that this requires.
+         (apply append-instruction-sequences
+           (map compile-module-invoke (Module-requires mod)))
+         
+         ;; 2.  Store the prefix:
+         (make-Perform (make-ExtendEnvironment/Prefix! names))
+         (make-AssignImmediate (make-ModulePrefixTarget path)
+                               (make-EnvWholePrefixReference 0))
+         ;; 3.  Next, evaluate the module body.
+         (compile (Module-code mod) 
+                  (cons (Module-prefix mod) module-cenv)
+                  'val
+                  next-linkage/drop-multiple)
+         
+         ;; 4. Finally, cleanup and return.
+         (make-PopEnvironment (make-Const 1) (make-Const 0))
+         (make-AssignImmediate 'proc (make-ControlStackLabel))
+         (make-PopControlFrame)
+         
+         ;; We sequester the prefix of the module with the record.
+         (make-Perform (make-FinalizeModuleInvokation! path provides))
+         (make-Goto (make-Reg 'proc))
+         
+         after-module-body))))
+
+(: compile-require (Require CompileTimeEnvironment Target Linkage -> InstructionSequence))
+(define (compile-require exp cenv target linkage)
+  (end-with-linkage linkage cenv
+                    (append-instruction-sequences
+                     (compile-module-invoke (Require-path exp))
+                     (make-AssignImmediate target (make-Const (void))))))
+
+
+(: compile-module-invoke (ModuleLocator -> InstructionSequence))
+;; Generates code that will invoke a module (if it hasn't been invoked
+;; yet) FIXME: assumes the module has already been loaded/linked.  We
+;; should try to load the module, or error out if the module can't be
+;; found.
+(define (compile-module-invoke a-module-name)
+  (cond
+    [(kernel-module-name? a-module-name)
+     empty-instruction-sequence]
+    [else
+     (define linked (make-label 'linked))
+     (define-values (on-return-multiple on-return) (new-linked-labels 'onReturn))
+     (append-instruction-sequences
+      (make-TestAndJump (make-TestTrue (make-ModulePredicate a-module-name 'linked?))
+                        linked)
+      ;; TODO: try to link dynamically, using plt.runtime.currentModuleLoader.
+      (make-Perform (make-LinkModule! a-module-name linked))
+      ;; If that fails, finally raise an exception here that says that the module hasn't been
+      ;; linked yet.
+      ;(make-DebugPrint (make-Const 
+      ;                    (format "DEBUG: the module ~a hasn't been linked in!!!"
+      ;                            (ModuleLocator-name a-module-name))))
+      ;(make-Goto (make-Label (LinkedLabel-label on-return)))
+      linked
+      (make-TestAndJump (make-TestTrue 
+                         (make-ModulePredicate a-module-name 'invoked?))
+                        (LinkedLabel-label on-return))
+      (make-PushControlFrame/Call on-return)
+      (make-Goto (ModuleEntry a-module-name))
+      on-return-multiple
+      (make-PopEnvironment (new-SubtractArg (make-Reg 'argcount)
+                                            (make-Const 1))
+                           (make-Const 0))
+      on-return)]))
+
+
+
+
+
+
+(: emit-singular-context (Linkage -> InstructionSequence))
+;; Emits code specific to a construct that's guaranteed to produce a single value.
+;;
+;; This does two things:
+;;
+;; 1.  The emitted code raises a runtime error if the linkage requires 
+;; multiple values will be produced, since there's no way to produce them.
+;;
+;; 2. In the case where the context is 'keep-multiple, it will also indicate a single
+;; value by assigning to the argcount register.
+(define (emit-singular-context linkage)
+  (cond [(ReturnLinkage? linkage)
+         ;; Callers who use ReturnLinkage are responsible for doing
+         ;; runtime checks for the singular context.
+         empty-instruction-sequence]
+        [(or (NextLinkage? linkage)
+             (LabelLinkage? linkage))
+         (let ([context (linkage-context linkage)])
+           (cond
+             [(eq? context 'tail)
+              empty-instruction-sequence]
+             
+             [(eq? context 'drop-multiple)
+              empty-instruction-sequence]
+             
+             [(eq? context 'keep-multiple)
+              (make-AssignImmediate 'argcount (make-Const 1))]
+             
+             [(natural? context)
+              (if (= context 1)
+                  empty-instruction-sequence
+                  (append-instruction-sequences
+                   (make-AssignImmediate 'argcount (make-Const 1))
+                   (make-Perform (make-RaiseContextExpectedValuesError!
+                                  context))))]))]))
+
+
+
+(: compile-constant (Constant CompileTimeEnvironment Target Linkage -> InstructionSequence))
+;; Generates output for constant values.
+(define (compile-constant exp cenv target linkage)
+  (let ([singular-context-check (emit-singular-context linkage)])
+    ;; Compiles constant values.
+    (end-with-linkage linkage
+                      cenv
+                      (append-instruction-sequences
+                       (make-AssignImmediate target (make-Const
+                                                     (ensure-const-value (Constant-v exp))))
+                       singular-context-check))))
+
+
+(: compile-variable-reference (VariableReference CompileTimeEnvironment Target Linkage -> InstructionSequence))
+(define (compile-variable-reference exp cenv target linkage)
+  (let ([singular-context-check (emit-singular-context linkage)])
+    ;; Compiles constant values.
+    (end-with-linkage linkage
+                      cenv
+                      (append-instruction-sequences
+                       (make-AssignImmediate target exp)
+                       singular-context-check))))
+
+
+(: compile-local-reference (LocalRef CompileTimeEnvironment Target Linkage -> InstructionSequence))
+;; Compiles local variable references.
+(define (compile-local-reference exp cenv target linkage)
+  (let ([singular-context-check (emit-singular-context linkage)])
+    (end-with-linkage linkage
+                      cenv
+                      (append-instruction-sequences
+                       (make-AssignImmediate target
+                                             (make-EnvLexicalReference (LocalRef-depth exp)
+                                                                       (LocalRef-unbox? exp)))
+                       singular-context-check))))
+
+
+(: compile-toplevel-reference (ToplevelRef CompileTimeEnvironment Target Linkage -> InstructionSequence))
+;; Compiles toplevel references.
+(define (compile-toplevel-reference exp cenv target linkage)
+  (define prefix (ensure-prefix (list-ref cenv (ToplevelRef-depth exp))))
+  (define prefix-element (list-ref (Prefix-names prefix) (ToplevelRef-pos exp)))
+  (let ([singular-context-check (emit-singular-context linkage)])
+    (end-with-linkage linkage
+                      cenv
+                      (append-instruction-sequences
+                       
+                       ;; If it's a module variable, we need to look there.
+                       (cond
+                         [(ModuleVariable? prefix-element)
+                          (cond [(kernel-module-name? (ModuleVariable-module-name prefix-element))
+                                 (make-AssignPrimOp target
+                                                    (make-PrimitivesReference
+                                                     (kernel-module-variable->primitive-name
+                                                      prefix-element)))]
+                                [else
+                                 (make-AssignImmediate
+                                  target
+                                  (make-EnvPrefixReference (ToplevelRef-depth exp)
+                                                           (ToplevelRef-pos exp)
+                                                           #t))])]
+                         [(GlobalBucket? prefix-element)
+                          (append-instruction-sequences
+                           (if (ToplevelRef-check-defined? exp)
+                               (make-Perform (make-CheckGlobalBound! (GlobalBucket-name prefix-element)))
+                               empty-instruction-sequence)
+                           (make-AssignPrimOp
+                            target
+                            (make-GlobalsReference (GlobalBucket-name prefix-element))))]
+                         [(or (eq? prefix-element #f) (symbol? prefix-element))
+                          (append-instruction-sequences
+                           (if (ToplevelRef-check-defined? exp)
+                               (make-Perform (make-CheckToplevelBound!
+                                              (ToplevelRef-depth exp)
+                                              (ToplevelRef-pos exp)))
+                               empty-instruction-sequence)
+                           (if (ToplevelRef-constant? exp)
+                               (make-Comment (format "Constant toplevel ref: ~s"
+                                                     (extract-static-knowledge exp cenv)))
+                               empty-instruction-sequence)
+                           (make-AssignImmediate
+                            target
+                            (make-EnvPrefixReference (ToplevelRef-depth exp)
+                                                     (ToplevelRef-pos exp)
+                                                     #f)))])
+                       singular-context-check))))
+
+
+
+
+
+
+(: compile-toplevel-set (ToplevelSet CompileTimeEnvironment Target Linkage -> InstructionSequence))
+;; Compiles a toplevel mutation.
+(define (compile-toplevel-set exp cenv target linkage)
+  (define prefix (ensure-prefix (list-ref cenv (ToplevelSet-depth exp))))
+  (define prefix-element (list-ref (Prefix-names prefix) (ToplevelSet-pos exp)))
+  
+  (define top-target
+    (cond
+      [(ModuleVariable? prefix-element)
+       (make-EnvPrefixReference (ToplevelSet-depth exp)
+                                (ToplevelSet-pos exp)
+                                #t)]
+      [(GlobalBucket? prefix-element)
+       (make-GlobalsReference (GlobalBucket-name prefix-element))]
+      
+      [(or (eq? prefix-element #f)
+           (symbol? prefix-element))
+       (make-EnvPrefixReference (ToplevelSet-depth exp)
+                                (ToplevelSet-pos exp)
+                                #f)]))
+  (let ([get-value-code
+         (cond
+           ;; Special case: when set!-ing globals, see that they're defined first.
+           [(GlobalBucket? prefix-element)
+            (append-instruction-sequences
+             (compile (ToplevelSet-value exp) cenv 'val next-linkage/expects-single)
+             (make-Perform (make-CheckGlobalBound! (GlobalBucket-name prefix-element)))
+             (make-AssignImmediate top-target (make-Reg 'val)))]
+           [else
+            (compile (ToplevelSet-value exp) cenv top-target next-linkage/expects-single)])]
+        [singular-context-check (emit-singular-context linkage)])
+    (end-with-linkage
+     linkage
+     cenv
+     (append-instruction-sequences
+      get-value-code
+      (make-AssignImmediate target (make-Const (void)))
+      singular-context-check))))
+
+
+(: compile-branch (Branch CompileTimeEnvironment Target Linkage -> InstructionSequence))
+;; Compiles a conditional branch.
+(define (compile-branch exp cenv target linkage)
+  (let ([f-branch: (make-label 'falseBranch)]  ; : Symbol 
+        [after-if: (make-label 'afterIf)])     ; : Symbol
+    (let ([consequent-linkage
+           (cond
+             [(NextLinkage? linkage)
+              (let ([context (NextLinkage-context linkage)])
+                (make-LabelLinkage after-if: context))]
+             [(ReturnLinkage? linkage)
+              linkage]
+             [(LabelLinkage? linkage)
+              linkage])])
+      (let ([p-code (compile (Branch-predicate exp) cenv 'val next-linkage/expects-single)]
+            [c-code (compile (Branch-consequent exp) cenv target consequent-linkage)]
+            [a-code (compile (Branch-alternative exp) cenv target linkage)])
+        (append-instruction-sequences 
+         p-code
+         (make-TestAndJump (make-TestFalse (make-Reg 'val))
+                           f-branch:)
+         c-code
+         f-branch: a-code
+         (if (NextLinkage? linkage)
+             after-if:
+             empty-instruction-sequence))))))
+
+
+(: compile-sequence ((Listof Expression) CompileTimeEnvironment Target Linkage -> InstructionSequence))
+;; Compiles a sequence of expressions.  The last expression will be compiled in the provided linkage.
+(define (compile-sequence seq cenv target linkage) 
+  ;; All but the last will use next-linkage linkage.
+  (cond [(empty? seq)
+         (end-with-linkage linkage cenv empty-instruction-sequence)]
+        [(empty? (rest seq))
+         (compile (first seq) cenv target linkage)]
+        [else
+         (append-instruction-sequences 
+          (compile (first seq) cenv 'val next-linkage/drop-multiple)
+          (compile-sequence (rest seq) cenv target linkage))]))
+
+
+
+(: compile-splice ((Listof Expression) CompileTimeEnvironment Target Linkage -> InstructionSequence))
+;; Compiles a sequence of expressions.  A continuation prompt wraps around each of the expressions
+;; to delimit any continuation captures.
+(define (compile-splice seq cenv target linkage)
+  (cond [(empty? seq)
+         (end-with-linkage linkage cenv empty-instruction-sequence)]
+        [(empty? (rest seq))
+         (define-values (on-return/multiple on-return)
+           (new-linked-labels 'beforePromptPop))
+         (end-with-linkage 
+          linkage
+          cenv
+          (append-instruction-sequences 
+           (make-PushControlFrame/Prompt default-continuation-prompt-tag
+                                         on-return)
+           (compile (first seq) cenv 'val return-linkage/nontail)
+           (emit-values-context-check-on-procedure-return (linkage-context linkage)
+                                                          on-return/multiple
+                                                          on-return)
+           (make-AssignImmediate target (make-Reg 'val))))]
+        [else
+         (define-values (on-return/multiple on-return)
+           (new-linked-labels 'beforePromptPop))
+         (append-instruction-sequences 
+          (make-PushControlFrame/Prompt (make-DefaultContinuationPromptTag)
+                                        on-return)
+          
+          (compile (first seq) cenv 'val return-linkage/nontail)
+          on-return/multiple
+          (make-PopEnvironment (new-SubtractArg (make-Reg 'argcount)
+                                                (make-Const 1))
+                               (make-Const 0))
+          on-return
+          (compile-splice (rest seq) cenv target linkage))]))
+
+
+(: compile-begin0 ((Listof Expression) CompileTimeEnvironment Target Linkage -> InstructionSequence))
+(define (compile-begin0 seq cenv target linkage)
+  (cond
+    [(empty? seq)
+     (end-with-linkage linkage cenv empty-instruction-sequence)]
+    [(empty? (rest seq))
+     (compile (first seq) cenv target linkage)]
+    [else
+     (let ([evaluate-and-save-first-expression
+            (let ([after-first-seq (make-label 'afterFirstSeqEvaluated)])
+              (append-instruction-sequences
+               ;; Evaluate the first expression in a multiple-value context, and get the values on the stack.
+               (compile (first seq) cenv 'val next-linkage/keep-multiple-on-stack)
+               
+               (make-TestAndJump (make-TestZero (make-Reg 'argcount)) after-first-seq)
+               (make-PushImmediateOntoEnvironment (make-Reg 'val) #f)
+               after-first-seq
+               ;; At this time, the argcount values are on the stack.
+               ;; Next, we save those values temporarily in a throwaway control frame.
+               (make-PushControlFrame/Generic)
+               (make-AssignImmediate (make-ControlFrameTemporary 'pendingBegin0Count)
+                                     (make-Reg 'argcount))
+               (make-Perform (make-UnspliceRestFromStack! (make-Const 0) (make-Reg 'argcount)))
+               (make-AssignImmediate (make-ControlFrameTemporary 'pendingBegin0Values)
+                                     (make-EnvLexicalReference 0 #f))
+               (make-PopEnvironment (make-Const 1) (make-Const 0))))]
+           
+           [reinstate-values-on-stack
+            (let ([after-values-reinstated (make-label 'afterValuesReinstated)])
+              (append-instruction-sequences
+               ;; Reinstate the values of the first expression, and drop the throwaway control frame.
+               (make-PushImmediateOntoEnvironment (make-ControlFrameTemporary 'pendingBegin0Values) #f)
+               (make-Perform (make-SpliceListIntoStack! (make-Const 0)))
+               (make-AssignImmediate 'argcount (make-ControlFrameTemporary 'pendingBegin0Count))
+               (make-PopControlFrame)
+               (make-TestAndJump (make-TestZero (make-Reg 'argcount)) after-values-reinstated)
+               (make-AssignImmediate 'val (make-EnvLexicalReference 0 #f))
+               (make-PopEnvironment (make-Const 1) (make-Const 0))
+               after-values-reinstated))])
+       
+       (append-instruction-sequences
+        evaluate-and-save-first-expression        
+        
+        (compile-sequence (rest seq) cenv 'val next-linkage/drop-multiple)
+        
+        reinstate-values-on-stack        
+        
+        (make-AssignImmediate target (make-Reg 'val))
+        
+        ;; TODO: context needs check for arguments.
+        (cond
+          [(ReturnLinkage? linkage)
+           (cond
+             [(ReturnLinkage-tail? linkage)
+              (append-instruction-sequences 
+               (make-PopEnvironment (make-Const (length cenv)) 
+                                    (new-SubtractArg (make-Reg 'argcount)
+                                                     (make-Const 1)))
+               (make-AssignImmediate 'proc (make-ControlStackLabel/MultipleValueReturn))
+               (make-PopControlFrame)
+               (make-Goto (make-Reg 'proc)))]
+             [else
+              (append-instruction-sequences
+               (make-AssignImmediate 'proc (make-ControlStackLabel/MultipleValueReturn))
+               (make-PopControlFrame)
+               (make-Goto (make-Reg 'proc)))])]
+          
+          [(NextLinkage? linkage)
+           empty-instruction-sequence]
+          
+          [(LabelLinkage? linkage)
+           (make-Goto (make-Label (LabelLinkage-label linkage)))])))]))
+
+
+
+
+(: compile-lambda (Lam CompileTimeEnvironment Target Linkage -> InstructionSequence))
+;; Write out code for lambda expressions.
+;; The lambda will close over the free variables.
+;; Assumption: all of the lambda bodies have already been written out at the top, in -compile.
+(define (compile-lambda exp cenv target linkage) 
+  (let ([singular-context-check (emit-singular-context linkage)])
+    (end-with-linkage 
+     linkage
+     cenv
+     (append-instruction-sequences
+      (make-AssignPrimOp 
+       target
+       (make-MakeCompiledProcedure (Lam-entry-label exp)
+                                   (Lam-arity exp)
+                                   (Lam-closure-map exp)
+                                   (Lam-name exp)))
+      singular-context-check))))
+
+(: compile-empty-closure-reference (EmptyClosureReference CompileTimeEnvironment Target Linkage -> InstructionSequence))
+(define (compile-empty-closure-reference exp cenv target linkage)
+  (let ([singular-context-check (emit-singular-context linkage)])
+    (end-with-linkage
+     linkage
+     cenv
+     (append-instruction-sequences      
+      (make-AssignPrimOp 
+       target
+       (make-MakeCompiledProcedure (EmptyClosureReference-entry-label exp)
+                                   (EmptyClosureReference-arity exp)
+                                   empty
+                                   (EmptyClosureReference-name exp)))
+      singular-context-check))))
+
+
+
+
+(: compile-case-lambda (CaseLam CompileTimeEnvironment Target Linkage -> InstructionSequence))
+;; Similar to compile-lambda.
+(define (compile-case-lambda exp cenv target linkage)
+  (let ([singular-context-check (emit-singular-context linkage)]
+        [n (length (CaseLam-clauses exp))])
+    
+    ;; We have to build all the lambda values, and then create a single CaseLam that holds onto
+    ;; all of them.
+    (end-with-linkage 
+     linkage
+     cenv
+     (append-instruction-sequences
+      ;; Make some temporary space for the lambdas
+      
+      (make-PushEnvironment n #f)
+      
+      ;; Compile each of the lambdas
+      (apply append-instruction-sequences
+        (map (lambda (lam target) #;([lam : (U Lam EmptyClosureReference)]
+                                     [target : Target])
+               (make-AssignPrimOp
+                target
+                (cond
+                  [(Lam? lam)
+                   (make-MakeCompiledProcedure (Lam-entry-label lam)
+                                               (Lam-arity lam)
+                                               (shift-closure-map (Lam-closure-map lam) n)
+                                               (Lam-name lam))]
+                  [(EmptyClosureReference? lam)
+                   (make-MakeCompiledProcedure (EmptyClosureReference-entry-label lam)
+                                               (EmptyClosureReference-arity lam)
+                                               '()
+                                               (EmptyClosureReference-name lam))])))
+             (CaseLam-clauses exp)
+             (build-list (length (CaseLam-clauses exp))
+                         (lambda (i) ;  ([i : Natural])
+                           (make-EnvLexicalReference i #f)))))
+      
+      ;; Make the case lambda as a regular compiled procedure.  Its closed values are the lambdas.
+      (make-AssignPrimOp 
+       (adjust-target-depth target n)
+       (make-MakeCompiledProcedure (CaseLam-entry-label exp)
+                                   (merge-arities (map Lam-arity (CaseLam-clauses exp)))
+                                   (build-list n (lambda (i) #;([i : Natural]) i))
+                                   (CaseLam-name exp)))
+      
+      ;; Finally, pop off the scratch space.
+      (make-PopEnvironment (make-Const n) (make-Const 0))
+      singular-context-check))))
+
+
+(: Lam-arity ((U Lam EmptyClosureReference) -> Arity))
+(define (Lam-arity lam)
+  (cond
+    [(Lam? lam)
+     (if (Lam-rest? lam)
+         (make-ArityAtLeast (Lam-num-parameters lam))
+         (Lam-num-parameters lam))]
+    [(EmptyClosureReference? lam)
+     (if (EmptyClosureReference-rest? lam)
+         (make-ArityAtLeast (EmptyClosureReference-num-parameters lam))
+         (EmptyClosureReference-num-parameters lam))]))
+
+
+(: EmptyClosureReference-arity (EmptyClosureReference -> Arity))
+(define (EmptyClosureReference-arity lam)
+  (if (EmptyClosureReference-rest? lam)
+      (make-ArityAtLeast (EmptyClosureReference-num-parameters lam))
+      (EmptyClosureReference-num-parameters lam)))
+
+
+
+
+(: shift-closure-map ((Listof Natural) Natural -> (Listof Natural)))
+(define (shift-closure-map closure-map n)
+  (map (lambda (i) #;([i : Natural]) (+ i n))
+       closure-map))
+
+
+(: merge-arities ((Listof Arity) -> Arity))
+(define (merge-arities arities)
+  (cond [(empty? (rest arities))
+         (first arities)]
+        [else
+         (let ([first-arity (first arities)]
+               [merged-rest (merge-arities (rest arities))])
+           (cond
+             [(AtomicArity? first-arity)
+              (cond [(AtomicArity? merged-rest)
+                     (list first-arity merged-rest)]
+                    [(listof-atomic-arity? merged-rest)
+                     (cons first-arity merged-rest)])]
+             [(listof-atomic-arity? first-arity)
+              (cond [(AtomicArity? merged-rest)
+                     (append first-arity (list merged-rest))]
+                    [(listof-atomic-arity? merged-rest)
+                     (append first-arity merged-rest)])]))]))
+
+
+
+(: compile-lambda-shell (Lam CompileTimeEnvironment Target Linkage -> InstructionSequence))
+;; Write out code for lambda expressions, minus the closure map.
+;; Assumption: all of the lambda bodies have already been written out at the top, in -compile.
+(define (compile-lambda-shell exp cenv target linkage) 
+  (let ([singular-context-check (emit-singular-context linkage)])
+    (end-with-linkage 
+     linkage
+     cenv
+     (append-instruction-sequences
+      (make-AssignPrimOp 
+       target
+       (make-MakeCompiledProcedureShell (Lam-entry-label exp)
+                                        (if (Lam-rest? exp)
+                                            (make-ArityAtLeast (Lam-num-parameters exp))
+                                            (Lam-num-parameters exp))
+                                        (Lam-name exp)))
+      singular-context-check))))
+
+
+
+
+
+(: compile-lambda-body (Lam CompileTimeEnvironment -> InstructionSequence))
+;; Compiles the body of the lambda in the appropriate environment.
+;; Closures will target their value to the 'val register, and use return linkage.
+(define (compile-lambda-body exp cenv)
+  (parameterize ([current-lambda-being-compiled exp])
+    ;; (define all-applications (collect-lam-applications exp cenv))
+    
+    (let ([maybe-unsplice-rest-argument ; : InstructionSequence
+           (if (Lam-rest? exp)
+               (make-Perform 
+                (make-UnspliceRestFromStack! 
+                 (make-Const (Lam-num-parameters exp))
+                 (new-SubtractArg (make-Reg 'argcount)
+                                  (make-Const (Lam-num-parameters exp)))))
+               empty-instruction-sequence)]
+          [maybe-install-closure-values ; : InstructionSequence
+           (if (not (empty? (Lam-closure-map exp)))
+               (append-instruction-sequences
+                (make-Perform (make-InstallClosureValues!
+                               (length (Lam-closure-map exp)))))
+               empty-instruction-sequence)]
+          [lam-body-code ; : InstructionSequence
+           (compile (Lam-body exp)
+                    cenv
+                    'val
+                    return-linkage)])
+      
+      (append-instruction-sequences      
+       (Lam-entry-label exp)
+       (make-MarkEntryPoint (Lam-entry-label exp))
+       (Comment (format "lambda body for ~a" (Lam-name exp)))
+       maybe-unsplice-rest-argument
+       maybe-install-closure-values
+       lam-body-code))))
+
+
+(: compile-case-lambda-body (CaseLam CompileTimeEnvironment -> InstructionSequence))
+(define (compile-case-lambda-body exp cenv)
+  (append-instruction-sequences
+   
+   (CaseLam-entry-label exp)
+   
+   (apply append-instruction-sequences
+     (map (lambda (lam i) #;([lam : (U Lam EmptyClosureReference)]
+                             [i : Natural])
+            (let ([not-match (make-label 'notMatch)])
+              (append-instruction-sequences
+               (make-TestAndJump (make-TestClosureArityMismatch
+                                  (make-CompiledProcedureClosureReference 
+                                   (make-Reg 'proc) 
+                                   i)
+                                  (make-Reg 'argcount))
+                                 not-match)
+               ;; Set the procedure register to the lam
+               (make-AssignImmediate 
+                'proc 
+                (make-CompiledProcedureClosureReference (make-Reg 'proc) i))
+               
+               (make-Goto (make-Label
+                           (cond [(Lam? lam)
+                                  (Lam-entry-label lam)]
+                                 [(EmptyClosureReference? lam)
+                                  (EmptyClosureReference-entry-label lam)])))
+               
+               not-match)))
+          (CaseLam-clauses exp)
+          (build-list (length (CaseLam-clauses exp)) (lambda (i) #;([i : Natural]) i))))))
+
+
+(: compile-lambda-bodies ((Listof lam+cenv) -> InstructionSequence))
+;; Compile several lambda bodies, back to back.
+(define (compile-lambda-bodies exps)
+  (cond
+    [(empty? exps)
+     empty-instruction-sequence]
+    [else
+     (let ([lam (lam+cenv-lam (first exps))]    ; : (U Lam CaseLam)
+           [cenv (lam+cenv-cenv (first exps))]) ; : CompileTimeEnvironment
+       (cond
+         [(Lam? lam)
+          (append-instruction-sequences (compile-lambda-body lam cenv)
+                                        (compile-lambda-bodies (rest exps)))]
+         [(CaseLam? lam)
+          (append-instruction-sequences 
+           (compile-case-lambda-body lam cenv)
+           (compile-lambda-bodies (rest exps)))]))]))
+
+
+
+
+(: extend-compile-time-environment/scratch-space (CompileTimeEnvironment Natural -> CompileTimeEnvironment))
+(define (extend-compile-time-environment/scratch-space cenv n)
+  (append (build-list n (lambda (i) #;([i : Natural])
+                          '?))
+          cenv))
+
+
+
+(: compile-application (App CompileTimeEnvironment Target Linkage -> InstructionSequence))
+;; Compiles procedure application
+;; Special cases: if we know something about the operator, the compiler will special case.
+;; This includes:
+;;     Known closure
+;;     Known kernel primitive
+;;  In the general case, we do general procedure application.
+(define (compile-application exp cenv target linkage) 
+  (let ([extended-cenv 
+         (extend-compile-time-environment/scratch-space 
+          cenv 
+          (length (App-operands exp)))])
+    
+    (define (default)
+      (compile-general-application exp cenv target linkage))
+    
+    (let ([op-knowledge ; : CompileTimeEnvironmentEntry
+           (extract-static-knowledge (App-operator exp)
+                                     extended-cenv)])
+      (cond
+        [(eq? op-knowledge '?)
+         (default)]
+        [(operator-is-statically-known-identifier? op-knowledge)
+         => 
+         (lambda (id)
+           (cond
+             [(KernelPrimitiveName/Inline? id)
+              (compile-open-codeable-application id exp cenv target linkage)]
+             [((current-primitive-identifier?) id)
+              => (lambda (expected-arity)
+                   (compile-primitive-application exp cenv target linkage id expected-arity))]
+             [else
+              (default)]))]
+        [(StaticallyKnownLam? op-knowledge)
+         (compile-statically-known-lam-application op-knowledge exp cenv target linkage)]
+        [(Prefix? op-knowledge)
+         (error 'impossible)]
+        [(Const? op-knowledge)
+         (append-instruction-sequences
+          (make-AssignImmediate 'proc op-knowledge)
+          (make-Perform
+           (make-RaiseOperatorApplicationError! (make-Reg 'proc))))]
+        [else
+         (default)]))))
+
+
+(: operator-is-statically-known-identifier? (CompileTimeEnvironmentEntry -> (U False Symbol)))
+(define (operator-is-statically-known-identifier? op-knowledge)
+  (cond [(PrimitiveKernelValue? op-knowledge)
+         (let ([id (PrimitiveKernelValue-id op-knowledge)])
+           id)]
+        [(ModuleVariable? op-knowledge)
+         (cond
+           [(kernel-module-name? (ModuleVariable-module-name op-knowledge))
+            (kernel-module-variable->primitive-name op-knowledge)]
+           [else
+            #f])]
+        [else
+         #f]))
+
+
+
+
+
+
+
+(: compile-general-application (App CompileTimeEnvironment Target Linkage -> InstructionSequence))
+(define (compile-general-application exp cenv target linkage)
+  (define n (length (App-operands exp)))
+  (define extended-cenv (extend-compile-time-environment/scratch-space 
+                         cenv 
+                         (length (App-operands exp))))
+  (define proc+operands-code
+    (cond
+      ;; Optimization: if the operand and operands are all side-effect-free, we don't need to
+      ;; juggle.
+      [(andmap side-effect-free-expression? (cons (App-operator exp) (App-operands exp)))
+       (define proc-code (compile (App-operator exp) extended-cenv 'proc next-linkage/expects-single))
+       (define operand-codes (map (lambda (operand target) #;([operand : Expression]
+                                                              [target : Target])
+                                    (compile operand
+                                             extended-cenv
+                                             target
+                                             next-linkage/expects-single))
+                                  (App-operands exp)
+                                  (build-list (length (App-operands exp))
+                                              (lambda (i) #;([i : Natural])
+                                                (make-EnvLexicalReference i #f)))))
+       (apply append-instruction-sequences proc-code operand-codes)]
+      [else
+       ;; Otherwise, we need to juggle a little.
+       (define proc-code
+         (compile (App-operator exp)
+                  extended-cenv 
+                  (if (empty? (App-operands exp))
+                      'proc
+                      (make-EnvLexicalReference 
+                       (ensure-natural (sub1 (length (App-operands exp))))
+                       #f))
+                  next-linkage/expects-single))
+       (define operand-codes
+         (map (lambda (operand target) #;([operand : Expression]
+                                          [target : Target])
+                (compile operand
+                         extended-cenv
+                         target
+                         next-linkage/expects-single))
+              (App-operands exp)
+              (build-list (length (App-operands exp))
+                          (lambda (i) #;([i : Natural])
+                            (if (< i (sub1 (length (App-operands exp))))
+                                (make-EnvLexicalReference i #f)
+                                'val)))))
+       (append-instruction-sequences
+        proc-code
+        (juggle-operands operand-codes))]))
+  
+  (append-instruction-sequences
+   (make-PushEnvironment (length (App-operands exp)) #f)
+   proc+operands-code
+   (make-AssignImmediate 'argcount (make-Const (length (App-operands exp))))
+   (compile-general-procedure-call cenv
+                                   (make-Const (length (App-operands exp)))
+                                   target
+                                   linkage)))
+
+
+
+
+
+
+(: compile-primitive-application (App CompileTimeEnvironment Target Linkage Symbol Arity -> InstructionSequence))
+(define (compile-primitive-application exp cenv target linkage primitive-name expected-arity)
+  (let* ([extended-cenv
+          (extend-compile-time-environment/scratch-space 
+           cenv 
+           (length (App-operands exp)))]
+         [operand-codes (map (lambda (operand target) #;([operand : Expression]
+                                                         [target : Target])
+                               (compile operand
+                                        extended-cenv
+                                        target
+                                        next-linkage/expects-single))
+                             (App-operands exp)
+                             (build-list (length (App-operands exp))
+                                         (lambda (i) #;([i : Natural])
+                                           (make-EnvLexicalReference i #f))))])
+    (append-instruction-sequences
+     (make-PushEnvironment (length (App-operands exp)) #f)
+     (apply append-instruction-sequences operand-codes)
+     
+     ;; Optimization: if the expected arity is a known constant, we don't
+     ;; need to touch argcount either.  If it's variable, we emit the argcount, since
+     ;; it's something we need at runtime.
+     (if (number? expected-arity)
+         empty-instruction-sequence
+         (make-AssignImmediate 'argcount (make-Const (length (App-operands exp)))))
+     
+     (if (arity-matches? expected-arity (length (App-operands exp)))
+         (compile-primitive-procedure-call primitive-name
+                                           cenv 
+                                           (make-Const (length (App-operands exp)))
+                                           target
+                                           linkage)
+         (append-instruction-sequences
+          (compile (App-operator exp) extended-cenv 'proc next-linkage/expects-single)
+          (make-Perform (make-RaiseArityMismatchError! 
+                         (make-Reg 'proc)
+                         expected-arity
+                         (make-Const (length (App-operands exp))))))))))
+
+
+;; If we know the procedure is implemented as a primitive (as opposed to a general closure),
+;; we can do a little less work.
+;; We don't need to check arity (as that's already been checked statically).
+;; Assumes 1. the procedure value is NOT loaded into proc.  We know statically what the
+;;            procedure is supposed to be.
+;;         2. (OPTIONAL) number-of-arguments has been conditionally written into the argcount register,
+; ;        3. the number-of-arguments values are on the stack.
+(: compile-primitive-procedure-call (Symbol CompileTimeEnvironment OpArg Target Linkage -> InstructionSequence))
+(define (compile-primitive-procedure-call primitive-name cenv number-of-arguments target linkage)
+  (end-with-linkage
+   linkage
+   cenv
+   (append-instruction-sequences
+    (make-AssignPrimOp 'val (make-ApplyPrimitiveProcedure primitive-name))
+    (make-PopEnvironment number-of-arguments (make-Const 0))
+    (if (eq? target 'val)
+        empty-instruction-sequence
+        (make-AssignImmediate target (make-Reg 'val)))
+    (emit-singular-context linkage))))
+
+
+
+
+
+
+(: compile-open-codeable-application
+   (KernelPrimitiveName/Inline App CompileTimeEnvironment Target Linkage -> InstructionSequence))
+;; This is a special case of application, where the operator is statically
+;; known to be in the set of hardcoded primitives, and where we can open-code
+;; the application.
+;;
+;; There's a special case optimization we can perform: we can avoid touching
+;; the stack for constant arguments; rather than allocate (length (App-operands exp))
+;; stack slots, we can do less than that.
+;;
+;; We have to be sensitive to mutation.
+(define (compile-open-codeable-application kernel-op exp cenv target linkage)
+  (let ([singular-context-check (emit-singular-context linkage)]
+        [n (length (App-operands exp))])
+    
+    (define expected-operand-types
+      (kernel-primitive-expected-operand-types kernel-op n))
+    
+    (: make-runtime-arity-mismatch-code (Arity -> InstructionSequence))
+    (define (make-runtime-arity-mismatch-code expected-arity)
+      ;; We compile the code to generate a runtime arity error here.
+      (end-with-linkage
+       linkage cenv
+       (append-instruction-sequences
+        (make-PushEnvironment n #f)
+        (apply append-instruction-sequences
+          (map (lambda (operand target) #;([operand : Expression]
+                                           [target : Target])
+                 (compile operand
+                          (extend-compile-time-environment/scratch-space 
+                           cenv 
+                           (length (App-operands exp)))
+                          target
+                          next-linkage/expects-single))
+               (App-operands exp)
+               (build-list (length (App-operands exp))
+                           (lambda (i) #;([i : Natural])
+                             (make-EnvLexicalReference i #f)))))
+        (make-AssignImmediate 'proc (make-PrimitiveKernelValue kernel-op))
+        (make-AssignImmediate 'argcount
+                              (make-Const (length (App-operands exp))))
+        (make-Perform (make-RaiseArityMismatchError! 
+                       (make-Reg 'proc)
+                       expected-arity
+                       (make-Const n))))))
+    
+    (cond
+      [(IncorrectArity? expected-operand-types)
+       (make-runtime-arity-mismatch-code (IncorrectArity-expected expected-operand-types))]
+      
+      [(not (= n (length expected-operand-types)))
+       (make-runtime-arity-mismatch-code (length expected-operand-types))]
+      
+      [else
+       (cond
+         ;; If all the arguments are primitive enough (all constants, localrefs, or toplevelrefs),
+         ;; then application requires no stack space at all, and application is especially side-effect-free.
+         [(andmap side-effect-free-expression? (App-operands exp))
+          (let* ([operand-knowledge
+                  (map (lambda (arg) #;([arg : Expression])
+                         (extract-static-knowledge 
+                          arg 
+                          (extend-compile-time-environment/scratch-space 
+                           cenv n)))
+                       (App-operands exp))]
+                 
+                 [typechecks?
+                  (map (lambda (dom known) #;([dom : OperandDomain]
+                                              [known : CompileTimeEnvironmentEntry])
+                         (not (redundant-check? dom known)))
+                       expected-operand-types
+                       operand-knowledge)]
+                 
+                 [operand-poss
+                  (side-effect-free-operands->opargs (map (lambda (op)  #;([op : Expression])
+                                                            (ensure-side-effect-free-expression
+                                                             (adjust-expression-depth op n n)))
+                                                          (App-operands exp))
+                                                     operand-knowledge)])
+            (end-with-linkage
+             linkage cenv
+             (append-instruction-sequences
+              (make-AssignPrimOp target
+                                 (make-CallKernelPrimitiveProcedure 
+                                  kernel-op 
+                                  operand-poss
+                                  expected-operand-types
+                                  typechecks?))
+              singular-context-check)))]
+         
+         [else
+          ;; Otherwise, we can split the operands into two categories: constants, and the rest.
+          (let*-values ([(constant-operands rest-operands)
+                         (split-operands-by-constants 
+                          (App-operands exp))]
+                        
+                        ;; here, we rewrite the stack references so they assume no scratch space
+                        ;; used by the constant operands.
+                        [(extended-cenv constant-operands rest-operands)
+                         (values (extend-compile-time-environment/scratch-space 
+                                  cenv 
+                                  (length rest-operands))
+                                 
+                                 (map (lambda (constant-operand) #;([constant-operand : Expression])
+                                        (ensure-side-effect-free-expression
+                                         (adjust-expression-depth constant-operand
+                                                                  (length constant-operands)
+                                                                  n)))
+                                      constant-operands)
+                                 
+                                 (map (lambda (rest-operand) #;([rest-operand : Expression])
+                                        (adjust-expression-depth rest-operand
+                                                                 (length constant-operands)
+                                                                 n))
+                                      rest-operands))]
+                        [(constant-operand-knowledge)
+                         (map (lambda (arg) #;([arg : Expression])
+                                (extract-static-knowledge arg extended-cenv))
+                              constant-operands)]
+                        
+                        [(operand-knowledge)
+                         (append constant-operand-knowledge
+                                 (map (lambda (arg) #;([arg : Expression])
+                                        (extract-static-knowledge arg extended-cenv))
+                                      rest-operands))]
+                        
+                        [(typechecks?)
+                         (map (lambda (dom known) #;([dom : OperandDomain]
+                                                     [known : CompileTimeEnvironmentEntry])
+                                (not (redundant-check? dom known)))
+                              expected-operand-types
+                              operand-knowledge)]
+                        
+                        [(stack-pushing-code) 
+                         (make-PushEnvironment (length rest-operands)
+                                               #f)]
+                        [(stack-popping-code) 
+                         (make-PopEnvironment (make-Const (length rest-operands))
+                                              (make-Const 0))]
+                        
+                        [(constant-operand-poss)
+                         (side-effect-free-operands->opargs constant-operands constant-operand-knowledge)]
+                        
+                        [(rest-operand-poss)
+                         (build-list (length rest-operands)
+                                     (lambda (i) #;([i : Natural])
+                                       (make-EnvLexicalReference i #f)))]
+                        [(rest-operand-code)
+                         (apply append-instruction-sequences
+                           (map (lambda (operand target) #;([operand : Expression]
+                                                            [target : Target])
+                                  (compile operand 
+                                           extended-cenv 
+                                           target 
+                                           next-linkage/expects-single))
+                                rest-operands
+                                rest-operand-poss))])
+            
+            (end-with-linkage
+             linkage cenv
+             (append-instruction-sequences
+              stack-pushing-code
+              rest-operand-code
+              (make-AssignPrimOp (adjust-target-depth target (length rest-operands))
+                                 (make-CallKernelPrimitiveProcedure 
+                                  kernel-op 
+                                  (append constant-operand-poss rest-operand-poss)
+                                  expected-operand-types
+                                  typechecks?))
+              stack-popping-code
+              singular-context-check)))])])))
+
+
+
+
+(: ensure-side-effect-free-expression (Expression -> (U Constant ToplevelRef LocalRef PrimitiveKernelValue)))
+(define (ensure-side-effect-free-expression e)
+  (if (or (Constant? e)
+          (LocalRef? e)
+          (ToplevelRef? e)
+          (PrimitiveKernelValue? e))
+      e
+      (error 'ensure-side-effect-free-expression)))
+
+
+(: side-effect-free-expression? (Expression -> Boolean))
+;; Produces true if the expression is side-effect-free and constant.
+;; TODO: generalize this so that it checks that the expression is
+;; side-effect free.  If it's side-effect free, then we can compute
+;; the expressions in any order.
+(define (side-effect-free-expression? e)
+  (or (Constant? e)
+      (LocalRef? e)
+      (ToplevelRef? e)
+      (PrimitiveKernelValue? e)))
+
+
+(: side-effect-free-operands->opargs ((Listof (U Constant LocalRef ToplevelRef PrimitiveKernelValue))
+                                      (Listof CompileTimeEnvironmentEntry)
+                                      -> (Listof OpArg)))
+;; Produces a list of OpArgs if all the operands are particularly side-effect-free.
+(define (side-effect-free-operands->opargs rands knowledge)
+  (map (lambda (e k) #;([e : (U Constant LocalRef ToplevelRef PrimitiveKernelValue)]
+                        [k : CompileTimeEnvironmentEntry])
+         (cond
+           [(Constant? e)
+            (make-Const (ensure-const-value (Constant-v e)))]
+           [(LocalRef? e)
+            (make-EnvLexicalReference (LocalRef-depth e)
+                                      (LocalRef-unbox? e))]
+           [(ToplevelRef? e)
+            (cond
+              [(ModuleVariable? k)
+               (cond [(kernel-module-name? (ModuleVariable-module-name k))
+                      (make-PrimitiveKernelValue
+                       (kernel-module-variable->primitive-name k))]
+                     [else
+                      (make-EnvPrefixReference (ToplevelRef-depth e)
+                                               (ToplevelRef-pos e)
+                                               #t)])]
+              [else
+               (make-EnvPrefixReference (ToplevelRef-depth e) (ToplevelRef-pos e) #f)])]
+           [(PrimitiveKernelValue? e)
+            e]))
+       rands
+       knowledge))
+
+
+
+(: redundant-check? (OperandDomain CompileTimeEnvironmentEntry -> Boolean))
+;; Produces true if we know the knowledge implies the domain-type.
+(define (redundant-check? domain-type knowledge)
+  (cond
+    [(eq? domain-type 'any)
+     #t]
+    [else
+     (cond [(Const? knowledge)
+            (case domain-type
+              [(number)
+               (number? (Const-const knowledge))]
+              [(string)
+               (string? (Const-const knowledge))]
+              [(box)
+               (box? (Const-const knowledge))]
+              [(list)
+               (list? (Const-const knowledge))]
+              [(vector)
+               (vector? (Const-const knowledge))]
+              [(pair)
+               (pair? (Const-const knowledge))]
+              [(caarpair)
+               (let ([x (Const-const knowledge)])
+                 (and (pair? x)
+                      (pair? (car x))))])]
+           [else
+            #f])]))
+
+
+(: split-operands-by-constants 
+   ((Listof Expression)  -> 
+                         (values (Listof (U Constant))
+                                 (Listof Expression))))
+;; Splits off the list of operations into two: a prefix of
+;; constant expressions, and the remainder.  TODO: if we can
+;; statically determine what arguments are immutable, regardless of
+;; side effects, we can do a much better job here...
+(define (split-operands-by-constants rands)
+  (let loop ; : (values (Listof (U Constant)) (Listof Expression))
+    ([rands rands] ; : (Listof Expression) 
+     [constants ; : (Listof (U Constant))
+      empty])
+    (cond [(empty? rands)
+           (values (reverse constants) empty)]
+          [else (let ([e (first rands)])
+                  (if (or (Constant? e)
+                          ;; These two are commented out because it's not sound otherwise.
+                          #;(and (LocalRef? e) (not (LocalRef-unbox? e))) 
+                          #;(and (ToplevelRef? e)
+                                 (let ([prefix (ensure-prefix 
+                                                (list-ref cenv (ToplevelRef-depth e)))])
+                                   (ModuleVariable? 
+                                    (list-ref prefix (ToplevelRef-pos e))))))
+                      (loop (rest rands) (cons e constants))
+                      (values (reverse constants) rands)))])))
+
+
+; (define-predicate natural? Natural)
+
+; (define-predicate atomic-arity-list? (Listof (U Natural ArityAtLeast)))
+(define (atomic-arity-list? o)
+  (and (list? o) (andmap (λ (o) (or (natural? o) (ArityAtLeast? o))))))
+
+(: arity-matches? (Arity Natural -> Boolean))
+(define (arity-matches? an-arity n)
+  (cond
+    [(natural? an-arity)
+     (= an-arity n)]
+    [(ArityAtLeast? an-arity)
+     (>= n (ArityAtLeast-value an-arity))]
+    [(atomic-arity-list? an-arity)
+     (ormap (lambda (an-arity) #;([an-arity : (U Natural ArityAtLeast)])
+              (cond
+                [(natural? an-arity)
+                 (= an-arity n)]
+                [(ArityAtLeast? an-arity)
+                 (>= n (ArityAtLeast-value an-arity))]))
+            an-arity)]))
+
+
+
+(: compile-statically-known-lam-application 
+   (StaticallyKnownLam App CompileTimeEnvironment Target Linkage 
+                       -> InstructionSequence))
+(define (compile-statically-known-lam-application static-operator-knowledge exp cenv target linkage)
+  (let ([arity-check
+         (cond [(arity-matches? (StaticallyKnownLam-arity static-operator-knowledge)
+                                (length (App-operands exp)))
+                empty-instruction-sequence]
+               [else
+                (make-Perform
+                 (make-RaiseArityMismatchError! 
+                  (make-Reg 'proc)
+                  (StaticallyKnownLam-arity static-operator-knowledge)
+                  (make-Const (length (App-operands exp)))))])])
+    (let* ([extended-cenv 
+            (extend-compile-time-environment/scratch-space 
+             cenv 
+             (length (App-operands exp)))]
+           [operand-codes (map (lambda (operand target) #;([operand : Expression]
+                                                           [target : Target])
+                                 (compile operand 
+                                          extended-cenv 
+                                          target 
+                                          next-linkage/expects-single))
+                               (App-operands exp)
+                               (build-list (length (App-operands exp))
+                                           (lambda (i) #;([i : Natural])
+                                             (make-EnvLexicalReference i #f))))]
+           [proc-code (compile (App-operator exp)
+                               extended-cenv 
+                               'proc
+                               next-linkage/expects-single)])    
+      (append-instruction-sequences
+       (make-PushEnvironment (length (App-operands exp)) #f)
+       (apply append-instruction-sequences operand-codes)
+       proc-code
+       arity-check
+       (compile-procedure-call/statically-known-lam static-operator-knowledge 
+                                                    cenv
+                                                    extended-cenv 
+                                                    (length (App-operands exp))
+                                                    target
+                                                    linkage)))))
+
+
+(: juggle-operands ((Listof InstructionSequence) -> InstructionSequence))
+;; Installs the operators.  At the end of this,
+;; the procedure lives in 'proc, and the operands on the environment stack.
+(define (juggle-operands operand-codes)
+  (let loop ; : InstructionSequence 
+    ([ops  operand-codes]) ; : (Listof InstructionSequence)
+    (cond
+      ;; If there are no operands, no need to juggle.
+      [(null? ops)
+       empty-instruction-sequence]
+      [(null? (rest ops))
+       (let ([n (ensure-natural (sub1 (length operand-codes)))]) ; : Natural 
+         ;; The last operand needs to be handled specially: it currently lives in 
+         ;; val.  We move the procedure at env[n] over to proc, and move the
+         ;; last operand at 'val into env[n].
+         (append-instruction-sequences 
+          (car ops)
+          (make-AssignImmediate 'proc 
+                                (make-EnvLexicalReference n #f))
+          (make-AssignImmediate (make-EnvLexicalReference n #f)
+                                (make-Reg 'val))))]
+      [else
+       ;; Otherwise, add instructions to juggle the operator and operands in the stack.
+       (append-instruction-sequences (car ops)
+                                     (loop (rest ops)))])))
+
+
+(: linkage-context (Linkage -> ValuesContext))
+(define (linkage-context linkage)
+  (cond
+    [(ReturnLinkage? linkage)
+     (cond [(ReturnLinkage-tail? linkage)
+            'tail]
+           [else
+            'keep-multiple])]
+    [(NextLinkage? linkage)
+     (NextLinkage-context linkage)]
+    [(LabelLinkage? linkage)
+     (LabelLinkage-context linkage)]))
+
+
+
+(: compile-general-procedure-call (CompileTimeEnvironment OpArg Target Linkage 
+                                                          ->
+                                                          InstructionSequence))
+;; Assumes the following:
+;; 1.  the procedure value has been loaded into the proc register.
+;; 2.  the n values passed in has been written into argcount register.
+;; 3.  environment stack contains the n operand values.
+;;
+;; n is the number of arguments passed in.
+;; cenv is the compile-time enviroment before arguments have been shifted in.
+;; extended-cenv is the compile-time environment after arguments have been shifted in.
+(define (compile-general-procedure-call cenv number-of-arguments target linkage)
+  (end-with-linkage
+   linkage
+   cenv
+   (append-instruction-sequences
+    (make-Perform (make-CheckClosureAndArity!))
+    (compile-compiled-procedure-application cenv
+                                            number-of-arguments
+                                            'dynamic
+                                            target
+                                            linkage))))
+
+
+
+
+
+(: compile-procedure-call/statically-known-lam 
+   (StaticallyKnownLam CompileTimeEnvironment CompileTimeEnvironment Natural Target Linkage -> InstructionSequence))
+(define (compile-procedure-call/statically-known-lam static-operator-knowledge cenv extended-cenv n target linkage)
+  (let* ([after-call  (make-label 'afterCall)] ; : Symbol
+         [compiled-linkage  (if (and (ReturnLinkage? linkage)
+                                     (ReturnLinkage-tail? linkage))
+                                linkage
+                                (make-LabelLinkage 
+                                 after-call
+                                 (linkage-context linkage)))]) ; : Linkage
+    (append-instruction-sequences
+     (make-AssignImmediate 'argcount
+                           (make-Const n))
+     (compile-compiled-procedure-application cenv
+                                             (make-Const n)
+                                             (make-Label 
+                                              (StaticallyKnownLam-entry-point static-operator-knowledge))
+                                             target
+                                             compiled-linkage)
+     (end-with-linkage
+      linkage
+      cenv
+      after-call))))
+
+
+
+
+
+
+(: compile-compiled-procedure-application (CompileTimeEnvironment OpArg (U Label 'dynamic) Target Linkage -> InstructionSequence))
+;; This is the heart of compiled procedure application.  A lot of things happen here.
+;;
+;;     Procedure linkage.
+;;     Handling of multiple-value-returns.
+;;     Tail calls.
+;;
+;; Three fundamental cases for general compiled-procedure application.
+;;    1.  Tail calls.
+;;    2.  Non-tail calls (next/label linkage) that write to val
+;;    3.  Calls in argument position (next/label linkage) that write to the stack.
+(define (compile-compiled-procedure-application cenv number-of-arguments entry-point target linkage)
+  (define entry-point-target
+    ;; Optimization: if the entry-point is known to be a static label,
+    ;; use that.  Otherwise, grab the entry point from the proc register.
+    (cond [(Label? entry-point)
+           entry-point]
+          [(eq? entry-point 'dynamic)
+           (make-CompiledProcedureEntry (make-Reg 'proc))]))
+  
+  ;; If the target isn't val, migrate the value from val into it.
+  (define maybe-migrate-val-to-target
+    (cond
+      [(eq? target 'val)
+       empty-instruction-sequence]
+      [else
+       (make-AssignImmediate target (make-Reg 'val))]))
+  
+  (define-values (on-return/multiple on-return) (new-linked-labels 'procReturn))
+  
+  ;; This code does the initial jump into the procedure.  Clients of this code
+  ;; are expected to generate the proc-return-multiple and proc-return code afterwards.
+  (define nontail-jump-into-procedure
+    (append-instruction-sequences 
+     (make-PushControlFrame/Call on-return)
+     (make-Goto entry-point-target)))
+  
+  (cond [(ReturnLinkage? linkage)
+         (cond
+           [(eq? target 'val)
+            (cond
+              [(ReturnLinkage-tail? linkage)
+               ;; This case happens when we're in tail position.
+               ;; We clean up the stack right before the jump, and do not add
+               ;; to the control stack.
+               (let ([reuse-the-stack
+                      (make-PopEnvironment (make-Const (length cenv))
+                                           number-of-arguments)])
+                 (append-instruction-sequences
+                  reuse-the-stack
+                  ;; Assign the proc value of the existing call frame.
+                  (make-Perform (make-SetFrameCallee! (make-Reg 'proc)))
+                  (make-Goto entry-point-target)))]
+              
+              [else	    
+               ;; This case happens when we should be returning to a caller, but where
+               ;; we are not in tail position.
+               (make-Goto entry-point-target)])]
+           
+           [else
+            (error 'compile "return linkage, target not val: ~s" target)])]
+        
+        
+        [(or (NextLinkage? linkage) (LabelLinkage? linkage))
+         (let* ([context (linkage-context linkage)]
+                
+                [check-values-context-on-procedure-return
+                 (emit-values-context-check-on-procedure-return context on-return/multiple on-return)]
+                
+                [maybe-jump-to-label
+                 (if (LabelLinkage? linkage)
+                     (make-Goto (make-Label (LabelLinkage-label linkage)))
+                     empty-instruction-sequence)])
+           
+           (append-instruction-sequences
+            nontail-jump-into-procedure
+            check-values-context-on-procedure-return
+            maybe-migrate-val-to-target
+            maybe-jump-to-label))]))
+
+
+
+(: emit-values-context-check-on-procedure-return (ValuesContext Symbol LinkedLabel -> InstructionSequence))
+;; When we come back from a procedure call, the following code ensures the context's expectations
+;; are met.
+(define (emit-values-context-check-on-procedure-return context on-return/multiple on-return)
+  (cond                                          
+    [(eq? context 'tail)
+     (append-instruction-sequences on-return/multiple
+                                   on-return)]
+    
+    [(eq? context 'drop-multiple)
+     (append-instruction-sequences
+      on-return/multiple
+      (make-PopEnvironment (new-SubtractArg (make-Reg 'argcount) (make-Const 1))
+                           (make-Const 0))
+      on-return)]
+    
+    [(eq? context 'keep-multiple)
+     (let ([after-return (make-label 'afterReturn)])
+       (append-instruction-sequences
+        on-return/multiple
+        (make-Goto (make-Label after-return))
+        on-return
+        (make-AssignImmediate 'argcount (make-Const 1))
+        after-return))]
+    
+    [(natural? context)
+     (cond
+       [(= context 1)
+        (append-instruction-sequences
+         on-return/multiple
+         (make-Perform
+          (make-RaiseContextExpectedValuesError! 1))
+         on-return)]
+       [else
+        (let ([after-value-check (make-label 'afterValueCheck)])
+          (append-instruction-sequences
+           on-return/multiple
+           ;; if the wrong number of arguments come in, die
+           (make-TestAndJump (make-TestZero (new-SubtractArg (make-Reg 'argcount)
+                                                             (make-Const context)))
+                             after-value-check)
+           on-return
+           (make-Perform
+            (make-RaiseContextExpectedValuesError! context))
+           after-value-check))])]))
+
+
+
+
+
+
+(: compile-let1 (Let1 CompileTimeEnvironment Target Linkage -> InstructionSequence))
+;; Single value binding.  Since there's only one rhs, we have more static guarantees we can make,
+;; which is why we can use extract-static-knowledge here.
+(define (compile-let1 exp cenv target linkage)
+  (let* ([rhs-code ; : InstructionSequence 
+          (compile (Let1-rhs exp)
+                   (cons '? cenv)
+                   (make-EnvLexicalReference 0 #f)
+                   next-linkage/expects-single)]
+         [after-body-code ; : Symbol 
+          (make-label 'afterLetBody)]
+         [extended-cenv ; : CompileTimeEnvironment 
+          (cons (extract-static-knowledge (Let1-rhs exp)
+                                          (cons '? cenv))
+                cenv)]
+         [context ; : ValuesContext 
+          (linkage-context linkage)]
+         [let-linkage ; : Linkage
+          (cond
+            [(NextLinkage? linkage)
+             linkage]
+            [(ReturnLinkage? linkage)
+             (cond [(ReturnLinkage-tail? linkage)
+                    linkage]
+                   [else
+                    (make-LabelLinkage after-body-code (linkage-context linkage))])]
+            [(LabelLinkage? linkage)
+             (make-LabelLinkage after-body-code (LabelLinkage-context linkage))])]
+         
+         [body-target ; : Target 
+          (adjust-target-depth target 1)]
+         [body-code ; : InstructionSequence
+          (compile (Let1-body exp) extended-cenv body-target let-linkage)])
+    (end-with-linkage 
+     linkage
+     extended-cenv
+     (append-instruction-sequences
+      (make-PushEnvironment 1 #f)
+      rhs-code
+      body-code
+      after-body-code
+      
+      
+      ;; We want to clear out the scratch space introduced by the
+      ;; let1.  However, there may be multiple values coming
+      ;; back at this point, from the evaluation of the body.  We
+      ;; look at the context and route around those values
+      ;; appropriate.
+      (cond
+        [(eq? context 'tail)
+         empty-instruction-sequence]
+        [(eq? context 'drop-multiple)
+         (make-PopEnvironment (make-Const 1)
+                              (make-Const 0))]
+        [(eq? context 'keep-multiple)
+         ;; dynamic number of arguments that need
+         ;; to be preserved
+         
+         (make-PopEnvironment (make-Const 1)
+                              (new-SubtractArg
+                               (make-Reg 'argcount)
+                               (make-Const 1)))]
+        [else
+         (cond [(= context 0)
+                (make-PopEnvironment (make-Const 1)                                  
+                                     (make-Const 0))]
+               [(= context 1)
+                (make-PopEnvironment (make-Const 1)
+                                     (make-Const 0))]
+               [else
+                ;; n-1 values on stack that we need to route
+                ;; around
+                (make-PopEnvironment (make-Const 1)
+                                     (new-SubtractArg
+                                      (make-Const context)
+                                      (make-Const 1)))])])))))
+
+
+
+
+(: compile-let-void (LetVoid CompileTimeEnvironment Target Linkage -> InstructionSequence))
+;; Binding several values.  Unlike before, it has less knowledge about what values will be bound,
+;; and so there's less analysis here.
+(define (compile-let-void exp cenv target linkage)
+  (let* ([n  (LetVoid-count exp)] ; : Natural
+         [after-let  (make-label 'afterLet)] ; : Symbol
+         [after-body-code  (make-label 'afterLetBody)] ; : Symbol
+         [extended-cenv ; : CompileTimeEnvironment
+          (append (build-list (LetVoid-count exp) 
+                              (lambda (i) #;([i : Natural]) '?))
+                  cenv)]
+         [context  (linkage-context linkage)] ; : ValuesContext
+         [let-linkage ; : Linkage
+          (cond
+            [(NextLinkage? linkage)
+             linkage]
+            [(ReturnLinkage? linkage)
+             (cond
+               [(ReturnLinkage-tail? linkage)
+                linkage]
+               [else
+                (make-LabelLinkage after-body-code context)])]
+            [(LabelLinkage? linkage)
+             (make-LabelLinkage after-body-code context)])]
+         [body-target ; : Target 
+          (adjust-target-depth target n)]
+         [body-code ; : InstructionSequence
+          (compile (LetVoid-body exp) extended-cenv body-target let-linkage)])
+    (end-with-linkage 
+     linkage
+     extended-cenv
+     (append-instruction-sequences 
+      (make-PushEnvironment n (LetVoid-boxes? exp))
+      body-code
+      after-body-code
+      
+      ;; We want to clear out the scratch space introduced by the
+      ;; let-void.  However, there may be multiple values coming
+      ;; back at this point, from the evaluation of the body.  We
+      ;; look at the context and route around those values
+      ;; appropriate.
+      (cond
+        [(eq? context 'tail)
+         empty-instruction-sequence]
+        [(eq? context 'drop-multiple)
+         (make-PopEnvironment (make-Const n)
+                              (make-Const 0))]
+        [(eq? context 'keep-multiple)
+         ;; dynamic number of arguments that need
+         ;; to be preserved
+         (make-PopEnvironment (make-Const n)
+                              (new-SubtractArg
+                               (make-Reg 'argcount)
+                               (make-Const 1)))]
+        [else
+         (cond [(= context 0)
+                (make-PopEnvironment (make-Const n)                                  
+                                     (make-Const 0))]
+               [(= context 1)
+                (make-PopEnvironment (make-Const n)
+                                     (make-Const 0))]
+               [else
+                
+                ;; n-1 values on stack that we need to route
+                ;; around
+                (make-PopEnvironment (make-Const n)
+                                     (new-SubtractArg
+                                      (make-Const context)
+                                      (make-Const 1)))])])
+      after-let))))
+
+
+
+(: compile-let-rec (LetRec CompileTimeEnvironment Target Linkage -> InstructionSequence))
+;; Compiled recursive Lams.  Each lambda is installed as a shell, and then the closures
+;; are installed in-place.
+(define (compile-let-rec exp cenv target linkage)
+  (let* ([n (length (LetRec-procs exp))] ; : Natural 
+         [extended-cenv ; : CompileTimeEnvironment
+          (append (map (lambda (p) #;([p : Lam])
+                         (extract-static-knowledge 
+                          p
+                          (append (build-list (length (LetRec-procs exp))
+                                              (lambda (i) #;([i : Natural])
+                                                '?))
+                                  (drop cenv n))))
+                       (LetRec-procs exp))
+                  (drop cenv n))]
+         [n (length (LetRec-procs exp))] ; : Natural 
+         [after-body-code (make-label 'afterBodyCode)] ; : Symbol
+         [letrec-linkage (cond    ;  : Linkage 
+                           [(NextLinkage? linkage)
+                            linkage]
+                           [(ReturnLinkage? linkage)
+                            (cond
+                              [(ReturnLinkage-tail? linkage)
+                               linkage]
+                              [else
+                               (make-LabelLinkage after-body-code
+                                                  (linkage-context linkage))])]
+                           [(LabelLinkage? linkage)
+                            (make-LabelLinkage after-body-code
+                                               (LabelLinkage-context linkage))])])
+    (end-with-linkage
+     linkage
+     extended-cenv
+     (append-instruction-sequences
+      
+      ;; Install each of the closure shells.
+      (apply append-instruction-sequences
+        (map (lambda (lam i) #;([lam : Lam]
+                                [i : Natural])
+               (compile-lambda-shell lam 
+                                     extended-cenv
+                                     (make-EnvLexicalReference i #f) 
+                                     next-linkage/expects-single))
+             (LetRec-procs exp)
+             (build-list n (lambda (i) #;([i : Natural]) i))))
+      
+      ;; Fix the closure maps of each
+      (apply append-instruction-sequences
+        (map (lambda (lam i) #;([lam : Lam]
+                                [i : Natural])
+               (append-instruction-sequences
+                (make-Perform (make-FixClosureShellMap! i 
+                                                        (Lam-closure-map lam)))))
+             (LetRec-procs exp)
+             (build-list n (lambda (i) #;([i : Natural]) i))))
+      
+      ;; Compile the body
+      (compile (LetRec-body exp) extended-cenv target letrec-linkage)
+      
+      after-body-code))))
+
+
+
+(: compile-install-value (InstallValue CompileTimeEnvironment Target Linkage -> InstructionSequence))
+(define (compile-install-value exp cenv target linkage)
+  (append-instruction-sequences
+   (let ([count (InstallValue-count exp)])
+     (cond [(= count 0)
+            (end-with-linkage
+             linkage
+             cenv
+             (append-instruction-sequences
+              (compile (InstallValue-body exp)
+                       cenv
+                       target
+                       (make-NextLinkage 0))
+              (make-AssignImmediate target (make-Const (void)))
+              (emit-singular-context linkage)))]
+           [(= count 1)
+            (append-instruction-sequences
+             (end-with-linkage
+              linkage
+              cenv
+              (append-instruction-sequences
+               (compile (InstallValue-body exp)
+                        cenv
+                        (make-EnvLexicalReference (InstallValue-depth exp) (InstallValue-box? exp))
+                        (make-NextLinkage 1))
+               (make-AssignImmediate target (make-Const (void)))
+               (emit-singular-context linkage))))]
+           [else
+            (end-with-linkage
+             linkage
+             cenv
+             (append-instruction-sequences
+              (compile (InstallValue-body exp)
+                       cenv
+                       'val
+                       (make-NextLinkage count))
+              (apply append-instruction-sequences
+                (map (lambda (to from) #;([to : EnvLexicalReference]
+                                          [from : OpArg])
+                       (append-instruction-sequences
+                        (make-AssignImmediate to from)))
+                     (build-list count (lambda (i) #;([i : Natural])
+                                         (make-EnvLexicalReference (+ i 
+                                                                      (InstallValue-depth exp)
+                                                                      (ensure-natural (sub1 count)))
+                                                                   (InstallValue-box? exp))))
+                     (cons (make-Reg 'val) 
+                           (build-list (sub1 count) (lambda (i) #;([i : Natural])
+                                                      (make-EnvLexicalReference i #f))))))
+              (make-PopEnvironment (make-Const (sub1 count)) (make-Const 0))
+              (make-AssignImmediate target (make-Const (void)))
+              (emit-singular-context linkage)))]))))
+
+
+
+(: compile-box-environment-value (BoxEnv CompileTimeEnvironment Target Linkage -> InstructionSequence))
+(define (compile-box-environment-value exp cenv target linkage)
+  (append-instruction-sequences
+   (make-AssignPrimOp (make-EnvLexicalReference (BoxEnv-depth exp) #f)
+                      (make-MakeBoxedEnvironmentValue (BoxEnv-depth exp)))
+   (compile (BoxEnv-body exp) cenv target linkage)))
+
+
+
+
+(: compile-with-cont-mark (WithContMark CompileTimeEnvironment Target Linkage -> InstructionSequence))
+(define (compile-with-cont-mark exp cenv target linkage)
+  
+  (: in-return-context (-> InstructionSequence))
+  (define (in-return-context)
+    (append-instruction-sequences
+     (compile (WithContMark-key exp) cenv 'val next-linkage/expects-single)
+     (make-AssignImmediate
+      (make-ControlFrameTemporary 'pendingContinuationMarkKey)
+      (make-Reg 'val))
+     (compile (WithContMark-value exp) cenv 'val next-linkage/expects-single)
+     (make-Perform (make-InstallContinuationMarkEntry!))
+     (compile (WithContMark-body exp) cenv target linkage)))
+  
+  (: in-other-context ((U NextLinkage LabelLinkage) -> InstructionSequence))
+  (define (in-other-context linkage)
+    (define-values (on-return/multiple: on-return:)
+      (new-linked-labels 'procReturn))
+    (define context (linkage-context linkage))
+    (define check-values-context-on-procedure-return
+      (emit-values-context-check-on-procedure-return
+       context on-return/multiple: on-return:))
+    (define maybe-migrate-val-to-target
+      (cond
+        [(eq? target 'val)
+         empty-instruction-sequence]
+        [else
+         (make-AssignImmediate target (make-Reg 'val))]))
+    (append-instruction-sequences
+     (make-PushControlFrame/Call on-return:)
+     (compile (WithContMark-key exp) cenv 'val next-linkage/expects-single)
+     (make-AssignImmediate (make-ControlFrameTemporary 'pendingContinuationMarkKey)
+                           (make-Reg 'val))
+     (compile (WithContMark-value exp) cenv 'val next-linkage/expects-single)
+     (make-Perform (make-InstallContinuationMarkEntry!))
+     (compile (WithContMark-body exp) cenv 'val return-linkage/nontail)
+     check-values-context-on-procedure-return
+     maybe-migrate-val-to-target))
+  (cond
+    [(ReturnLinkage? linkage)
+     (in-return-context)]
+    [(NextLinkage? linkage) 
+     (in-other-context linkage)]
+    [(LabelLinkage? linkage)
+     (append-instruction-sequences
+      (in-other-context linkage)
+      (make-Goto (make-Label (LabelLinkage-label linkage))))]))
+
+
+(: compile-apply-values (ApplyValues CompileTimeEnvironment Target Linkage -> InstructionSequence))
+(define (compile-apply-values exp cenv target linkage)
+  ;(log-debug (format "apply values ~a" exp))
+  (let ([on-zero (make-label 'onZero)]
+        [after-args-evaluated (make-label 'afterArgsEvaluated)]
+        [consumer-info
+         (extract-static-knowledge (ApplyValues-proc exp) cenv)])
+    (append-instruction-sequences
+     
+     ;; Save the procedure value temporarily in a control stack frame
+     (make-PushControlFrame/Generic)
+     (compile (ApplyValues-proc exp) 
+              cenv 
+              (make-ControlFrameTemporary 'pendingApplyValuesProc)
+              next-linkage/expects-single)
+     
+     ;; Then evaluate the value producer in a context that expects
+     ;; the return values to be placed onto the stack.
+     (compile (ApplyValues-args-expr exp)
+              cenv 
+              'val
+              next-linkage/keep-multiple-on-stack)
+     
+     (make-TestAndJump (make-TestZero (make-Reg 'argcount)) after-args-evaluated)
+     ;; In the common case where we do get values back, we push val onto the stack too,
+     ;; so that we have n values on the stack before we jump to the procedure call.
+     (make-PushImmediateOntoEnvironment (make-Reg 'val) #f)
+     
+     after-args-evaluated
+     ;; Retrieve the procedure off the temporary control frame.
+     (make-AssignImmediate 
+      'proc 
+      (make-ControlFrameTemporary 'pendingApplyValuesProc))
+     
+     ;; Pop off the temporary control frame
+     (make-PopControlFrame)
+     
+     
+     ;; Finally, do the generic call into the consumer function.
+     ;; FIXME: we have more static knowledge here of what the operator is.
+     ;; We can make this faster.
+     (compile-general-procedure-call cenv (make-Reg 'argcount) target linkage))))
+
+
+(: compile-def-values (DefValues CompileTimeEnvironment Target Linkage -> InstructionSequence))
+(define (compile-def-values exp cenv target linkage)
+  (let* ([ids (DefValues-ids exp)]
+         [rhs (DefValues-rhs exp)]
+         [n (length ids)])
+    ;; First, compile the body, which will produce right side values.
+    (end-with-linkage 
+     linkage 
+     cenv
+     (append-instruction-sequences
+      (compile rhs cenv 'val (make-NextLinkage (length ids)))
+      
+      ;; Now install each of the values in place.  The first value's in val, and the rest of the
+      ;; values are on the stack.
+      (if (> n 0)
+          (apply append-instruction-sequences
+            (map (lambda (id from) #;([id : ToplevelRef]
+                                      [from : OpArg])
+                   (define prefix 
+                     (ensure-prefix (list-ref cenv (ToplevelRef-depth id))))
+                   (define prefix-element (list-ref (Prefix-names prefix) (ToplevelRef-pos id)))  
+                   (cond
+                     [(GlobalBucket? prefix-element)
+                      (make-AssignImmediate (make-GlobalsReference (GlobalBucket-name prefix-element))
+                                            from)]
+                     [else
+                      ;; Slightly subtle: the toplevelrefs were with respect to the
+                      ;; stack at the beginning of def-values, but at the moment,
+                      ;; there may be additional values that are currently there.
+                      (make-AssignImmediate
+                       (make-EnvPrefixReference (+ (ensure-natural (sub1 n))
+                                                   (ToplevelRef-depth id))
+                                                (ToplevelRef-pos id)
+                                                #f)
+                       from)]))
+                 ids
+                 (if (> n 0) 
+                     (cons (make-Reg 'val)
+                           (build-list (sub1 n)
+                                       (lambda (i) #;([i : Natural])
+                                         (make-EnvLexicalReference i #f))))
+                     empty)))
+          empty-instruction-sequence)
+      
+      ;; Make sure any multiple values are off the stack.
+      (if (> (length ids) 1)
+          (make-PopEnvironment (make-Const (sub1 (length ids)))
+                               (make-Const 0))
+          empty-instruction-sequence)
+      
+      ;; Finally, set the target to void.
+      
+      (make-AssignImmediate target (make-Const (void)))
+      (emit-singular-context linkage)))))
+
+
+
+(: compile-primitive-kernel-value (PrimitiveKernelValue CompileTimeEnvironment Target Linkage -> InstructionSequence))
+(define (compile-primitive-kernel-value exp cenv target linkage)
+  (let ([id (PrimitiveKernelValue-id exp)])
+    (cond
+      [(KernelPrimitiveName? id)   
+       (let ([singular-context-check (emit-singular-context linkage)])
+         ;; Compiles constant values.
+         (end-with-linkage linkage
+                           cenv
+                           (append-instruction-sequences
+                            (make-AssignImmediate target exp)
+                            singular-context-check)))]
+      [else
+       ;; Maybe warn about the unimplemented kernel primitive.
+       (unless (set-contains? (current-seen-unimplemented-kernel-primitives)
+                              id)
+         (set-insert! (current-seen-unimplemented-kernel-primitives)
+                      id)
+         ((current-warn-unimplemented-kernel-primitive) id))
+       
+       (make-Perform (make-RaiseUnimplementedPrimitiveError! id))])))
+
+
+
+
+
+
+
+(: ensure-natural (Integer -> Natural))
+(define (ensure-natural n)
+  (if (>= n 0)
+      n
+      (error 'ensure-natural "Not a natural: ~s\n" n)))
+
+
+(: ensure-lam (Any -> Lam))
+(define (ensure-lam x)
+  (if (Lam? x)
+      x
+      (error 'ensure-lam "Not a Lam: ~s" x)))
+
+
+(: ensure-toplevelref (Any -> ToplevelRef))
+(define (ensure-toplevelref x)
+  (if (ToplevelRef? x)
+      x
+      (error 'ensure-toplevelref "Not a ToplevelRef: ~s" x)))
+
+
+(: adjust-target-depth (Target Natural -> Target))
+(define (adjust-target-depth target n)
+  (cond
+    [(eq? target 'val)
+     target]
+    [(eq? target 'proc)
+     target]
+    [(eq? target 'argcount)
+     target]
+    [(EnvLexicalReference? target)
+     (make-EnvLexicalReference (+ n (EnvLexicalReference-depth target))
+                               (EnvLexicalReference-unbox? target))]
+    [(EnvPrefixReference? target)
+     (make-EnvPrefixReference (+ n (EnvPrefixReference-depth target))
+                              (EnvPrefixReference-pos target)
+                              (EnvPrefixReference-modvar? target))]
+    [(PrimitivesReference? target)
+     target]
+    [(GlobalsReference? target)
+     target]
+    [(ControlFrameTemporary? target)
+     target]
+    [(ModulePrefixTarget? target)
+     target]
+    [(ModuleVariable? target)
+     target]))
+
+
+
+(: adjust-expression-depth (Expression Natural Natural -> Expression))
+;; Redirects references to the stack to route around a region of size n.
+;; The region begins at offset skip into the environment.
+(define (adjust-expression-depth exp n skip)
+  (cond
+    [(Top? exp)
+     (make-Top (Top-prefix exp)
+               (adjust-expression-depth (Top-code exp) n (add1 skip)))]
+    
+    [(Module? exp)
+     (make-Module (Module-name exp)
+                  (Module-path exp)
+                  (Module-prefix exp)
+                  (Module-requires exp)
+                  (Module-provides exp)
+                  (adjust-expression-depth (Module-code exp) n (add1 skip)))]
+    
+    [(Constant? exp)
+     exp]
+    
+    [(ToplevelRef? exp)
+     (if (< (ToplevelRef-depth exp) skip)
+         exp
+         (make-ToplevelRef (ensure-natural (- (ToplevelRef-depth exp) n))
+                           (ToplevelRef-pos exp)
+                           (ToplevelRef-constant? exp)
+                           (ToplevelRef-check-defined? exp)))]
+    
+    [(LocalRef? exp)
+     (if (< (LocalRef-depth exp) skip)
+         exp
+         (make-LocalRef (ensure-natural (- (LocalRef-depth exp) n))
+                        (LocalRef-unbox? exp)))]
+    
+    [(ToplevelSet? exp)
+     (if (< (ToplevelSet-depth exp) skip)
+         (make-ToplevelSet (ToplevelSet-depth exp)
+                           (ToplevelSet-pos exp)
+                           (adjust-expression-depth (ToplevelSet-value exp) n skip))
+         (make-ToplevelSet (ensure-natural (- (ToplevelSet-depth exp) n))
+                           (ToplevelSet-pos exp)
+                           (adjust-expression-depth (ToplevelSet-value exp) n skip)))]
+    
+    [(Branch? exp)
+     (make-Branch (adjust-expression-depth (Branch-predicate exp) n skip)
+                  (adjust-expression-depth (Branch-consequent exp) n skip)
+                  (adjust-expression-depth (Branch-alternative exp) n skip))]
+    
+    [(Lam? exp)
+     (make-Lam (Lam-name exp)
+               (Lam-num-parameters exp)
+               (Lam-rest? exp)
+               (Lam-body exp)
+               (map (lambda (d) #;([d : Natural]) 
+                      (if (< d skip)
+                          d
+                          (ensure-natural (- d n))))
+                    (Lam-closure-map exp))
+               (Lam-entry-label exp))]
+    
+    [(CaseLam? exp)
+     (make-CaseLam (CaseLam-name exp)
+                   (map (lambda (lam) #;([lam : (U Lam EmptyClosureReference)])
+                          (cond
+                            [(Lam? lam)
+                             (ensure-lam (adjust-expression-depth lam n skip))]
+                            [(EmptyClosureReference? lam)
+                             lam]))
+                        (CaseLam-clauses exp))
+                   (CaseLam-entry-label exp))]
+    
+    [(EmptyClosureReference? exp)
+     exp]
+    
+    [(Seq? exp)
+     (make-Seq (map (lambda (action) #;([action : Expression])
+                      (adjust-expression-depth action n skip))
+                    (Seq-actions exp)))]
+    
+    [(Splice? exp)
+     (make-Splice (map (lambda (action) #;([action : Expression])
+                         (adjust-expression-depth action n skip))
+                       (Splice-actions exp)))]
+    
+    [(Begin0? exp)
+     (make-Begin0 (map (lambda (action) #;([action : Expression])
+                         (adjust-expression-depth action n skip))
+                       (Begin0-actions exp)))]
+    
+    [(App? exp)
+     (make-App (adjust-expression-depth (App-operator exp) n 
+                                        (+ skip (length (App-operands exp))))
+               (map (lambda (operand) #; ([operand : Expression])
+                      (adjust-expression-depth 
+                       operand n (+ skip (length (App-operands exp)))))
+                    (App-operands exp)))]
+    
+    [(Let1? exp)
+     (make-Let1 (adjust-expression-depth (Let1-rhs exp) n (add1 skip))
+                (adjust-expression-depth (Let1-body exp) n (add1 skip)))]
+    
+    [(LetVoid? exp)
+     (make-LetVoid (LetVoid-count exp)
+                   (adjust-expression-depth (LetVoid-body exp) 
+                                            n
+                                            (+ skip (LetVoid-count exp)))
+                   (LetVoid-boxes? exp))]
+    
+    [(LetRec? exp)
+     (make-LetRec (let loop ; : (Listof Lam) 
+                    ([procs (LetRec-procs exp)]) ; : (Listof Lam) 
+                    (cond
+                      [(empty? procs)
+                       '()]
+                      [else
+                       (cons (ensure-lam (adjust-expression-depth 
+                                          (first procs)
+                                          n 
+                                          skip))
+                             (loop (rest procs)))]))
+                  (adjust-expression-depth (LetRec-body exp) n 
+                                           skip))]
+    
+    [(InstallValue? exp)
+     (if (< (InstallValue-depth exp) skip)
+         (make-InstallValue (InstallValue-count exp)
+                            (InstallValue-depth exp)
+                            (adjust-expression-depth (InstallValue-body exp)
+                                                     n
+                                                     skip)
+                            (InstallValue-box? exp))
+         (make-InstallValue (InstallValue-count exp)
+                            (ensure-natural (- (InstallValue-depth exp) n))
+                            (adjust-expression-depth (InstallValue-body exp)
+                                                     n
+                                                     skip)
+                            (InstallValue-box? exp)))]
+    
+    [(BoxEnv? exp)
+     (if (< (BoxEnv-depth exp) skip)
+         (make-BoxEnv (BoxEnv-depth exp)
+                      (adjust-expression-depth (BoxEnv-body exp) n skip))
+         (make-BoxEnv (ensure-natural (- (BoxEnv-depth exp) n))
+                      (adjust-expression-depth (BoxEnv-body exp) n skip)))]
+    
+    [(WithContMark? exp)
+     (make-WithContMark (adjust-expression-depth (WithContMark-key exp) n skip)
+                        (adjust-expression-depth (WithContMark-value exp) n skip)
+                        (adjust-expression-depth (WithContMark-body exp) n skip))]
+    [(ApplyValues? exp)
+     (make-ApplyValues (adjust-expression-depth (ApplyValues-proc exp) n skip)
+                       (adjust-expression-depth (ApplyValues-args-expr exp) n skip))]
+    
+    [(DefValues? exp)
+     (make-DefValues (map (lambda (id) #;([id : ToplevelRef])
+                            (ensure-toplevelref
+                             (adjust-expression-depth id n skip)))
+                          (DefValues-ids exp))
+                     (adjust-expression-depth (DefValues-rhs exp) n skip))]
+    
+    [(PrimitiveKernelValue? exp)
+     exp]
+    
+    [(VariableReference? exp)
+     (make-VariableReference 
+      (ensure-toplevelref
+       (adjust-expression-depth (VariableReference-toplevel exp) n skip)))]
+    [(Require? exp)
+     exp]))

--- a/whalesong/selfhost/compiler/expression-structs.rkt
+++ b/whalesong/selfhost/compiler/expression-structs.rkt
@@ -1,0 +1,173 @@
+#lang whalesong (require "../selfhost-lang.rkt")
+(require "lexical-structs.rkt")
+
+
+(provide (all-defined-out))
+
+
+;; Expressions
+(define-type Expression (U
+                         Top
+                         Constant 
+                         ToplevelRef
+                         LocalRef
+                         ToplevelSet
+                         Branch 
+                         Lam 
+                         CaseLam
+                         EmptyClosureReference
+                         Seq 
+                         Splice 
+                         Begin0
+                         App
+                         Let1 
+                         LetVoid 
+                         LetRec
+                         InstallValue
+                         BoxEnv
+                         WithContMark
+                         ApplyValues
+                         DefValues
+                         PrimitiveKernelValue
+                         Module
+                         VariableReference
+                         Require))
+
+
+(define-struct: Module ([name : Symbol]
+                        [path : ModuleLocator]
+                        [prefix : Prefix]
+                        [requires : (Listof ModuleLocator)]
+                        [provides : (Listof ModuleProvide)]
+                        [code : Expression])
+  #:transparent)
+
+
+(define-struct: ModuleProvide ([internal-name : Symbol]
+                               [external-name : Symbol]
+                               [source : ModuleLocator])
+  #:transparent)
+
+
+
+(define-struct: Top ([prefix : Prefix]
+                     [code : Expression]) #:transparent)
+
+(define-struct: Constant ([v : Any]) #:transparent)
+
+(define-struct: ToplevelRef ([depth : Natural]
+                             [pos : Natural]
+                             [constant? : Boolean]
+                             [check-defined? : Boolean]) #:transparent)
+
+(define-struct: LocalRef ([depth : Natural]
+                          [unbox? : Boolean]) #:transparent)
+
+(define-struct: ToplevelSet ([depth : Natural]
+                             [pos : Natural]
+                             [value : Expression]) #:transparent)
+
+(define-struct: Branch ([predicate : Expression]
+                        [consequent : Expression]
+                        [alternative : Expression]) #:transparent)
+
+(define-struct: CaseLam ([name : (U Symbol LamPositionalName)]
+                         [clauses : (Listof (U Lam EmptyClosureReference))]
+                         [entry-label : Symbol]) #:transparent)
+
+(define-struct: Lam ([name : (U Symbol LamPositionalName)]
+                     [num-parameters : Natural]
+                     [rest? : Boolean]
+                     [body : Expression]
+                     [closure-map : (Listof Natural)]
+                     [entry-label : Symbol]) #:transparent)
+
+;; An EmptyClosureReference has enough information to create the lambda value,
+;; assuming that the lambda's body has already been compiled.  The entry-label needs
+;; to have been shared with an existing Lam, and the closure must be empty.
+(define-struct: EmptyClosureReference ([name : (U Symbol LamPositionalName)]
+                                       [num-parameters : Natural]
+                                       [rest? : Boolean]
+                                       [entry-label : Symbol]) #:transparent)
+
+
+
+;; We may have more information about the lambda's name.  This will show it.
+(define-struct: LamPositionalName ([name : Symbol] 
+                                   [path : String]    ;; the source of the name
+                                   [line : Natural] 
+                                   [column : Natural] 
+                                   [offset : Natural] 
+                                   [span : Natural]) #:transparent)
+
+
+
+(define-struct: Seq ([actions : (Listof Expression)]) #:transparent)
+(define-struct: Splice ([actions : (Listof Expression)]) #:transparent)
+(define-struct: Begin0 ([actions : (Listof Expression)]) #:transparent)
+(define-struct: App ([operator : Expression]
+                     [operands : (Listof Expression)]) #:transparent)
+
+(define-struct: Let1 ([rhs : Expression]
+                      [body : Expression])  #:transparent)
+
+(define-struct: LetVoid ([count : Natural]
+                         [body : Expression]
+                         [boxes? : Boolean]) #:transparent)
+
+
+;; During evaluation, the closures corresponding to procs are expected
+;; to be laid out so that stack position 0 corresponds to procs[0],
+;; stack position 1 to procs[1], and so on.
+(define-struct: LetRec ([procs : (Listof Lam)]
+                        [body : Expression]) #:transparent)
+
+(define-struct: InstallValue ([count : Natural] ;; how many values to install
+                              [depth : Natural] ;; how many slots to skip
+                              [body : Expression]
+                              [box? : Boolean])  #:transparent)
+
+
+(define-struct: BoxEnv ([depth : Natural]
+                        [body : Expression]) #:transparent)
+
+
+
+(define-struct: WithContMark ([key : Expression]
+                              [value : Expression]
+                              [body : Expression]) #:transparent)
+
+
+(define-struct: ApplyValues ([proc : Expression]
+                             [args-expr : Expression]) #:transparent)
+
+
+;; Multiple value definition
+(define-struct: DefValues ([ids : (Listof ToplevelRef)]
+                           [rhs : Expression]) #:transparent)
+
+
+
+(define-struct: PrimitiveKernelValue ([id : Symbol]) #:transparent)
+
+
+(define-struct: VariableReference ([toplevel : ToplevelRef]) #:transparent)
+
+
+(define-struct: Require ([path : ModuleLocator]) #:transparent)
+
+
+
+
+(: current-short-labels? (Parameterof Boolean))
+(define current-short-labels? (make-parameter #t))
+
+
+(: make-label (Symbol -> Symbol))
+(define make-label
+  (let ([n 0])
+    (lambda (l)
+      (set! n (add1 n))
+      (if (current-short-labels?)
+          (string->symbol (format "_~a" n))
+          (string->symbol (format "~a~a" l n))))))

--- a/whalesong/selfhost/compiler/il-structs.rkt
+++ b/whalesong/selfhost/compiler/il-structs.rkt
@@ -1,0 +1,666 @@
+#lang whalesong (require "../selfhost-lang.rkt")
+(provide (all-defined-out))
+
+(require "expression-structs.rkt"
+         "lexical-structs.rkt"
+         "kernel-primitives.rkt"
+         "arity-structs.rkt")
+
+
+
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Registers of the machine:
+
+(define-type StackRegisterSymbol (U 'control 'env))
+(define-type AtomicRegisterSymbol (U 'val 'proc 'argcount))
+(define-type RegisterSymbol (U StackRegisterSymbol AtomicRegisterSymbol))
+
+;(define-predicate AtomicRegisterSymbol? AtomicRegisterSymbol)
+(define (AtomicRegisterSymbol? o)
+  (or (eq? o 'control) (eq? o 'env)))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+
+;; An operation can refer to the following arguments:
+(define-type OpArg (U Const ;; an constant
+                      Label ;; an label
+                      Reg   ;; an register 
+                      EnvLexicalReference ;; a reference into the stack
+                      EnvPrefixReference  ;; a reference into an element in the toplevel.
+                      EnvWholePrefixReference ;; a reference into a toplevel prefix in the stack.
+                      SubtractArg
+                      ControlStackLabel
+                      ControlStackLabel/MultipleValueReturn
+                      ControlFrameTemporary
+                      CompiledProcedureEntry
+                      CompiledProcedureClosureReference
+                      ModuleEntry
+                      ModulePredicate
+                      PrimitiveKernelValue
+                      VariableReference
+                      ))
+
+(define (OpArg? o)
+  (or (Const? o) ;; an constant
+      (Label? o) ;; an label
+      (Reg? o)   ;; an register 
+      (EnvLexicalReference? o) ;; a reference into the stack
+      (EnvPrefixReference? o)  ;; a reference into an element in the toplevel.
+      (EnvWholePrefixReference? o) ;; a reference into a toplevel prefix in the stack.
+      (SubtractArg? o)
+      (ControlStackLabel? o)
+      (ControlStackLabel/MultipleValueReturn? o)
+      (ControlFrameTemporary? o)
+      (CompiledProcedureEntry? o)
+      (CompiledProcedureClosureReference? o)
+      (ModuleEntry? o)
+      (ModulePredicate? o)
+      (PrimitiveKernelValue? o)
+      (VariableReference? o)))
+  
+
+
+;; Targets: these are the allowable lhs's for a targetted assignment.
+(define-type Target (U AtomicRegisterSymbol 
+                       EnvLexicalReference
+                       EnvPrefixReference
+                       PrimitivesReference
+                       GlobalsReference
+                       ControlFrameTemporary
+                       ModulePrefixTarget
+                       ))
+
+(define-struct: ModuleVariableThing () #:transparent)
+
+
+;; When we need to store a value temporarily in the top control frame, we can use this as a target.
+(define-struct: ControlFrameTemporary ([name : (U 'pendingContinuationMarkKey ;; for continuation marks
+                                                  'pendingApplyValuesProc ;; for apply-values
+                                                  'pendingBegin0Count
+                                                  'pendingBegin0Values
+                                                  )])
+  #:transparent)
+
+
+;; Targetting the prefix attribute of a module.
+(define-struct: ModulePrefixTarget ([path : ModuleLocator])
+  #:transparent)
+
+(define-struct: ModuleVariableReference ([name : Symbol]
+                                         [module-name : ModuleLocator])
+  #:transparent)
+
+
+
+(define-type const-value
+  (Rec C
+       (U Symbol
+          String
+          Number
+          Boolean
+          Void
+          Null
+          Char
+          Bytes
+          Path
+          (Pairof C C)
+          (Vectorof C)
+          (Boxof C))))
+
+
+(define-struct: Label ([name : Symbol])
+  #:transparent)
+(define-struct: Reg ([name : AtomicRegisterSymbol])
+  #:transparent)
+(define-struct: Const ([const : const-value])
+  #:transparent)
+
+;; Limited arithmetic on OpArgs
+(define-struct: SubtractArg ([lhs : OpArg]
+                             [rhs : OpArg])
+  #:transparent)
+
+
+(: new-SubtractArg (OpArg OpArg -> OpArg))
+(define (new-SubtractArg lhs rhs)
+  ;; FIXME: do some limited constant folding here
+  (cond
+    [(and (Const? lhs)(Const? rhs))
+     (let ([lhs-val (Const-const lhs)]
+           [rhs-val (Const-const rhs)])
+       (cond [(and (number? lhs-val)
+                   (number? rhs-val))
+              (make-Const (- lhs-val rhs-val))]
+             [else
+              (make-SubtractArg lhs rhs)]))]
+    [(Const? rhs)
+     (let ([rhs-val (Const-const rhs)])
+       (cond
+         [(and (number? rhs-val)
+               (= rhs-val 0))
+          lhs]
+         [else
+          (make-SubtractArg lhs rhs)]))]
+    [else
+     (make-SubtractArg lhs rhs)]))
+
+
+
+
+
+
+;; Gets the return address embedded at the top of the control stack.
+(define-struct: ControlStackLabel ()
+  #:transparent)
+
+;; Gets the secondary (mulitple-value-return) return address embedded
+;; at the top of the control stack.
+(define-struct: ControlStackLabel/MultipleValueReturn ()
+  #:transparent)
+
+;; Get the entry point of a compiled procedure.
+(define-struct: CompiledProcedureEntry ([proc : OpArg])
+  #:transparent)
+
+
+;; Get at the nth value in a closure's list of closed values.
+(define-struct: CompiledProcedureClosureReference ([proc : OpArg]
+                                                   [n : Natural])
+  #:transparent)
+
+
+(define-struct: PrimitivesReference ([name : Symbol])
+  #:transparent)
+
+(define-struct: GlobalsReference ([name : Symbol])
+  #:transparent)
+
+
+;; Produces the entry point of the module.
+(define-struct: ModuleEntry ([name : ModuleLocator])
+  #:transparent)
+
+
+(define-struct: ModulePredicate ([module-name : ModuleLocator]
+                                 [pred : (U 'invoked? 'linked?)])
+  #:transparent)
+
+
+
+;; A straight-line statement includes non-branching stuff.
+(define-type StraightLineStatement (U
+                                    DebugPrint
+                                    Comment
+                                    MarkEntryPoint
+                                    
+                                    AssignImmediate
+                                    AssignPrimOp
+                                    Perform
+                                    
+                                    PopEnvironment
+                                    PushEnvironment
+                                    PushImmediateOntoEnvironment
+                                    
+                                    PushControlFrame/Generic
+                                    PushControlFrame/Call
+                                    PushControlFrame/Prompt
+                                    PopControlFrame))
+(define (StraightLineStatement? o)
+  (or (DebugPrint? o)
+      (Comment? o)
+      (MarkEntryPoint? o)
+      
+      (AssignImmediate? o)
+      (AssignPrimOp? o)
+      (Perform? o)
+          
+      (PopEnvironment? o)
+      (PushEnvironment? o)
+      (PushImmediateOntoEnvironment? o)
+          
+      (PushControlFrame/Generic? o)
+      (PushControlFrame/Call? o)
+      (PushControlFrame/Prompt? o)
+      (PopControlFrame? o)))
+
+(define-type BranchingStatement (U Goto TestAndJump))
+(define (BranchingStatement? o) (or (Goto? o) (TestAndJump? o)))
+
+;; instruction sequences
+(define-type UnlabeledStatement (U StraightLineStatement BranchingStatement))
+
+; (define-predicate UnlabeledStatement? UnlabeledStatement)
+(define (UnlabeledStatement? o) (or (StraightLineStatement? o) (BranchingStatement? o)))
+
+
+;; Debug print statement.
+(define-struct: DebugPrint ([value : OpArg])
+  #:transparent)
+
+
+(define-type Statement (U UnlabeledStatement
+                          Symbol      ;; label
+                          LinkedLabel ;; Label with a reference to a multiple-return-value label
+                          ))
+(define (Statement? o)
+  (or (UnlabeledStatement? o)
+      (symbol? o)
+      (LinkedLabel? o)))
+
+(define-struct: LinkedLabel ([label : Symbol]
+                             [linked-to : Symbol])
+  #:transparent)
+
+
+;; Returns a pair of labels, the first being the mutiple-value-return
+;; label and the second its complementary single-value-return label.
+(: new-linked-labels (Symbol -> (Values Symbol LinkedLabel)))
+(define (new-linked-labels sym)
+  (define a-label-multiple (make-label (string->symbol (format "~aMultiple" sym))))
+  (define a-label (make-LinkedLabel (make-label sym) a-label-multiple))
+  (values a-label-multiple a-label))
+
+
+
+
+
+;; FIXME: it would be nice if I can reduce AssignImmediate and
+;; AssignPrimOp into a single Assign statement, but I run into major
+;; issues with Typed Racket taking minutes to compile.  So we're
+;; running into some kind of degenerate behavior.
+(define-struct: AssignImmediate ([target : Target]
+                                 [value : OpArg])
+  #:transparent)
+(define-struct: AssignPrimOp ([target : Target]
+                              [op : PrimitiveOperator])
+  #:transparent)
+
+
+;; Pop n slots from the environment, skipping past a few first.
+(define-struct: PopEnvironment ([n : OpArg]
+                                [skip : OpArg])
+  #:transparent)
+(define-struct: PushEnvironment ([n : Natural]
+                                 [unbox? : Boolean])
+  #:transparent)
+
+
+;; Evaluate the value, and then push it onto the top of the environment.
+(define-struct: PushImmediateOntoEnvironment ([value : OpArg]
+                                              [box? : Boolean])
+  #:transparent)
+
+
+(define-struct: PopControlFrame () 
+  #:transparent)
+
+
+;; A generic control frame only holds marks and other temporary variables.
+(define-struct: PushControlFrame/Generic ()
+  #:transparent)
+
+;; Adding a frame for getting back after procedure application.
+;; The 'proc register must hold either #f or a closure at the time of
+;; this call, as the control frame will hold onto the called procedure record.
+(define-struct: PushControlFrame/Call ([label : LinkedLabel]) 
+  #:transparent)
+
+(define-struct: PushControlFrame/Prompt
+  ([tag : (U OpArg DefaultContinuationPromptTag)]
+   [label : LinkedLabel])
+  #:transparent)
+
+
+(define-struct: DefaultContinuationPromptTag ()
+  #:transparent)
+(define default-continuation-prompt-tag 
+  (make-DefaultContinuationPromptTag))
+
+
+
+
+(define-struct: Goto ([target : (U Label 
+                                   Reg
+                                   ModuleEntry
+                                   CompiledProcedureEntry)]) 
+  #:transparent)
+
+(define-struct: Perform ([op : PrimitiveCommand])
+  #:transparent)
+
+
+
+(define-struct: TestAndJump ([op : PrimitiveTest]
+                             [label : Symbol])
+  #:transparent)
+
+
+(define-struct: Comment ([val : Any])
+  #:transparent)
+
+
+;; Marks the head of every lambda.
+(define-struct: MarkEntryPoint ([label : Symbol])
+  #:transparent)
+
+
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Primitive Operators
+
+;; The operators that return values, that are used in AssignPrimopStatement.
+;; The reason this is here is really to get around what looks like a Typed Racket issue.
+;; I would prefer to move these all to OpArgs, but if I do, Typed Racket takes much longer
+;; to type my program than I'd like.
+(define-type PrimitiveOperator (U GetCompiledProcedureEntry
+                                  MakeCompiledProcedure
+                                  MakeCompiledProcedureShell
+                                  
+                                  ModuleVariable
+                                  PrimitivesReference
+                                  GlobalsReference
+                                  
+                                  MakeBoxedEnvironmentValue
+                                  
+                                  CaptureEnvironment
+                                  CaptureControl
+                                  
+                                  CallKernelPrimitiveProcedure
+                                  ApplyPrimitiveProcedure
+                                  ))
+
+;; Gets the label from the closure stored in the 'proc register and returns it.
+(define-struct: GetCompiledProcedureEntry ()
+  #:transparent)
+
+;; Constructs a closure, given the label, # of expected arguments,
+;; and the set of lexical references into the environment that the
+;; closure needs to close over.
+(define-struct: MakeCompiledProcedure ([label : Symbol]
+                                       [arity : Arity]
+                                       [closed-vals : (Listof Natural)]
+                                       [display-name : (U Symbol LamPositionalName)])
+  #:transparent)
+
+
+;; Constructs a closure shell.  Like MakeCompiledProcedure, but doesn't
+;; bother with trying to capture the free variables.
+(define-struct: MakeCompiledProcedureShell ([label : Symbol]
+                                            [arity : Arity]
+                                            [display-name : (U Symbol LamPositionalName)])
+  #:transparent)
+
+
+
+
+
+(define-struct: CallKernelPrimitiveProcedure ([operator : KernelPrimitiveName/Inline]
+                                              
+                                              [operands : (Listof (U OpArg ModuleVariable))]
+                                              [expected-operand-types : (Listof OperandDomain)]
+                                              ;; For each operand, #t will add code to typecheck the operand
+                                              [typechecks? : (Listof Boolean)])
+  #:transparent)
+
+
+(define-struct: ApplyPrimitiveProcedure ([name : Symbol]) #:transparent)
+
+
+(define-struct: MakeBoxedEnvironmentValue ([depth : Natural])
+  #:transparent)
+
+
+;; Capture the current environment, skipping skip frames.
+(define-struct: CaptureEnvironment ([skip : Natural]
+                                    [tag : (U DefaultContinuationPromptTag OpArg)]))
+
+;; Capture the control stack, skipping skip frames.
+(define-struct: CaptureControl ([skip : Natural]
+                                [tag : (U DefaultContinuationPromptTag OpArg)]))
+
+
+
+
+;; Primitive tests (used with TestAndBranch)
+(define-type PrimitiveTest (U 
+                            TestFalse
+                            TestTrue
+                            TestOne
+                            TestZero
+                            TestClosureArityMismatch
+                            ))
+(define-struct: TestFalse ([operand : OpArg]) #:transparent)
+(define-struct: TestTrue ([operand : OpArg]) #:transparent)
+(define-struct: TestOne ([operand : OpArg]) #:transparent)
+(define-struct: TestZero ([operand : OpArg]) #:transparent)
+(define-struct: TestClosureArityMismatch ([closure : OpArg]
+                                          [n : OpArg]) #:transparent)
+
+
+
+;; Check that the value in the prefix has been defined.
+;; If not, raise an error and stop evaluation.
+(define-struct: CheckToplevelBound! ([depth : Natural]
+                                     [pos : Natural])
+  #:transparent)
+
+;; Check that the global can be defined.
+;; If not, raise an error and stop evaluation.
+(define-struct: CheckGlobalBound! ([name : Symbol])
+  #:transparent)
+
+
+;; Check the closure procedure value in 'proc and make sure it's a closure
+;; that can accept the right arguments (stored as a number in the argcount register.).
+(define-struct: CheckClosureAndArity! ()
+  #:transparent)
+
+;; Check the primitive can accept the right arguments 
+;; (stored as a number in the argcount register.).
+(define-struct: CheckPrimitiveArity! () #:transparent)
+
+
+;; Extends the environment with a prefix that holds
+;; lookups to the namespace.
+(define-struct: ExtendEnvironment/Prefix! ([names : (Listof (U False Symbol GlobalBucket ModuleVariable))])
+  #:transparent)
+
+;; Adjusts the environment by pushing the values in the
+;; closure (held in the proc register) into itself.
+(define-struct: InstallClosureValues! ([n : Natural])
+  #:transparent)
+
+
+(define-struct: SetFrameCallee! ([proc : OpArg])
+  #:transparent)
+
+
+;; Splices the list structure that lives in env[depth] into position.
+;; Depth must evaluate to a natural.
+(define-struct: SpliceListIntoStack! ([depth : OpArg])
+  #:transparent)
+
+;; Unsplices the length arguments on the stack, replacing with a list of that length.
+;; Side effects: touches both the environment and argcount appropriately. 
+(define-struct: UnspliceRestFromStack! ([depth : OpArg]
+                                        [length : OpArg])
+  #:transparent)
+
+
+(define-struct: FixClosureShellMap! (;; depth: where the closure shell is located in the environment
+                                     [depth : Natural] 
+                                     
+                                     [closed-vals : (Listof Natural)])
+  #:transparent)
+
+;; Raises an exception that says that we expected a number of values.
+;; Assume that argcount is not equal to expected.
+(define-struct: RaiseContextExpectedValuesError! ([expected : Natural])
+  #:transparent)
+
+
+;; Raises an exception that says that we're doing a
+;; procedure application, but got sent an incorrect number.
+(define-struct: RaiseArityMismatchError! ([proc : OpArg]
+                                          [expected : Arity]
+                                          [received : OpArg])
+  #:transparent)
+
+
+;; Raises an exception that says that we're doing a
+;; procedure application, but got sent an incorrect number.
+(define-struct: RaiseOperatorApplicationError! ([operator : OpArg])
+  #:transparent)
+
+
+;; Raise a runtime error if we hit a use of an unimplemented kernel primitive.
+(define-struct: RaiseUnimplementedPrimitiveError! ([name : Symbol])
+  #:transparent)
+
+
+
+
+;; Changes over the control located at the given argument from the structure in env[1]
+(define-struct: RestoreControl! ([tag : (U DefaultContinuationPromptTag OpArg)]) #:transparent)
+
+;; Changes over the environment located at the given argument from the structure in env[0]
+(define-struct: RestoreEnvironment! () #:transparent)
+
+
+;; Adds a continuation mark into the current top control frame.
+(define-struct: InstallContinuationMarkEntry! () #:transparent)
+
+
+;; Use the dynamic module loader to link the module into the runtime.
+;; After successful linkage, jump into label.
+(define-struct: LinkModule! ([path : ModuleLocator]
+                             [label : Symbol]))
+
+
+;; Installs a module record into the machine
+(define-struct: InstallModuleEntry! ([name : Symbol]
+                                     [path : ModuleLocator]
+                                     [entry-point : Symbol])
+  #:transparent)
+
+
+;; Mark that the module has been invoked.
+(define-struct: MarkModuleInvoked! ([path : ModuleLocator])
+  #:transparent)
+
+
+;; Give an alternative locator to the module as a main module.
+;; Assumes the module has already been installed.
+(define-struct: AliasModuleAsMain! ([from : ModuleLocator])
+  #:transparent)
+
+;; Given the module locator, do any finalizing operations, like
+;; setting up the module namespace.
+(define-struct: FinalizeModuleInvokation! ([path : ModuleLocator]
+                                           [provides : (Listof ModuleProvide)])
+  #:transparent)
+
+
+
+(define-type PrimitiveCommand (U                                
+                               CheckToplevelBound!
+                               CheckGlobalBound!
+                               CheckClosureAndArity!
+                               CheckPrimitiveArity!
+                               
+                               ExtendEnvironment/Prefix!
+                               InstallClosureValues!
+                               FixClosureShellMap!
+                               
+                               InstallContinuationMarkEntry!
+                               
+                               SetFrameCallee!
+                               SpliceListIntoStack!
+                               UnspliceRestFromStack!
+                               
+                               RaiseContextExpectedValuesError!
+                               RaiseArityMismatchError!
+                               RaiseOperatorApplicationError!
+                               RaiseUnimplementedPrimitiveError!
+                               
+                               RestoreEnvironment!
+                               RestoreControl!
+                               
+                               LinkModule!
+                               InstallModuleEntry!
+                               MarkModuleInvoked!
+                               AliasModuleAsMain!
+                               FinalizeModuleInvokation!
+                               ))
+
+
+
+
+(define-type InstructionSequence (U Symbol
+                                    LinkedLabel
+                                    UnlabeledStatement
+                                    instruction-sequence-list
+                                    instruction-sequence-chunks))
+(define-struct: instruction-sequence-list ([statements : (Listof Statement)])
+  #:transparent)
+(define-struct: instruction-sequence-chunks ([chunks : (Listof InstructionSequence)])
+  #:transparent)
+(define empty-instruction-sequence (make-instruction-sequence-list '()))
+
+
+; (define-predicate Statement? Statement)
+
+
+
+(: statements (InstructionSequence -> (Listof Statement)))
+(define (statements s)
+  (reverse (statements-fold (inst cons Statement (Listof Statement))
+                            '() s)))
+
+
+(: statements-fold (All (A) ((Statement A -> A) A InstructionSequence -> A)))
+(define (statements-fold f acc seq)
+  (cond
+    [(symbol? seq)
+     (f seq acc)]
+    [(LinkedLabel? seq)
+     (f seq acc)]
+    [(UnlabeledStatement? seq)
+     (f seq acc)]
+    [(instruction-sequence-list? seq)
+     (foldl f acc (instruction-sequence-list-statements seq))]
+    [(instruction-sequence-chunks? seq)
+     (foldl (lambda (subseq acc)
+              (statements-fold f acc subseq))
+            acc
+            (instruction-sequence-chunks-chunks seq))]))
+
+
+
+
+
+
+(: append-instruction-sequences (InstructionSequence * -> InstructionSequence))
+(define (append-instruction-sequences . seqs)
+  (append-seq-list seqs))
+
+(: append-2-sequences (InstructionSequence InstructionSequence -> InstructionSequence))
+(define (append-2-sequences seq1 seq2)
+  (make-instruction-sequence-chunks (list seq1 seq2)))
+
+(: append-seq-list ((Listof InstructionSequence) -> InstructionSequence))
+(define (append-seq-list seqs)
+  (if (null? seqs)
+      empty-instruction-sequence
+      (make-instruction-sequence-chunks seqs)))
+
+
+
+
+
+
+
+
+; (define-predicate OpArg? OpArg)

--- a/whalesong/selfhost/compiler/kernel-primitives.rkt
+++ b/whalesong/selfhost/compiler/kernel-primitives.rkt
@@ -1,0 +1,380 @@
+#lang whalesong (require "../selfhost-lang.rkt")
+
+(provide (all-defined-out))
+
+(require "arity-structs.rkt"
+         "lexical-structs.rkt"
+         ; "../type-helpers.rkt"
+         )
+
+
+
+
+(: kernel-module-name? (ModuleLocator -> Boolean))
+;; Produces true if the module is hardcoded.
+(define (kernel-module-name? name)
+
+  
+  (: kernel-locator? (ModuleLocator -> Boolean))
+  (define (kernel-locator? locator)
+    (or (and (eq? (ModuleLocator-name locator) '#%kernel)
+             (eq? (ModuleLocator-real-path locator) '#%kernel))
+        (eq? (ModuleLocator-name locator)
+             'whalesong/lang/kernel.rkt)
+        
+        ;; HACK HACK HACK
+        ;; This is for srcloc:
+        (eq? (ModuleLocator-name locator)
+             'collects/racket/private/kernstruct.rkt)))
+
+
+  (: paramz-locator? (ModuleLocator -> Boolean))
+  (define (paramz-locator? locator)
+    (or (and (eq? (ModuleLocator-name locator) '#%paramz)
+             (eq? (ModuleLocator-real-path locator) '#%paramz))))
+
+
+  (: kernel-module-locator? (ModuleLocator -> Boolean))
+  ;; Produces true if the given module locator should be treated as a primitive root one
+  ;; that is implemented by us.
+  (define (kernel-module-locator? locator)
+    (or (kernel-locator? locator)
+        (paramz-locator? locator)))
+
+  
+  (kernel-module-locator? name))
+
+
+
+;; Given a kernel-labeled ModuleVariable, returns the kernel name for it.
+(: kernel-module-variable->primitive-name (ModuleVariable -> Symbol))
+(define (kernel-module-variable->primitive-name a-modvar)
+  ;; FIXME: remap if the module is something else like whalesong/unsafe/ops
+
+  (ModuleVariable-name a-modvar))
+
+
+
+
+
+
+
+
+
+
+(define-type OperandDomain (U 'number
+                              'string
+                              'vector
+                              'box
+                              'list
+                              'pair
+                              'caarpair
+                              'any))
+
+
+;; The following are primitives that the compiler knows about:
+(define KernelPrimitiveNames (list '+
+                                    '-
+                                    '*
+                                    '/
+                                    'zero?
+                                    'add1
+                                    'sub1
+				    'abs
+                                    '<
+                                    '<=
+                                    '=
+                                    '>
+                                    '>=
+                                    'cons
+                                    'car
+                                    'cdr
+
+                                    
+                                    'caar
+                                    'cdar
+                                    'cadr
+                                    'cddr
+                                    'caaar
+                                    'cdaar
+                                    'cadar
+                                    'cddar
+                                    'caadr
+                                    'cdadr
+                                    'caddr
+                                    'cdddr
+                                    'caaaar
+                                    'cdaaar
+                                    'cadaar
+                                    'cddaar
+                                    'caadar
+                                    'cdadar
+                                    'caddar
+                                    'cdddar
+                                    'caaadr
+                                    'cdaadr
+                                    'cadadr
+                                    'cddadr
+                                    'caaddr
+                                    'cdaddr
+                                    'cadddr
+                                    'cddddr
+
+                                    
+				    'list
+                                    'list?
+                                    'list*
+                                    'list->vector
+                                    'vector->list
+                                    'vector
+                                    'vector-length
+                                    'vector-ref
+                                    'vector-set!
+                                    'make-vector
+                                    'equal?
+                                    'member
+                                    'memq
+                                    'memv
+                                    'memf
+                                    'append
+                                    'reverse
+                                    'length
+				    'pair?
+                                    'null?
+                                    'not
+                                    'eq?
+                                    'eqv?
+				    'remainder
+				    'display
+				    'newline
+				    'call/cc
+				    'box
+				    'unbox
+				    'set-box!
+				    'string-append
+				    'current-continuation-marks
+				    'continuation-mark-set->list
+				    'values
+				    'call-with-values
+                                    'apply
+                                    
+
+                                    'for-each
+                                    'current-print
+
+                                    'make-struct-type
+                                    'current-inspector
+                                    'make-struct-field-accessor
+                                    'make-struct-field-mutator
+                                    
+                                    'gensym
+                                    'srcloc
+                                    'make-srcloc
+                                    'srcloc-source
+                                    'srcloc-line
+                                    'srcloc-column
+                                    'srcloc-position
+                                    'srcloc-span
+
+				    'error
+                                    'raise-type-error
+                                    'raise-mismatch-error
+                                    'struct:exn:fail
+                                    'prop:exn:srclocs
+                                    'make-exn
+                                    'make-exn:fail
+                                    'make-exn:fail:contract
+                                    'make-exn:fail:contract:arity
+                                    'make-exn:fail:contract:variable
+                                    'make-exn:fail:contract:divide-by-zero
+
+                                    'exn:fail?
+                                    'exn:fail:contract?
+                                    'exn:fail:contract:arity?
+                                    
+                                    'exn-message
+                                    'exn-continuation-marks
+
+                                    'hash?
+                                    'hash-equal?
+                                    'hash-eq?
+                                    'hash-eqv?
+                                    'hash
+                                    'hasheqv
+                                    'hasheq
+                                    'make-hash
+                                    'make-hasheqv
+                                    'make-hasheq
+                                    'make-immutable-hash
+                                    'make-immutable-hasheqv
+                                    'make-immutable-hasheq
+                                    'hash-copy
+                                    'hash-ref
+                                    'hash-has-key?
+                                    'hash-set!
+                                    'hash-set
+                                    'hash-remove!
+                                    'hash-remove
+                                    'equal-hash-code
+                                    'hash-count
+                                    'hash-keys
+                                    'hash-values
+                                    
+                                    'string-copy
+
+                                    'unsafe-car
+                                    'unsafe-cdr
+
+                                    'continuation-prompt-available?
+                                    'abort-current-continuation
+                                    'call-with-continuation-prompt
+                                    ))
+; (define-predicate KernelPrimitiveName? KernelPrimitiveName)
+(define (KernelPrimitiveName? s)
+  (member s KernelPrimitiveNames))
+
+
+
+;; These are the primitives that we know how to inline.
+(define KernelPrimitiveNames/Inline (list '+
+                                           '-
+                                           '*
+                                           '/
+                                           'zero?
+                                           'add1
+                                           'sub1
+                                           '<
+                                           '<=
+                                           '=
+                                           '>
+                                           '>=
+                                           'cons
+                                           'car
+                                           'caar
+                                           'cdr
+                                           'list
+                                           'list?
+                                           'pair?
+                                           'null?
+                                           'not
+                                           'eq?
+                                           'vector-ref
+                                           'vector-set!
+                                           ))
+
+(ensure-type-subsetof KernelPrimitiveName/Inline KernelPrimitiveName)
+
+; (define-predicate KernelPrimitiveName/Inline? KernelPrimitiveName/Inline)
+(define (KernelPrimitiveName/Inline? s)
+  (member s KernelPrimitiveNames/Inline))
+
+(define-struct: IncorrectArity ([expected : Arity]))
+
+
+(: kernel-primitive-expected-operand-types (KernelPrimitiveName/Inline Natural -> (U (Listof OperandDomain)
+                                                                                     IncorrectArity)))
+;; Given a primitive and the number of arguments, produces the list of expected domains.
+;; TODO: do something more polymorphic.
+(define (kernel-primitive-expected-operand-types prim arity)
+  (cond
+    [(eq? prim '+)
+     (build-list arity (lambda (i) 'number))]
+
+    [(eq? prim '-)
+     (cond [(> arity 0)
+            (build-list arity (lambda (i) 'number))]
+           [else
+            (make-IncorrectArity (make-ArityAtLeast 1))])]
+
+    [(eq? prim '*)
+     (build-list arity (lambda (i) 'number))]
+
+    [(eq? prim '/)
+     (cond [(> arity 0)
+            (build-list arity (lambda (i) 'number))]
+           [else
+            (make-IncorrectArity (make-ArityAtLeast 1))])]
+
+    [(eq? prim 'zero?)
+     (cond [(= arity 1)
+            (list 'number)]
+           [else
+            (make-IncorrectArity (make-ArityAtLeast 1))])]
+
+    [(eq? prim 'add1)
+     (cond [(= arity 1)
+            (list 'number)]
+           [else
+            (make-IncorrectArity (make-ArityAtLeast 1))])]
+    
+    [(eq? prim 'sub1)
+     (cond [(= arity 1)
+            (list 'number)]
+           [else
+            (make-IncorrectArity (make-ArityAtLeast 1))])]
+                           
+    [(eq? prim '<)
+     (cond [(>= arity 2)
+            (build-list arity (lambda (i) 'number))]
+           [else
+            (make-IncorrectArity (make-ArityAtLeast 2))])]
+    
+    [(eq? prim '<=)
+     (cond [(>= arity 2)
+            (build-list arity (lambda (i) 'number))]
+           [else
+            (make-IncorrectArity (make-ArityAtLeast 2))])]
+    
+    [(eq? prim '=)
+     (cond [(>= arity 2)
+            (build-list arity (lambda (i) 'number))]
+           [else
+            (make-IncorrectArity (make-ArityAtLeast 2))])]
+    
+    [(eq? prim '>)
+     (cond [(>= arity 2)
+            (build-list arity (lambda (i) 'number))]
+           [else
+            (make-IncorrectArity (make-ArityAtLeast 2))])]
+    
+    [(eq? prim '>=)
+     (cond [(>= arity 2)
+            (build-list arity (lambda (i) 'number))]
+           [else
+            (make-IncorrectArity (make-ArityAtLeast 2))])]
+
+    [(eq? prim 'cons)
+     (list 'any 'any)]
+
+    [(eq? prim 'car)
+     (list 'pair)]
+
+    [(eq? prim 'caar)
+     (list 'caarpair)]
+    
+    [(eq? prim 'cdr)
+     (list 'pair)]
+    
+    [(eq? prim 'list)
+     (build-list arity (lambda (i) 'any))]
+
+    [(eq? prim 'list?)
+     (list 'any)]
+
+    [(eq? prim 'pair?)
+     (list 'any)]
+
+    [(eq? prim 'null?)
+     (list 'any)]
+
+    [(eq? prim 'not)
+     (list 'any)]
+
+    [(eq? prim 'eq?)
+     (list 'any 'any)]
+
+    [(eq? prim 'vector-ref)
+     (list 'vector 'number)]
+
+    [(eq? prim 'vector-set!)
+     (list 'vector 'number 'any)]))

--- a/whalesong/selfhost/compiler/lexical-env.rkt
+++ b/whalesong/selfhost/compiler/lexical-env.rkt
@@ -1,0 +1,237 @@
+#lang whalesong (require "../selfhost-lang.rkt")
+
+(require racket/list
+         "lexical-structs.rkt"
+         "../sets.rkt")
+(provide find-variable 
+         extend-lexical-environment
+         extend-lexical-environment/names
+         extend-lexical-environment/parameter-names
+         extend-lexical-environment/boxed-names
+         extend-lexical-environment/placeholders
+         
+         collect-lexical-references
+         lexical-references->compile-time-environment
+         place-prefix-mask
+         adjust-env-reference-depth
+         env-reference-depth)
+
+
+;; Find where the variable is located in the lexical environment
+(: find-variable (Symbol ParseTimeEnvironment -> LexicalAddress))
+(define (find-variable name cenv)
+  (: find-pos (Symbol (Listof (U Symbol ModuleVariable False)) -> Natural))
+  (define (find-pos sym los)
+    (let ([elt (car los)])
+      (cond
+        [(and (symbol? elt) (eq? sym elt))
+         0]
+        [(and (ModuleVariable? elt) (eq? (ModuleVariable-name elt) sym))
+         0]
+        [else
+         (add1 (find-pos sym (cdr los)))])))
+  (let loop ; : LexicalAddress
+        ([cenv cenv] ; : ParseTimeEnvironment 
+         [depth 0])  ; : Natural
+        (cond [(empty? cenv)
+               (error 'find-variable "~s not in lexical environment" name)]
+              [else
+               (let ([elt (first cenv)]) ; : ParseTimeEnvironmentEntry
+                 (cond
+                   [(Prefix? elt)
+                    (let prefix-loop ; : LexicalAddress
+                          ([names (Prefix-names elt)] ; : (Listof (U False Symbol GlobalBucket ModuleVariable))
+                           [pos 0]) ; : Natural 
+                          (cond [(empty? names)
+                                 (loop (rest cenv) (add1 depth))]
+                                [else
+                                 (let ([n (first names)]) ; : (U False Symbol GlobalBucket ModuleVariable) 
+                                       (cond
+                                         [(and (symbol? n) (eq? name n))
+                                          (make-EnvPrefixReference depth pos #f)]
+                                         [(and (ModuleVariable? n) (eq? name (ModuleVariable-name n)))
+                                          (make-EnvPrefixReference depth pos #t)]
+                                         [(and (GlobalBucket? n) (eq? name (GlobalBucket-name n)))
+                                          (make-EnvPrefixReference depth pos #f)]
+                                         [else
+                                          (prefix-loop (rest names) (add1 pos))]))]))]
+                   
+                   [(NamedBinding? elt)
+                    (cond
+                      [(eq? (NamedBinding-name elt) name)
+                       (make-EnvLexicalReference depth (NamedBinding-boxed? elt))]
+                      [else
+                       (loop (rest cenv) (add1 depth))])]
+                   
+                   [(eq? elt #f)
+                    (loop (rest cenv) (add1 depth))]))])))
+
+
+(: list-index (All (A) A (Listof A) -> (U #f Natural)))
+(define (list-index x l)
+  (let loop  ; : (U #f Natural) 
+    ([i  0]  ; : Natural
+     [l  l]) ; : (Listof A)
+        (cond
+          [(empty? l)
+           #f]
+          [(eq? x (first l))
+           i]
+          [else
+           (loop (add1 i) (rest l))])))
+
+
+(: extend-lexical-environment 
+   (ParseTimeEnvironment ParseTimeEnvironmentEntry -> ParseTimeEnvironment))
+;; Extends the lexical environment with procedure bindings.
+(define (extend-lexical-environment cenv extension)
+  (cons extension cenv))
+
+
+
+(: extend-lexical-environment/names (ParseTimeEnvironment (Listof Symbol) (Listof Boolean) ->
+                                                            ParseTimeEnvironment))
+(define (extend-lexical-environment/names cenv names boxed?)
+  (append (map (lambda (n #;[n : Symbol]
+                          b #;[b : Boolean]) (make-NamedBinding n #f b)) names boxed?)
+          cenv))
+
+(: extend-lexical-environment/parameter-names (ParseTimeEnvironment (Listof Symbol) (Listof Boolean) -> ParseTimeEnvironment))
+(define (extend-lexical-environment/parameter-names cenv names boxed?)
+  (append (map (lambda (n b) ; [n : Symbol] [b : Boolean]
+                        (make-NamedBinding n #t b)) names boxed?) 
+          cenv))
+
+(: extend-lexical-environment/boxed-names (ParseTimeEnvironment (Listof Symbol) -> ParseTimeEnvironment))
+(define (extend-lexical-environment/boxed-names cenv names)
+  (append (map (lambda (n) ;  ([n : Symbol]) 
+                 (make-NamedBinding n #f #t)) names)
+          cenv))
+
+
+(: extend-lexical-environment/placeholders
+   (ParseTimeEnvironment Natural -> ParseTimeEnvironment))
+;; Add placeholders to the lexical environment (This represents what happens during procedure application.)
+(define (extend-lexical-environment/placeholders cenv n)
+  (append (build-list n (lambda (i) #;([i : Natural]) #f))
+          cenv))
+  
+
+(: collect-lexical-references ((Listof LexicalAddress) 
+                               -> 
+                               (Listof (U EnvLexicalReference EnvWholePrefixReference))))
+;; Given a list of lexical addresses, computes a set of unique references.
+;; Multiple lexical addresses to a single prefix should be treated identically.
+(define (collect-lexical-references addresses)
+  (let ([prefix-references ((inst new-set EnvWholePrefixReference))] ; : (Setof EnvWholePrefixReference)
+        [lexical-references ((inst new-set EnvLexicalReference))])   ; : (Setof EnvLexicalReference)
+        (let loop ; : (Listof (U EnvLexicalReference EnvWholePrefixReference)) 
+          ([addresses addresses]) ; : (Listof LexicalAddress)
+              (cond 
+                [(empty? addresses)
+                 (append (set->list prefix-references)
+                         ((inst sort
+				EnvLexicalReference 
+				EnvLexicalReference)
+			  (set->list lexical-references)
+			  lex-reference<?))]
+                [else
+                 (let ([addr (first addresses)])
+                   (cond
+                     [(EnvLexicalReference? addr)
+                      (set-insert! lexical-references
+                                   addr)
+                      (loop (rest addresses))]
+                     [(EnvPrefixReference? addr)
+                      (set-insert! prefix-references
+                                   (make-EnvWholePrefixReference (EnvPrefixReference-depth addr)))
+                      (loop (rest addresses))]))]))))
+
+
+
+(: lex-reference<? (EnvLexicalReference EnvLexicalReference -> Boolean))
+(define (lex-reference<? x y)
+  (< (EnvLexicalReference-depth x)
+     (EnvLexicalReference-depth y)))
+
+
+
+(: lexical-references->compile-time-environment ((Listof EnvReference) ParseTimeEnvironment ParseTimeEnvironment
+                                                                     (Listof Symbol)
+                                                                       -> ParseTimeEnvironment))
+;; Creates a lexical environment containing the closure's bindings.
+(define (lexical-references->compile-time-environment refs cenv new-cenv symbols-to-keep)
+  (let loop ; : ParseTimeEnvironment 
+    ([refs (reverse refs)] ; : (Listof EnvReference) 
+     [new-cenv new-cenv])  ; : ParseTimeEnvironment 
+        (cond
+          [(empty? refs)
+           new-cenv]
+          [else
+           (let ([a-ref (first refs)]) ; : EnvReference 
+                 (cond
+                   [(EnvLexicalReference? a-ref)
+                    (loop (rest refs)
+                          (cons (list-ref cenv (EnvLexicalReference-depth a-ref))
+                                new-cenv))]
+                   [(EnvWholePrefixReference? a-ref)
+                    (loop (rest refs)
+                          (cons (place-prefix-mask 
+                                 (ensure-Prefix (list-ref cenv (EnvWholePrefixReference-depth a-ref)))
+                                 symbols-to-keep)
+                                new-cenv))]))])))
+
+(: ensure-Prefix (Any -> Prefix))
+(define (ensure-Prefix x)
+  (if (Prefix? x)
+      x
+      (error 'ensure-Prefix "~s" x)))
+
+
+
+(: place-prefix-mask (Prefix (Listof Symbol) -> Prefix))
+;; Masks elements of the prefix off.
+(define (place-prefix-mask a-prefix symbols-to-keep)
+  (make-Prefix
+   (map (lambda (n) #; ([n : (U False Symbol GlobalBucket ModuleVariable)])
+                 (cond [(eq? n #f)
+                        n]
+                       [(symbol? n)
+                        (if (member n symbols-to-keep)
+                            n
+                            #f)]
+                       [(GlobalBucket? n)
+                        (if (member (GlobalBucket-name n) symbols-to-keep)
+                            n
+                            #f)]
+                       [(ModuleVariable? n)
+                        (if (member (ModuleVariable-name n) symbols-to-keep)
+                            n
+                            #f)]))
+        (Prefix-names a-prefix))))
+
+
+
+(: adjust-env-reference-depth (EnvReference Natural -> EnvReference))
+(define (adjust-env-reference-depth target n)
+  (cond
+    [(EnvLexicalReference? target)
+     (make-EnvLexicalReference (+ n (EnvLexicalReference-depth target))
+                               (EnvLexicalReference-unbox? target))]
+    [(EnvPrefixReference? target)
+     (make-EnvPrefixReference (+ n (EnvPrefixReference-depth target))
+                              (EnvPrefixReference-pos target)
+                              (EnvPrefixReference-modvar? target))]
+    [(EnvWholePrefixReference? target)
+     (make-EnvWholePrefixReference (+ n (EnvWholePrefixReference-depth target)))]))
+
+
+(: env-reference-depth ((U EnvLexicalReference EnvPrefixReference EnvWholePrefixReference) -> Natural))
+(define (env-reference-depth a-ref)
+  (cond
+    [(EnvLexicalReference? a-ref)
+     (EnvLexicalReference-depth a-ref)]
+    [(EnvPrefixReference? a-ref)
+     (EnvPrefixReference-depth a-ref)]
+    [(EnvWholePrefixReference? a-ref)
+     (EnvWholePrefixReference-depth a-ref)]))

--- a/whalesong/selfhost/compiler/lexical-structs.rkt
+++ b/whalesong/selfhost/compiler/lexical-structs.rkt
@@ -1,0 +1,66 @@
+#lang whalesong (require "../selfhost-lang.rkt")
+
+(provide (all-defined-out))
+
+;;;;;;;;;;;;;;
+
+;;  Lexical environments
+
+
+;; A toplevel prefix contains a list of toplevel variables.  Some of the
+;; names may be masked out by #f.
+(define-struct: Prefix ([names : (Listof (U False Symbol GlobalBucket ModuleVariable))])
+  #:transparent)
+
+(define-struct: GlobalBucket ([name : Symbol])
+  #:transparent)
+
+
+;; A ModuleLocator is an identifier for a Module.
+(define-struct: ModuleLocator ([name : Symbol]
+                            [real-path : (U Symbol Path)])
+  #:transparent)
+
+
+(define-struct: ModuleVariable ([name : Symbol]
+                                [module-name : ModuleLocator])
+  #:transparent)
+
+
+(define-struct: NamedBinding ([name : Symbol]
+                              [parameter? : Boolean]
+                              [boxed? : Boolean])
+  #:transparent)
+
+
+(define-type ParseTimeEnvironmentEntry (U Prefix ;; a prefix
+                                            NamedBinding
+                                            False))
+
+
+
+
+;; A compile-time environment is a (listof (listof symbol)).
+;; A lexical address is either a 2-tuple (depth pos), or 'not-found.
+(define-type ParseTimeEnvironment (Listof ParseTimeEnvironmentEntry))
+
+;; A lexical address is a reference to an value in the environment stack.
+(define-type LexicalAddress (U EnvLexicalReference EnvPrefixReference))
+
+
+(define-struct: EnvLexicalReference ([depth : Natural]
+                                     [unbox? : Boolean])
+  #:transparent)
+
+(define-struct: EnvPrefixReference ([depth : Natural]
+                                    [pos : Natural]
+                                    [modvar? : Boolean])
+  #:transparent)
+
+(define-struct: EnvWholePrefixReference ([depth : Natural])
+  #:transparent)
+
+
+;; An environment reference is either lexical or referring to a whole prefix.
+(define-type EnvReference (U EnvLexicalReference
+                             EnvWholePrefixReference))

--- a/whalesong/selfhost/compiler/optimize-il.rkt
+++ b/whalesong/selfhost/compiler/optimize-il.rkt
@@ -1,0 +1,454 @@
+#lang whalesong (require "../selfhost-lang.rkt")
+(require "expression-structs.rkt"
+         "il-structs.rkt"
+         "lexical-structs.rkt"
+         (prefix-in ufind: "../union-find.rkt")
+         racket/list)
+; (require/typed "../logger.rkt" [log-debug (String -> Void)]) ; TODO /soegaard
+(provide optimize-il)
+
+;; perform optimizations on the intermediate language.
+;;
+
+
+
+(: optimize-il ((Listof Statement) -> (Listof Statement)))
+(define (optimize-il statements)
+  ;; For now, replace pairs of PushEnvironment / AssignImmediate(0, ...)
+  ;; We should do some more optimizations here, like peephole...
+  (let* ([statements (filter not-no-op? statements)]
+         [statements (pairwise-reductions statements)]
+         [statements (flatten-adjacent-labels statements)])
+    statements))
+
+
+
+
+(: flatten-adjacent-labels ((Listof Statement) -> (Listof Statement)))
+;; Squash adjacent labels together.
+(define (flatten-adjacent-labels statements)
+  (cond
+   [(empty? statements)
+    empty]
+   [else
+
+    ;; The first pass through will collect adjacent labels and equate them.
+    (define a-forest (ufind:new-forest))
+    (let loop ; : 'ok 
+      ([stmts (rest statements)]       ; : (Listof Statement) 
+       [last-stmt (first statements)]) ; : Statement 
+      (cond
+       [(empty? stmts)
+        'ok]
+       [else
+        (define next-stmt (first stmts))
+        (cond
+         [(and (symbol? last-stmt) (symbol? next-stmt))
+          (log-debug (format "merging label ~a and ~a" last-stmt next-stmt))
+          (ufind:union-set a-forest last-stmt next-stmt)
+          (loop (rest stmts) next-stmt)]
+         
+         ;; If there's a label, immediately followed by a direct Goto jump,
+         ;; just equate the label and the jump.
+         [(and (symbol? last-stmt) (Goto? next-stmt))
+          (define goto-target (Goto-target next-stmt))
+          (cond
+            [(Label? goto-target)
+             (log-debug (format "merging label ~a and ~a" last-stmt (Label-name goto-target)))
+             (ufind:union-set a-forest last-stmt (Label-name goto-target))
+             (loop (rest stmts) next-stmt)]
+            [else
+             (loop (rest stmts) next-stmt)])]
+               
+         [else
+          (loop (rest stmts) next-stmt)])]))
+
+    
+    (: ref (Symbol -> Symbol))
+    (define (ref a-label)
+      (ufind:find-set a-forest a-label))
+
+    
+    (: rewrite-target (Target -> Target))
+    (define (rewrite-target target)
+      target)
+
+    (: rewrite-oparg (OpArg -> OpArg))
+    (define (rewrite-oparg oparg)
+      (cond
+       [(Const? oparg)
+        oparg]
+       [(Label? oparg)
+        (make-Label (ref (Label-name oparg)))]
+       [(Reg? oparg)
+        oparg]
+       [(EnvLexicalReference? oparg)
+        oparg]
+       [(EnvPrefixReference? oparg)
+        oparg]
+       [(EnvWholePrefixReference? oparg)
+        oparg]
+       [(SubtractArg? oparg)
+        oparg]
+       [(ControlStackLabel? oparg)
+        oparg]
+       [(ControlStackLabel/MultipleValueReturn? oparg)
+        oparg]
+       [(ControlFrameTemporary? oparg)
+        oparg]
+       [(CompiledProcedureEntry? oparg)
+        oparg]
+       [(CompiledProcedureClosureReference? oparg)
+        oparg]
+       [(ModuleEntry? oparg)
+        oparg]
+       [(ModulePredicate? oparg)
+        oparg]
+       [(PrimitiveKernelValue? oparg)
+        oparg]
+       [(VariableReference? oparg)
+        oparg]))
+
+
+    (: rewrite-primop (PrimitiveOperator -> PrimitiveOperator))
+    (define (rewrite-primop op)
+      (cond
+       [(GetCompiledProcedureEntry? op)
+        op]
+       [(MakeCompiledProcedure? op)
+        (make-MakeCompiledProcedure (ref (MakeCompiledProcedure-label op))
+                                    (MakeCompiledProcedure-arity op)
+                                    (MakeCompiledProcedure-closed-vals op)
+                                    (MakeCompiledProcedure-display-name op))]
+       
+       [(MakeCompiledProcedureShell? op)
+        (make-MakeCompiledProcedureShell (ref (MakeCompiledProcedureShell-label op))
+                                         (MakeCompiledProcedureShell-arity op)
+                                         (MakeCompiledProcedureShell-display-name op))]
+       
+       
+       [(MakeBoxedEnvironmentValue? op)
+        op]
+       
+       [(CaptureEnvironment? op)
+        op]
+       
+       [(CaptureControl? op)
+        op]
+       
+       [(CallKernelPrimitiveProcedure? op)
+        op]
+       
+       [(ApplyPrimitiveProcedure? op)
+        op]
+
+       [(ModuleVariable? op)
+        op]
+       
+       [(PrimitivesReference? op)
+        op]
+       
+       [(GlobalsReference? op)
+        op]))
+
+
+    (: rewrite-primcmd (PrimitiveCommand -> PrimitiveCommand))
+    (define (rewrite-primcmd cmd)
+      (cond
+       [(InstallModuleEntry!? cmd)
+        (make-InstallModuleEntry! (InstallModuleEntry!-name cmd)
+                                  (InstallModuleEntry!-path cmd)
+                                  (ref (InstallModuleEntry!-entry-point cmd)))]
+       [else
+        cmd]))
+    
+
+    (: rewrite-primtest (PrimitiveTest -> PrimitiveTest))
+    (define (rewrite-primtest test)
+      test)
+
+
+    
+    ;; The second pass will then rewrite references of labels.
+    (let loop ; : (Listof Statement) 
+      ([stmts statements]) ; : (Listof Statement) 
+      (cond
+       [(empty? stmts)
+        empty]
+       [else
+        (define a-stmt (first stmts))
+        (cond
+         [(symbol? a-stmt)
+          (cond
+           [(eq? (ref a-stmt) a-stmt)
+            (cons (ref a-stmt) (loop (rest stmts)))]
+           [else
+            (loop (rest stmts))])]
+
+         [(LinkedLabel? a-stmt)
+          (cons (make-LinkedLabel (LinkedLabel-label a-stmt)
+                                  (ref (LinkedLabel-linked-to a-stmt)))
+                (loop (rest stmts)))]
+         
+         [(DebugPrint? a-stmt)
+          (cons a-stmt (loop (rest stmts)))
+          #;(loop (rest stmts))
+          ]
+
+         [(Comment? a-stmt)
+          ;(loop (rest stmts))
+          (cons a-stmt (loop (rest stmts)))
+          ]
+
+         [(MarkEntryPoint? a-stmt)
+          (cons a-stmt (loop (rest stmts)))]
+         
+         [(AssignImmediate? a-stmt)
+          (cons (make-AssignImmediate (rewrite-target (AssignImmediate-target a-stmt))
+                                               (rewrite-oparg (AssignImmediate-value a-stmt)))
+                (loop (rest stmts)))]
+
+         [(AssignPrimOp? a-stmt)
+          (cons (make-AssignPrimOp (rewrite-target (AssignPrimOp-target a-stmt))
+                                            (rewrite-primop (AssignPrimOp-op a-stmt)))
+                (loop (rest stmts)))]
+
+         [(Perform? a-stmt)
+          (cons (make-Perform (rewrite-primcmd (Perform-op a-stmt)))
+                (loop (rest stmts)))]
+         
+         [(PopEnvironment? a-stmt)
+          (cons (make-PopEnvironment (rewrite-oparg (PopEnvironment-n a-stmt))
+                                     (rewrite-oparg (PopEnvironment-skip a-stmt)))
+                (loop (rest stmts)))]
+
+         [(PushEnvironment? a-stmt)
+          (cons a-stmt (loop (rest stmts)))]
+         
+         [(PushImmediateOntoEnvironment? a-stmt)
+          (cons (make-PushImmediateOntoEnvironment (rewrite-oparg (PushImmediateOntoEnvironment-value a-stmt))
+                                                   (PushImmediateOntoEnvironment-box? a-stmt))
+                (loop (rest stmts)))]
+         
+         [(PushControlFrame/Generic? a-stmt)
+          (cons a-stmt (loop (rest stmts)))]
+
+         [(PushControlFrame/Call? a-stmt)
+          (define a-label (PushControlFrame/Call-label a-stmt))
+          (cons (make-PushControlFrame/Call
+                 (make-LinkedLabel (LinkedLabel-label a-label)
+                                   (ref (LinkedLabel-linked-to a-label))))
+                (loop (rest stmts)))]
+         
+         [(PushControlFrame/Prompt? a-stmt)
+          (define a-label (PushControlFrame/Prompt-label a-stmt))
+          (cons (make-PushControlFrame/Prompt (let ([tag (PushControlFrame/Prompt-tag a-stmt)])
+                                                (if (DefaultContinuationPromptTag? tag)
+                                                    tag
+                                                    (rewrite-oparg tag)))
+                                              (make-LinkedLabel (LinkedLabel-label a-label)
+                                                                (ref (LinkedLabel-linked-to a-label))))
+                (loop (rest stmts)))]
+         
+         [(PopControlFrame? a-stmt)
+          (cons a-stmt (loop (rest stmts)))]
+
+         [(Goto? a-stmt)
+          (define target (Goto-target a-stmt))
+          (cond
+           [(Label? target)
+            (cons (make-Goto (make-Label (ref (Label-name target))))
+                  (loop (rest stmts)))]
+           [else
+            (cons a-stmt (loop (rest stmts)))])]
+
+
+         [(TestAndJump? a-stmt)
+          (cons (make-TestAndJump (rewrite-primtest (TestAndJump-op a-stmt))
+                                           (ref (TestAndJump-label a-stmt)))
+                (loop (rest stmts)))])]))]))
+    
+
+    
+
+
+(: pairwise-reductions ((Listof Statement) -> (Listof Statement)))
+(define (pairwise-reductions statements)
+  (let loop ([statements statements])
+      (cond
+       [(empty? statements)
+        empty]
+       [else
+        (let ([first-stmt (first statements)])
+          (: default (-> (Listof Statement)))
+          (define (default)
+            (cons first-stmt (loop (rest statements))))
+          (cond
+           [(empty? (rest statements))
+            (default)]
+           [else
+            (let ([second-stmt (second statements)])
+              (cond
+               
+               ;; A PushEnvironment followed by a direct AssignImmediate can be reduced to a single
+               ;; instruction.
+               [(and (PushEnvironment? first-stmt)
+                     (equal? first-stmt (make-PushEnvironment 1 #f))
+                     (AssignImmediate? second-stmt))
+                (let ([target (AssignImmediate-target second-stmt)])
+                  (cond
+                   [(equal? target (make-EnvLexicalReference 0 #f))
+                    (loop (cons (make-PushImmediateOntoEnvironment 
+                                 (adjust-oparg-depth 
+                                  (AssignImmediate-value second-stmt) -1)
+                                 #f)
+                                (rest (rest statements))))]
+                   [else
+                    (default)]))]
+
+               ;; Adjacent PopEnvironments with constants can be reduced to single ones
+               [(and (PopEnvironment? first-stmt)
+                     (PopEnvironment? second-stmt))
+                (let ([first-n (PopEnvironment-n first-stmt)]
+                      [second-n (PopEnvironment-n second-stmt)]
+                      [first-skip (PopEnvironment-skip first-stmt)]
+                      [second-skip (PopEnvironment-skip second-stmt)])
+                  (cond [(and (Const? first-n) (Const? second-n) (Const? first-skip) (Const? second-skip))
+                         (let ([first-n-val (Const-const first-n)]
+                               [second-n-val (Const-const second-n)]
+                               [first-skip-val (Const-const first-skip)]
+                               [second-skip-val (Const-const second-skip)])
+                           (cond
+                            [(and (number? first-n-val)
+                                  (number? second-n-val)
+                                  (number? first-skip-val) (= first-skip-val 0)
+                                  (number? second-skip-val) (= second-skip-val 0))
+                             (loop (cons (make-PopEnvironment (make-Const (+ first-n-val second-n-val))
+                                                              (make-Const 0))
+                                         (rest (rest statements))))]
+                            [else
+                             (default)]))]
+                         [else
+                          (default)]))]
+
+               [else
+                (default)]))]))])))
+
+
+(: not-no-op? (Statement -> Boolean))
+(define (not-no-op? stmt) (not (no-op? stmt)))
+
+
+(: no-op? (Statement -> Boolean))
+;; Produces true if the statement should have no effect.
+(define (no-op? stmt)
+  (cond
+    [(symbol? stmt)
+     #f]
+    
+    [(LinkedLabel? stmt)
+     #f]
+    
+    [(DebugPrint? stmt)
+     #f
+     #;#t]
+    
+    [(MarkEntryPoint? stmt)
+     #f]
+    
+    [(AssignImmediate? stmt)
+     (equal? (AssignImmediate-target stmt)
+             (AssignImmediate-value stmt))]
+
+    [(AssignPrimOp? stmt)
+     #f]
+    
+    [(Perform? stmt)
+     #f]
+    
+    [(Goto? stmt)
+     #f]
+    
+    [(TestAndJump? stmt)
+     #f]
+    
+    [(PopEnvironment? stmt)
+     (and (Const? (PopEnvironment-n stmt))
+          (equal? (PopEnvironment-n stmt) 
+                  (make-Const 0)))]
+     
+    [(PushEnvironment? stmt)
+     (= (PushEnvironment-n stmt) 0)]
+    
+    [(PushImmediateOntoEnvironment? stmt)
+     #f]
+
+    [(PushControlFrame/Generic? stmt)
+     #f]
+    
+    [(PushControlFrame/Call? stmt)
+     #f]
+    
+    [(PushControlFrame/Prompt? stmt)
+     #f]
+    
+    [(PopControlFrame? stmt)
+     #f]
+    [(Comment? stmt)
+     #f]))
+
+
+
+
+
+
+(: adjust-oparg-depth (OpArg Integer -> OpArg))
+(define (adjust-oparg-depth oparg n)
+  (cond
+    [(Const? oparg) oparg]
+    [(Label? oparg) oparg]
+    [(Reg? oparg) oparg]
+    [(EnvLexicalReference? oparg)
+     (make-EnvLexicalReference (ensure-natural (+ n (EnvLexicalReference-depth oparg)))
+                               (EnvLexicalReference-unbox? oparg))]
+    [(EnvPrefixReference? oparg)
+     (make-EnvPrefixReference (ensure-natural (+ n (EnvPrefixReference-depth oparg)))
+                              (EnvPrefixReference-pos oparg)
+                              (EnvPrefixReference-modvar? oparg))]
+    [(EnvWholePrefixReference? oparg)
+     (make-EnvWholePrefixReference (ensure-natural (+ n (EnvWholePrefixReference-depth oparg))))]
+    [(SubtractArg? oparg)
+     (make-SubtractArg (adjust-oparg-depth (SubtractArg-lhs oparg) n)
+                       (adjust-oparg-depth (SubtractArg-rhs oparg) n))]
+    [(ControlStackLabel? oparg)
+     oparg]
+    [(ControlStackLabel/MultipleValueReturn? oparg)
+     oparg]
+    [(ControlFrameTemporary? oparg)
+     oparg]
+    [(CompiledProcedureEntry? oparg)
+     (make-CompiledProcedureEntry (adjust-oparg-depth (CompiledProcedureEntry-proc oparg) n))]
+    [(CompiledProcedureClosureReference? oparg)
+     (make-CompiledProcedureClosureReference 
+      (adjust-oparg-depth (CompiledProcedureClosureReference-proc oparg) n)
+      (CompiledProcedureClosureReference-n oparg))]
+    [(PrimitiveKernelValue? oparg)
+     oparg]
+    [(ModuleEntry? oparg)
+     oparg]
+    [(ModulePredicate? oparg)
+     oparg]
+    [(VariableReference? oparg)
+     (let ([t (VariableReference-toplevel oparg)])
+       (make-VariableReference 
+        (make-ToplevelRef (ensure-natural (+ n (ToplevelRef-depth t)))
+                          (ToplevelRef-pos t)
+                          (ToplevelRef-constant? t)
+                          (ToplevelRef-check-defined? t))))]))
+
+
+; (define-predicate natural? Natural)
+(define (ensure-natural x)
+  (if (natural? x)
+      x
+      (error 'ensure-natural)))

--- a/whalesong/selfhost/helpers.rkt
+++ b/whalesong/selfhost/helpers.rkt
@@ -1,0 +1,58 @@
+#lang whalesong (require "selfhost-lang.rkt") (require whalesong/lang/for)
+; #lang typed/racket/base
+(require racket/list)
+(provide list-union list-difference list-intersection unique/eq? unique/equal?)
+
+
+(: list-union ((Listof Symbol) (Listof Symbol) -> (Listof Symbol)))
+(define (list-union s1 s2)
+  (cond [(null? s1) s2]
+        [(memq (car s1) s2)
+         (list-union (cdr s1) s2)]
+        [else (cons (car s1) (list-union (cdr s1) s2))]))
+
+
+(: list-difference ((Listof Symbol) (Listof Symbol) -> (Listof Symbol)))
+(define (list-difference s1 s2)
+  (cond [(null? s1) '()]
+        [(memq (car s1) s2)
+         (list-difference (cdr s1) s2)]
+        [else
+         (cons (car s1) (list-difference (cdr s1) s2))]))
+
+(: list-intersection ((Listof Symbol) (Listof Symbol) -> (Listof Symbol)))
+(define (list-intersection s1 s2)
+  (cond [(null? s1) '()]
+        [(memq (car s1) s2)
+         (cons (car s1) (list-intersection (cdr s1) s2))]
+        [else
+         (list-intersection (cdr s1) s2)]))
+
+
+;; Trying to work around what looks like a bug in typed racket:
+(define string-sort (inst sort String String))
+
+(: unique/eq? ((Listof Symbol) -> (Listof Symbol)))
+(define (unique/eq? los)
+  (let ([ht ; : (HashTable Symbol Boolean) 
+            (make-hasheq)])
+    (for ([l los])
+      (hash-set! ht l #t))
+    (map string->symbol
+         (string-sort
+          (hash-map ht (lambda (k v) ;  ([k : Symbol] [v : Boolean]) 
+                                (symbol->string k)))
+          string<?))))
+
+
+
+(: unique/equal? (All (A) ((Listof A) -> (Listof A))))
+(define (unique/equal? lst)
+  (cond
+    [(empty? lst)
+     empty]
+    [(member (first lst) (rest lst))
+     (unique/equal? (rest lst))]
+    [else
+     (cons (first lst)
+           (unique/equal? (rest lst)))]))

--- a/whalesong/selfhost/js-assembler/assemble-expression.rkt
+++ b/whalesong/selfhost/js-assembler/assemble-expression.rkt
@@ -1,0 +1,112 @@
+#lang whalesong (require "../selfhost-lang.rkt")
+; #lang typed/racket/base
+
+(require "assemble-structs.rkt"
+         "assemble-helpers.rkt"
+         "assemble-open-coded.rkt"
+         "../compiler/lexical-structs.rkt"
+         "../compiler/il-structs.rkt"
+         racket/string)
+
+(provide assemble-op-expression
+         current-interned-constant-closure-table
+         assemble-current-interned-constant-closure-table)
+
+
+
+
+(: current-interned-constant-closure-table (Parameterof (HashTable Symbol MakeCompiledProcedure)))
+(define current-interned-constant-closure-table
+  (make-parameter ((inst make-hasheq Symbol MakeCompiledProcedure))))
+
+
+(: assemble-current-interned-constant-closure-table (-> String))
+(define (assemble-current-interned-constant-closure-table)
+  (string-join (hash-map
+                  (current-interned-constant-closure-table)
+                  (lambda (a-label a-shell) ; ([a-label : Symbol] [a-shell : MakeCompiledProcedure]) 
+                           (format "var ~a_c=new RT.Closure(~a,~a,void(0),~a);"
+                                   (assemble-label (make-Label (MakeCompiledProcedure-label a-shell)))
+                                   (assemble-label (make-Label (MakeCompiledProcedure-label a-shell)))
+                                   (assemble-arity (MakeCompiledProcedure-arity a-shell))
+                                   (assemble-display-name (MakeCompiledProcedure-display-name a-shell)))))
+                 "\n"))
+
+
+(: assemble-op-expression (PrimitiveOperator Blockht -> String))
+(define (assemble-op-expression op blockht)
+  (cond
+    [(GetCompiledProcedureEntry? op)
+     "M.p.label"]
+    
+    [(MakeCompiledProcedure? op)
+     (cond
+      ;; Small optimization: try to avoid creating the array if we know up front
+      ;; that the closure has no closed values.  It's a constant that we lift up to the toplevel.
+      [(null? (MakeCompiledProcedure-closed-vals op))
+       (define assembled-label (assemble-label (make-Label (MakeCompiledProcedure-label op))))
+       (unless (hash-has-key? (current-interned-constant-closure-table) (MakeCompiledProcedure-label op))
+         (hash-set! (current-interned-constant-closure-table)
+                    (MakeCompiledProcedure-label op)
+                    op))
+       (format "~a_c" assembled-label)]
+      [else
+       (format "new RT.Closure(~a,~a,[~a],~a)"
+               (assemble-label (make-Label (MakeCompiledProcedure-label op)))
+               (assemble-arity (MakeCompiledProcedure-arity op))
+               (string-join (map
+                             assemble-env-reference/closure-capture 
+                             ;; The closure values are in reverse order
+                             ;; to make it easier to push, in bulk, into
+                             ;; the environment (which is also in reversed order)
+                             ;; during install-closure-values.
+                             (reverse (MakeCompiledProcedure-closed-vals op)))
+                            ",")
+               (assemble-display-name (MakeCompiledProcedure-display-name op)))])]
+    
+    [(MakeCompiledProcedureShell? op)
+     (format "new RT.Closure(~a,~a,void(0),~a)"
+             (assemble-label (make-Label (MakeCompiledProcedureShell-label op)))
+             (assemble-arity (MakeCompiledProcedureShell-arity op))
+             (assemble-display-name (MakeCompiledProcedureShell-display-name op)))]
+    
+    [(CaptureEnvironment? op)
+     (format "M.e.slice(0, M.e.length-~a)"
+             (CaptureEnvironment-skip op))]
+    
+    [(CaptureControl? op)
+     (format "M.captureControl(~a,~a)"
+             (CaptureControl-skip op)
+             (let ([tag ; : (U DefaultContinuationPromptTag OpArg)
+                    (CaptureControl-tag op)])
+               (cond [(DefaultContinuationPromptTag? tag)
+                      (assemble-default-continuation-prompt-tag)]
+                     [(OpArg? tag)
+                      (assemble-oparg tag blockht)])))]
+
+    
+    [(MakeBoxedEnvironmentValue? op)
+     (format "[M.e[M.e.length-~a]]"
+             (add1 (MakeBoxedEnvironmentValue-depth op)))]
+
+    [(CallKernelPrimitiveProcedure? op)
+     (open-code-kernel-primitive-procedure op blockht)]
+
+    [(ApplyPrimitiveProcedure? op)
+     (format "M.primitives[~s]._i(M)" (symbol->string (ApplyPrimitiveProcedure-name op)))]
+
+    [(ModuleVariable? op)
+     (format "M.modules[~s].getExports().get(~s)"
+             (symbol->string
+              (ModuleLocator-name
+               (ModuleVariable-module-name op)))
+             (symbol->string (ModuleVariable-name op)))]
+
+    [(PrimitivesReference? op)
+     (format "M.primitives[~s]" (symbol->string (PrimitivesReference-name op)))]
+
+    [(GlobalsReference? op)
+     (format "(M.globals[~s]!==void(0)?M.globals[~s]:M.params.currentNamespace.get(~s))" 
+             (symbol->string (GlobalsReference-name op))
+             (symbol->string (GlobalsReference-name op))
+             (symbol->string (GlobalsReference-name op)))]))

--- a/whalesong/selfhost/js-assembler/assemble-helpers.rkt
+++ b/whalesong/selfhost/js-assembler/assemble-helpers.rkt
@@ -1,0 +1,527 @@
+#lang whalesong (require "../selfhost-lang.rkt" "../selfhost-strings.rkt")
+; #lang typed/racket/base
+
+(require "../compiler/il-structs.rkt"
+         "../compiler/expression-structs.rkt"
+         "../compiler/lexical-structs.rkt"
+         "../compiler/arity-structs.rkt"
+         "assemble-structs.rkt"
+         racket/list
+         ; racket/string
+         racket/match)
+
+
+; (require/typed net/base64 [base64-encode (Bytes -> Bytes)])
+(require "../base64.rkt") ; base64-encode : string -> string
+
+(provide assemble-oparg
+         assemble-target
+         assemble-const
+         assemble-lexical-reference
+         assemble-prefix-reference
+         assemble-whole-prefix-reference
+         assemble-reg
+         munge-label-name
+         assemble-label
+         assemble-listof-assembled-values
+	 assemble-default-continuation-prompt-tag
+	 assemble-env-reference/closure-capture
+	 assemble-arity
+	 assemble-jump
+	 assemble-display-name
+	 assemble-location
+         assemble-numeric-constant
+         assemble-module-variable-ref
+         
+         block-looks-like-context-expected-values?
+         block-looks-like-pop-multiple-values-and-continue?
+
+         current-interned-symbol-table
+         assemble-current-interned-symbol-table
+         )
+
+#;(require/typed typed/racket/base
+                 [regexp-split (Regexp String -> (Listof String))])
+
+
+(: assemble-oparg (OpArg Blockht -> String))
+(define (assemble-oparg v blockht)
+  (cond 
+    [(Reg? v)
+     (assemble-reg v)]
+    [(Label? v)
+     (assemble-label v)]
+    [(Const? v)
+     (assemble-const v)]
+    [(EnvLexicalReference? v)
+     (assemble-lexical-reference v)]
+    [(EnvPrefixReference? v)
+     (assemble-prefix-reference v)]
+    [(EnvWholePrefixReference? v)
+     (assemble-whole-prefix-reference v)]
+    [(SubtractArg? v)
+     (assemble-subtractarg v blockht)]
+    [(ControlStackLabel? v)
+     (assemble-control-stack-label v)]
+    [(ControlStackLabel/MultipleValueReturn? v)
+     (assemble-control-stack-label/multiple-value-return v)]
+    [(ControlFrameTemporary? v)
+     (assemble-control-frame-temporary v)]
+    [(CompiledProcedureEntry? v)
+     (assemble-compiled-procedure-entry v blockht)]
+    [(CompiledProcedureClosureReference? v)
+     (assemble-compiled-procedure-closure-reference v blockht)]
+    [(PrimitiveKernelValue? v)
+     (assemble-primitive-kernel-value v)]
+    [(ModuleEntry? v)
+     (assemble-module-entry v)]
+    [(ModulePredicate? v)
+     (assemble-module-predicate v)]
+    [(VariableReference? v)
+     (assemble-variable-reference v)]))
+
+
+
+
+
+
+(: assemble-target (Target -> (String -> String)))
+(define (assemble-target target)
+  (cond
+   [(PrimitivesReference? target)
+    (lambda (rhs) ; ([rhs : String])
+             (format "RT.Primitives[~s]=RT.Primitives[~s]||~a;"
+                     (symbol->string (PrimitivesReference-name target))
+                     (symbol->string (PrimitivesReference-name target))
+                     rhs))]
+   [(ModuleVariable? target)
+    (lambda (rhs) ; ([rhs : String])
+             (format "M.modules[~s].getExports().set(~s,~s);"
+                     (symbol->string (ModuleLocator-name (ModuleVariable-module-name target)))
+                     (symbol->string (ModuleVariable-name target))
+                     rhs))]
+   [else
+    (lambda (rhs) ; ([rhs : String])
+             (format "~a=~a;"
+                     (ann (cond
+                            [(eq? target 'proc)
+                             "M.p"]
+                            [(eq? target 'val)
+                             "M.v"]
+                            [(eq? target 'argcount)
+                             "M.a"]
+                            [(EnvLexicalReference? target)
+                             (assemble-lexical-reference target)]
+                            [(EnvPrefixReference? target)
+                             (assemble-prefix-reference target)]
+                            [(ControlFrameTemporary? target)
+                             (assemble-control-frame-temporary target)]
+                            [(GlobalsReference? target)
+                             (format "M.globals[~s]" (symbol->string (GlobalsReference-name target)))]
+                            [(ModulePrefixTarget? target)
+                             (format "M.modules[~s].prefix"
+                                     (symbol->string (ModuleLocator-name (ModulePrefixTarget-path target))))])
+                           String)
+                     rhs))]))
+
+
+
+(: assemble-control-frame-temporary (ControlFrameTemporary -> String))
+(define (assemble-control-frame-temporary t)
+  (format "M.c[M.c.length-1].~a"
+          (ControlFrameTemporary-name t)))
+
+
+(: current-interned-symbol-table (Parameterof (HashTable Symbol Symbol)))
+(define current-interned-symbol-table
+  (make-parameter ((inst make-hasheq Symbol Symbol))))
+
+
+(: assemble-current-interned-symbol-table (-> String))
+(define (assemble-current-interned-symbol-table)
+  (string-join (hash-map
+                  (current-interned-symbol-table)
+                  (lambda (a-symbol variable-name) ; ([a-symbol : Symbol] [variable-name : Symbol]) 
+                    (format "var ~a=RT.makeSymbol(~s);"
+                            variable-name
+                            (symbol->string a-symbol))))
+                 "\n"))
+  
+;; fixme: use js->string
+(: assemble-const (Const -> String))
+(define (assemble-const stmt)
+  (let loop ; : String ([val : const-value (Const-const stmt)])
+    ([val (Const-const stmt)])
+        (cond [(symbol? val)
+               (define intern-var (hash-ref (current-interned-symbol-table)
+                                            val
+                                            (lambda ()
+                                              (define fresh (gensym 'sym))
+                                              (hash-set! (current-interned-symbol-table) val fresh)
+                                              fresh)))
+               (symbol->string intern-var)
+               ;;(format "RT.makeSymbol(~s)" (symbol->string val))
+               ]
+              [(pair? val)
+               (format "RT.makePair(~a,~a)" 
+                       (loop (car val))
+                       (loop (cdr val)))]
+              [(boolean? val)
+               (if val "true" "false")]
+              [(void? val)
+               "RT.VOID"]
+              [(empty? val)
+               (format "RT.NULL")]
+              [(number? val)
+               (assemble-numeric-constant val)]
+              [(string? val)
+               (format "~s" val)]
+              [(char? val)
+               (format "RT.makeChar(~s)" (string val))]
+              [(bytes? val)
+               ;; This needs to be an array, because this may contain
+               ;; a LOT of elements, and certain JS evaluators will break
+               ;; otherewise.
+               (format "RT.makeBytesFromBase64(~s)"
+                       (bytes->string/utf-8 (base64-encode val)))]
+              [(path? val)
+               (format "RT.makePath(~s)"
+                       (path->string val))]
+              [(vector? val)
+               (format "RT.makeVector([~a])"
+                       (string-join (map loop (vector->list val)) 
+                                    ","))]
+              [(box? val)
+               (format "RT.makeBox(~s)"
+                       (loop (unbox val)))])))
+
+
+
+(: assemble-listof-assembled-values ((Listof String) -> String))
+(define (assemble-listof-assembled-values vals)
+  (let loop ([vals vals])
+    (cond
+      [(empty? vals)
+       "RT.NULL"]
+      [else
+       (format "RT.makePair(~a,~a)" (first vals) (loop (rest vals)))])))
+
+
+
+;; Slightly ridiculous definition, but I need it to get around what appear to
+;; be Typed Racket bugs in its numeric tower.
+; (define-predicate int? Integer)
+(define int? integer?)
+
+
+(: assemble-numeric-constant (Number -> String))
+(define (assemble-numeric-constant a-num)
+
+  (: floating-number->js (Real -> String))
+  (define (floating-number->js a-num)
+    (cond
+     [(eqv? a-num -0.0)
+      "RT.NEGATIVE_ZERO"]
+     [(eqv? a-num +inf.0)
+      "RT.INF"]
+     [(eqv? a-num -inf.0)
+      "RT.NEGATIVE_INF"]
+     [(eqv? a-num +nan.0)
+      "RT.NAN"]
+     [else
+      (string-append "RT.makeFloat(" (number->string a-num) ")")]))
+
+  ;; FIXME: fix the type signature when typed-racket isn't breaking on
+  ;; (define-predicate ExactRational? (U Exact-Rational))
+  (: rational-number->js (Real -> String))
+  (define (rational-number->js a-num)
+    (cond [(= (denominator a-num) 1)
+           (string-append (integer->js (ensure-integer (numerator a-num))))]
+          [else
+           (string-append "RT.makeRational("
+                          (integer->js (ensure-integer (numerator a-num)))
+                          ","
+                          (integer->js (ensure-integer (denominator a-num)))
+                          ")")]))
+
+  
+  (: ensure-integer (Any -> Integer))
+  (define (ensure-integer x)
+    (if (int? x)
+        x
+        (error "not an integer: ~e" x)))
+  
+
+
+  (: integer->js (Integer -> String))
+  (define (integer->js an-int)
+    (cond
+     ;; non-overflow case
+     [(< (abs an-int) 9e15)
+      (number->string an-int)]
+     ;; overflow case
+     [else
+      (string-append "RT.makeBignum("
+                     (format "~s" (number->string an-int))
+                     ")")]))
+
+  (cond 
+   [(and (exact? a-num) (rational? a-num))
+    (rational-number->js a-num)]
+   
+   [(real? a-num)
+    (floating-number->js a-num)]
+   
+   [(complex? a-num)
+    (string-append "RT.makeComplex("
+                   (assemble-numeric-constant (real-part a-num))
+                   ","
+                   (assemble-numeric-constant (imag-part a-num))
+                   ")")]))
+
+
+(: assemble-lexical-reference (EnvLexicalReference -> String))
+(define (assemble-lexical-reference a-lex-ref)
+  (if (EnvLexicalReference-unbox? a-lex-ref)
+      (format "M.e[M.e.length-~a][0]"
+              (add1 (EnvLexicalReference-depth a-lex-ref)))
+      (format "M.e[M.e.length-~a]"
+              (add1 (EnvLexicalReference-depth a-lex-ref)))))
+
+
+(: assemble-prefix-reference (EnvPrefixReference -> String))
+(define (assemble-prefix-reference a-ref)
+  (cond
+   [(EnvPrefixReference-modvar? a-ref)
+    (format "M.e[M.e.length-~a][~a][0][M.e[M.e.length-~a][~a][1]]"
+            (add1 (EnvPrefixReference-depth a-ref))
+            (EnvPrefixReference-pos a-ref)
+            (add1 (EnvPrefixReference-depth a-ref))
+            (EnvPrefixReference-pos a-ref))]
+   [else
+    (format "M.e[M.e.length-~a][~a]"
+            (add1 (EnvPrefixReference-depth a-ref))
+            (EnvPrefixReference-pos a-ref))]))
+
+(: assemble-whole-prefix-reference (EnvWholePrefixReference -> String))
+(define (assemble-whole-prefix-reference a-prefix-ref)
+  (format "M.e[M.e.length-~a]"
+          (add1 (EnvWholePrefixReference-depth a-prefix-ref))))
+
+
+(: assemble-reg (Reg -> String))
+(define (assemble-reg a-reg)
+  (let ([name (Reg-name a-reg)])
+    (cond
+     [(eq? name 'proc)
+      "M.p"]
+     [(eq? name 'val)
+      "M.v"]
+     [(eq? name 'argcount)
+      "M.a"])))
+
+
+(: munge-label-name (Label -> String))
+(define (munge-label-name a-label)
+  (define chunks
+    (string-split-at-non-alphanumeric        ; was (regexp-split #rx"[^a-zA-Z0-9]+" ...)
+     (symbol->string (Label-name a-label))))
+  (cond
+   [(empty? chunks)
+    (error "impossible: empty label ~s" a-label)]
+   [(empty? (rest chunks))
+    (string-append "_" (first chunks))]
+   [else
+    (string-append "_"
+                   (first chunks)
+                   (apply string-append (map string-titlecase (rest chunks))))]))
+
+
+
+(: assemble-label (Label -> String))
+(define (assemble-label a-label)
+  (munge-label-name a-label))
+
+
+
+(: assemble-subtractarg (SubtractArg Blockht -> String))
+(define (assemble-subtractarg s blockht)
+  (format "(~a-~a)"
+          (assemble-oparg (SubtractArg-lhs s) blockht)
+          (assemble-oparg (SubtractArg-rhs s) blockht)))
+
+
+(: assemble-control-stack-label (ControlStackLabel -> String))
+(define (assemble-control-stack-label a-csl)
+  "M.c[M.c.length-1].label")
+
+
+(: assemble-control-stack-label/multiple-value-return (ControlStackLabel/MultipleValueReturn -> String))
+(define (assemble-control-stack-label/multiple-value-return a-csl)
+  "(M.c[M.c.length-1].label.mvr||RT.si_context_expected_1)")
+
+
+
+(: assemble-compiled-procedure-entry (CompiledProcedureEntry Blockht -> String))
+(define (assemble-compiled-procedure-entry a-compiled-procedure-entry blockht)
+  (format "(~a).label"
+          (assemble-oparg (CompiledProcedureEntry-proc a-compiled-procedure-entry)
+                          blockht)))
+
+
+(: assemble-compiled-procedure-closure-reference (CompiledProcedureClosureReference Blockht -> String))
+(define (assemble-compiled-procedure-closure-reference a-ref blockht)
+  (format "(~a).closedVals[(~a).closedVals.length - ~a]"
+          (assemble-oparg (CompiledProcedureClosureReference-proc a-ref) blockht)
+          (assemble-oparg (CompiledProcedureClosureReference-proc a-ref) blockht)
+          (add1 (CompiledProcedureClosureReference-n a-ref))))
+
+
+
+(: assemble-default-continuation-prompt-tag (-> String))
+(define (assemble-default-continuation-prompt-tag)
+  "RT.DEFAULT_CONTINUATION_PROMPT_TAG")
+
+
+
+(: assemble-env-reference/closure-capture (Natural -> String))
+;; When we're capturing the values for a closure, we need to not unbox
+;; lexical references: they must remain boxes.  So all we need is 
+;; the depth into the environment.
+(define (assemble-env-reference/closure-capture depth)
+  (format "M.e[M.e.length-~a]"
+          (add1 depth)))
+
+
+
+; (define-predicate natural? Natural)
+
+(: assemble-arity (Arity -> String))
+(define (assemble-arity an-arity)
+  (cond
+   [(natural? an-arity)
+    (number->string an-arity)]
+   [(ArityAtLeast? an-arity)
+    (format "(RT.makeArityAtLeast(~a))"
+            (ArityAtLeast-value an-arity))]
+   [(listof-atomic-arity? an-arity)
+    (assemble-listof-assembled-values
+     (map
+      (lambda (atomic-arity) ; ([atomic-arity : (U Natural ArityAtLeast)])
+	       (cond
+		[(natural? atomic-arity)
+		 (number->string atomic-arity)]
+		[(ArityAtLeast? atomic-arity)
+		 (format "(RT.makeArityAtLeast(~a))"
+                         (ArityAtLeast-value atomic-arity))]))
+      an-arity))]))
+
+
+
+
+
+
+(: assemble-jump (OpArg Blockht -> String))
+(define (assemble-jump target blockht)
+
+  (define (default)
+    (format "return(~a)(M);" (assemble-oparg target blockht)))
+  
+  ;; Optimization: if the target of the jump goes to a block whose
+  ;; only body is a si-context-expected_1, then jump directly to that code.
+  (cond
+   [(Label? target)
+    (define target-block (hash-ref blockht (Label-name target)))
+    (cond
+     [(block-looks-like-context-expected-values? target-block)
+      =>
+      (lambda (expected)
+        (format "RT.si_context_expected(~a)(M);\n" expected))]
+     [else
+      (default)])]
+   [else
+    (default)]))
+
+
+
+(: block-looks-like-context-expected-values? (BasicBlock -> (U Natural False)))
+(define (block-looks-like-context-expected-values? a-block)
+  (match (BasicBlock-stmts a-block)
+    [(list (struct Perform ((struct RaiseContextExpectedValuesError! (expected))))
+           stmts ...)
+     expected]
+    [else
+     #f]))
+
+
+(: block-looks-like-pop-multiple-values-and-continue? (BasicBlock -> (U False)))
+(define (block-looks-like-pop-multiple-values-and-continue? a-block)
+  ;; FIXME!
+  #f)
+
+
+
+
+
+
+(: assemble-display-name ((U Symbol LamPositionalName) -> String))
+(define (assemble-display-name name)
+  (cond
+   [(symbol? name)
+    (format "~s" (symbol->string name))]
+   [(LamPositionalName? name)
+    ;; FIXME: record more interesting information here.
+    (format "~s" (symbol->string (LamPositionalName-name name)))]))
+
+
+
+
+(: assemble-location ((U Reg Label) Blockht -> String))
+(define (assemble-location a-location blockht)
+  (cond
+     [(Reg? a-location)
+      (assemble-reg a-location)]
+     [(Label? a-location)
+      (assemble-label a-location)]))
+
+
+(: assemble-primitive-kernel-value (PrimitiveKernelValue -> String))
+(define (assemble-primitive-kernel-value a-prim)
+  (format "M.primitives[~s]" (symbol->string (PrimitiveKernelValue-id a-prim))))
+
+
+
+(: assemble-module-entry (ModuleEntry -> String))
+(define (assemble-module-entry entry)
+  (format "M.modules[~s].label"
+          (symbol->string (ModuleLocator-name (ModuleEntry-name entry)))))
+
+
+(: assemble-module-variable-ref (ModuleVariable -> String))
+(define (assemble-module-variable-ref var)
+  (format "M.modules[~s].getExports().get(~s)"
+          (symbol->string (ModuleLocator-name (ModuleVariable-module-name var)))
+          (symbol->string (ModuleVariable-name var))))
+
+
+(: assemble-module-predicate (ModulePredicate -> String))
+(define (assemble-module-predicate entry)
+  (define modname (ModulePredicate-module-name entry))
+  (define pred (ModulePredicate-pred entry))
+  (cond
+   [(eq? pred 'invoked?)
+    (format "M.modules[~s].isInvoked"
+            (symbol->string (ModuleLocator-name modname)))]
+
+   [(eq? pred 'linked?)
+    (format "(M.installedModules[~s]!==void(0)&&M.modules[~s]!==undefined)"
+            (symbol->string (ModuleLocator-name modname))
+            (symbol->string (ModuleLocator-name modname)))]))
+
+
+(: assemble-variable-reference (VariableReference -> String))
+(define (assemble-variable-reference varref)
+  (let ([t (VariableReference-toplevel varref)])
+    (format "(new RT.VariableReference(M.e[M.e.length-~a],~a))"
+            (add1 (ToplevelRef-depth t))
+            (ToplevelRef-pos t))))

--- a/whalesong/selfhost/js-assembler/assemble-open-coded.rkt
+++ b/whalesong/selfhost/js-assembler/assemble-open-coded.rkt
@@ -1,0 +1,232 @@
+#lang whalesong (require "../selfhost-lang.rkt")
+(require (for-syntax racket/base))
+
+; #lang typed/racket/base
+
+(require "assemble-helpers.rkt"
+         "../compiler/il-structs.rkt"
+         "../compiler/lexical-structs.rkt"
+         "../compiler/kernel-primitives.rkt"
+         "assemble-structs.rkt"
+         racket/string
+         racket/list
+         typed/rackunit)
+
+(provide open-code-kernel-primitive-procedure)
+
+;; Conservative estimate: JavaScript evaluators don't like to eat
+;; more than some number of arguments at once.
+(define MAX-JAVASCRIPT-ARGS-AT-ONCE 100)
+
+
+;; Workaround for a regression in Racket 5.3.1: 
+(define-syntax (mycase stx)
+  (syntax-case stx ()
+    [(_ op ((x ...) b ...) ...)
+     #'(let ([v op])
+         (cond
+           [(or (eqv? v 'x) ...) b ...] ...))]))
+
+
+(: open-code-kernel-primitive-procedure (CallKernelPrimitiveProcedure Blockht -> String))
+(define (open-code-kernel-primitive-procedure op blockht)
+  (let* ([operator (CallKernelPrimitiveProcedure-operator op)] ;: KernelPrimitiveName/Inline
+         [operands  (map (lambda (op)  #;([op : (U OpArg ModuleVariable)]) ; : (Listof String)
+                           (cond
+                             [(OpArg? op)
+                              (assemble-oparg op blockht)]
+                             [(ModuleVariable? op)
+                              (assemble-module-variable-ref op)]))
+                         (CallKernelPrimitiveProcedure-operands op))]
+         [checked-operands ; : (Listof String)
+          (map (lambda (dom pos rand typecheck?) 
+                 ; ([dom : OperandDomain] [pos : Natural] [rand : String]
+                 ;  [typecheck? : Boolean])
+                 (maybe-typecheck-operand operator dom pos rand typecheck?))
+               (CallKernelPrimitiveProcedure-expected-operand-types op)
+               (build-list (length operands) (lambda (i) #;([i : Natural]) i))
+               operands
+               (CallKernelPrimitiveProcedure-typechecks? op))])
+    (mycase operator
+            [(+)
+             (cond [(empty? checked-operands)
+                    (assemble-numeric-constant 0)]
+                   [(< (length operands) MAX-JAVASCRIPT-ARGS-AT-ONCE)
+                    (format "RT.checkedAdd(M, ~a)" (string-join operands ","))]
+                   [else
+                    (format "RT.checkedAddSlowPath(M, [~a])" (string-join operands ","))])]
+            
+            [(-)
+             (cond [(empty? (rest checked-operands))
+                    (format "RT.checkedNegate(M, ~a)" (first operands))]
+                   [(< (length operands) MAX-JAVASCRIPT-ARGS-AT-ONCE)
+                    (format "RT.checkedSub(M, ~a)" (string-join operands ","))]
+                   [else
+                    (format "RT.checkedSubSlowPath(M, [~a])" (string-join operands ","))])]
+            
+            [(*)
+             (cond [(empty? checked-operands)
+                    (assemble-numeric-constant 1)]
+                   [(< (length operands) MAX-JAVASCRIPT-ARGS-AT-ONCE)
+                    (format "RT.checkedMul(M, ~a)" (string-join operands ","))]
+                   [else
+                    (format "RT.checkedMulSlowPath(M, [~a])" (string-join operands ","))])]
+            
+            [(/)
+             (assemble-binop-chain "plt.baselib.numbers.divide" checked-operands)]
+            
+            [(zero?)
+             (format "RT.checkedIsZero(M, ~a)" (first operands))]
+            
+            [(add1)
+             (format "RT.checkedAdd1(M, ~a)" (first operands))]
+            
+            [(sub1)
+             (format "RT.checkedSub1(M, ~a)" (first operands))]
+            
+            [(<)
+             (assemble-boolean-chain "plt.baselib.numbers.lessThan" checked-operands)]
+            
+            [(<=)
+             (assemble-boolean-chain "plt.baselib.numbers.lessThanOrEqual" checked-operands)]
+            
+            [(=)
+             (cond
+               [(< (length operands) MAX-JAVASCRIPT-ARGS-AT-ONCE)
+                (format "RT.checkedNumEquals(M, ~a)" (string-join operands ","))]
+               [else
+                (format "RT.checkedNumEqualsSlowPath(M, [~a])" (string-join operands ","))])]
+            
+            [(>)
+             (cond
+               [(< (length operands) MAX-JAVASCRIPT-ARGS-AT-ONCE)
+                (format "RT.checkedGreaterThan(M, ~a)" (string-join operands ","))]
+               [else
+                (format "RT.checkedGreaterThanSlowPath(M, [~a])" (string-join operands ","))])]
+            
+            [(>=)
+             (assemble-boolean-chain "plt.baselib.numbers.greaterThanOrEqual" checked-operands)]
+            
+            [(cons)
+             (format "RT.makePair(~a,~a)"
+                     (first checked-operands)
+                     (second checked-operands))]
+            
+            [(car)
+             (format "RT.checkedCar(M, ~a)" (first operands))]
+            
+            [(caar)
+             (format "(~a).first.first" (first checked-operands))]
+            
+            [(cdr)
+             (format "RT.checkedCdr(M, ~a)" (first operands))]
+            
+            [(list)
+             (let loop ([checked-operands checked-operands])
+               (assemble-listof-assembled-values checked-operands))]
+            
+            [(list?)
+             (format "RT.isList(~a)"
+                     (first checked-operands))]
+            
+            [(vector-ref)
+             (format "RT.checkedVectorRef(M, ~a)"
+                     (string-join operands ","))]
+            
+            [(vector-set!)
+             (format "RT.checkedVectorSet(M, ~a)"
+                     (string-join operands ","))]
+            
+            [(pair?)
+             (format "RT.isPair(~a)"
+                     (first checked-operands))]
+            
+            [(null?)
+             (format "(~a===RT.NULL)" (first checked-operands))]
+            
+            [(not)
+             (format "(~a===false)" (first checked-operands))]
+            
+            [(eq?)
+             (format "(~a===~a)" (first checked-operands) (second checked-operands))])))
+
+
+
+(: assemble-binop-chain (String (Listof String) -> String))
+(define (assemble-binop-chain rator rands)
+  (cond
+    [(empty? rands)
+     ""]
+    [(empty? (rest rands))
+     (first rands)]
+    [else
+     (assemble-binop-chain
+      rator
+      (cons (string-append rator "(" (first rands) ", " (second rands) ")")
+            (rest (rest rands))))]))
+
+(check-equal? (assemble-binop-chain "plt.baselib.numbers.add" '("3" "4" "5"))
+              "plt.baselib.numbers.add(plt.baselib.numbers.add(3, 4), 5)")
+(check-equal? (assemble-binop-chain "plt.baselib.numbers.subtract" '("0" "42"))
+              "plt.baselib.numbers.subtract(0, 42)")
+
+
+
+
+(: assemble-boolean-chain (String (Listof String) -> String))
+(define (assemble-boolean-chain rator rands)
+  (string-append "("
+                 (string-join (let loop  ([rands  rands])
+                                (cond
+                                  [(empty? rands)
+                                   '()]
+                                  [(empty? (rest rands))
+                                   '()]
+                                  [else
+                                   (cons (format "(~a(~a,~a))" rator (first rands) (second rands))
+                                         (loop (rest rands)))]))
+                              "&&")
+                 ")"))
+
+
+
+
+
+(: assemble-domain-check (Symbol OperandDomain String Natural -> String))
+(define (assemble-domain-check caller domain operand-string pos)
+  (cond
+    [(eq? domain 'any)
+     operand-string]
+    [else
+     (let ([predicate ; : String
+            (case domain
+              [(number)
+               (format "RT.isNumber")]
+              [(string)
+               (format "RT.isString")]
+              [(list)
+               (format "RT.isList")]
+              [(pair)
+               (format "RT.isPair")]
+              [(caarpair)
+               (format "RT.isCaarPair")]
+              [(box)
+               (format "RT.isBox")]
+              [(vector)
+               (format "RT.isVector")])])
+       (format "RT.testArgument(M,~s,~a,~a,~a,~s)"
+               (symbol->string domain)
+               predicate
+               operand-string
+               pos
+               (symbol->string caller)))]))
+
+
+(: maybe-typecheck-operand (Symbol OperandDomain Natural String Boolean -> String))
+;; Adds typechecks if we can't prove that the operand is of the required type.
+(define (maybe-typecheck-operand caller domain-type position operand-string typecheck?)
+  (cond
+    [typecheck?
+     (assemble-domain-check caller domain-type operand-string position)]
+    [else
+     operand-string]))

--- a/whalesong/selfhost/js-assembler/assemble-perform-statement.rkt
+++ b/whalesong/selfhost/js-assembler/assemble-perform-statement.rkt
@@ -1,0 +1,220 @@
+#lang whalesong (require "../selfhost-lang.rkt")
+(require whalesong/lang/for)
+; #lang typed/racket/base
+(require "assemble-helpers.rkt"
+         "../compiler/il-structs.rkt"
+         "../compiler/expression-structs.rkt"
+	 "../compiler/lexical-structs.rkt"
+         "../compiler/kernel-primitives.rkt"
+         "../parameters.rkt"
+         "assemble-structs.rkt"
+	 racket/string)
+
+(provide assemble-op-statement)
+
+
+
+(: assemble-op-statement (PrimitiveCommand Blockht -> String))
+(define (assemble-op-statement op blockht)  
+  (cond 
+    
+    [(CheckToplevelBound!? op)
+     (format "if (M.e[M.e.length-~a][~a]===void(0)){ RT.raiseUnboundToplevelError(M,M.e[M.e.length-~a].names[~a]); }"
+             (add1 (CheckToplevelBound!-depth op))
+             (CheckToplevelBound!-pos op)
+             (add1 (CheckToplevelBound!-depth op))
+             (CheckToplevelBound!-pos op))]
+    [(CheckGlobalBound!? op)
+     (format "if (M.globals[~s]===void(0)&&M.params.currentNamespace.get(~s)===void(0)){ RT.raiseUnboundToplevelError(M,~s); }"
+             (symbol->string (CheckGlobalBound!-name op))
+             (symbol->string (CheckGlobalBound!-name op))
+             (symbol->string (CheckGlobalBound!-name op)))]
+
+
+    [(CheckClosureAndArity!? op)
+     "RT.checkClosureAndArity(M);"]
+    
+    [(CheckPrimitiveArity!? op)
+     "RT.checkPrimitiveArity(M);"]
+
+    [(ExtendEnvironment/Prefix!? op)
+     (let (; : (Listof (U Symbol False GlobalBucket ModuleVariable))
+           [names (ExtendEnvironment/Prefix!-names op)]) 
+           (format "M.e.push([~a]);M.e[M.e.length-1].names=[~a];"
+                   (string-join (map
+                                 (lambda (n) ; ([n : (U Symbol False GlobalBucket ModuleVariable)])
+                                          (cond [(symbol? n)
+                                                 (format "M.params.currentNamespace.get(~s)||M.primitives[~s]"
+                                                         (symbol->string n) 
+                                                         (symbol->string n))]
+                                                [(eq? n #f)
+                                                 "false"]
+                                                [(GlobalBucket? n)
+                                                 (format "M.globals[~s]!==void(0)?M.globals[~s]:M.params.currentNamespace.get(~s)"
+                                                         (symbol->string (GlobalBucket-name n))
+                                                         (symbol->string (GlobalBucket-name n))
+                                                         (symbol->string (GlobalBucket-name n)))]
+                                                ;; FIXME:  this should be looking at the module path and getting
+                                                ;; the value here!  It shouldn't be looking into Primitives...
+                                                [(ModuleVariable? n)
+                                                 (cond
+                                                  [(kernel-module-name? (ModuleVariable-module-name n))
+                                                   (format "M.primitives[~s]"
+                                                           (symbol->string
+                                                            (kernel-module-variable->primitive-name n)))]
+                                                  [else
+                                                   (define module-name
+                                                     (symbol->string
+                                                            (ModuleLocator-name
+                                                             (ModuleVariable-module-name n))))
+                                                   (format "[M.modules[~s].prefix,M.modules[~s].getPrefixOffset(~s),{moduleName:~s,name:~s}]"
+                                                           module-name
+                                                           module-name
+                                                           (symbol->string (ModuleVariable-name n))
+                                                           module-name
+                                                           (symbol->string (ModuleVariable-name n)))])]))
+                                 names)
+                                ",")
+                   (string-join (map
+				 (lambda (n) ; ([n : (U Symbol False GlobalBucket ModuleVariable)])
+					  (cond
+					   [(symbol? n)
+					    (format "~s" (symbol->string n))]
+					   [(eq? n #f)
+					    "false"]
+                                           [(GlobalBucket? n)
+                                            (format "~s" (symbol->string (GlobalBucket-name n)))]
+					   [(ModuleVariable? n)
+					    (format "~s" (symbol->string (ModuleVariable-name n)))]))
+				 names)
+                                ",")))]
+    
+    [(InstallClosureValues!? op)
+     (format "M.e.push(~a);"
+             (string-join (build-list (InstallClosureValues!-n op)
+                                      (lambda (i) ; ([i : Natural])
+                                               (format "M.p.closedVals[~a]" i)))
+                          ","))]
+    
+    [(RestoreEnvironment!? op)
+     "M.e=M.e[M.e.length-2].slice(0);"]
+    
+    [(RestoreControl!? op)
+     (format "M.restoreControl(~a);"
+             (let ([tag ;  : (U DefaultContinuationPromptTag OpArg)
+			 (RestoreControl!-tag op)])
+               (cond
+                 [(DefaultContinuationPromptTag? tag)
+                  (assemble-default-continuation-prompt-tag)]
+                 [(OpArg? tag)
+                  (assemble-oparg tag blockht)])))]
+    
+    [(FixClosureShellMap!? op)
+     (format "M.e[M.e.length-~a].closedVals=[~a];"
+             (add1 (FixClosureShellMap!-depth op))
+             (string-join (map
+                           assemble-env-reference/closure-capture 
+                           ;; The closure values are in reverse order
+                           ;; to make it easier to push, in bulk, into
+                           ;; the environment (which is also in reversed order)
+                           ;; during install-closure-values.
+                           (reverse (FixClosureShellMap!-closed-vals op)))
+                          ","))]
+    
+    [(SetFrameCallee!? op)
+     (format "M.c[M.c.length-1].p=~a;"
+             (assemble-oparg (SetFrameCallee!-proc op)
+                             blockht))]
+    
+    [(SpliceListIntoStack!? op)
+     (format "M.spliceListIntoStack(~a);"
+             (assemble-oparg (SpliceListIntoStack!-depth op)
+                             blockht))]
+
+    [(UnspliceRestFromStack!? op)
+     (format "M.unspliceRestFromStack(~a,~a);"
+             (assemble-oparg (UnspliceRestFromStack!-depth op) blockht)
+             (assemble-oparg (UnspliceRestFromStack!-length op) blockht))]
+
+    [(InstallContinuationMarkEntry!? op)
+     (string-append "M.installContinuationMarkEntry("
+                    "M.c[M.c.length-1].pendingContinuationMarkKey,"
+                    "M.v);")]
+
+    [(RaiseContextExpectedValuesError!? op)
+     (format "RT.raiseContextExpectedValuesError(M,~a);"
+             (RaiseContextExpectedValuesError!-expected op))]
+
+
+    [(RaiseArityMismatchError!? op)
+     (format "RT.raiseArityMismatchError(M,~a,~a);"
+             (assemble-oparg (RaiseArityMismatchError!-proc op) blockht)
+             (assemble-oparg (RaiseArityMismatchError!-received op) blockht))]
+
+
+    [(RaiseOperatorApplicationError!? op)
+     (format "RT.raiseOperatorApplicationError(M,~a);"
+             (assemble-oparg (RaiseOperatorApplicationError!-operator op) blockht))]
+
+
+    [(RaiseUnimplementedPrimitiveError!? op)
+     (format "RT.raiseUnimplementedPrimitiveError(M,~s);"
+             (symbol->string (RaiseUnimplementedPrimitiveError!-name op)))]
+    
+    [(LinkModule!? op)
+     (format "RT.PAUSE(
+                  function(restart){
+                      var modname = ~s;
+                      RT.currentModuleLoader(M,modname,
+                                             function(){
+                                                 M.modules[modname] = M.installedModules[modname]();
+                                                 restart(~a);
+                                             },
+                                             function(){
+                                                 RT.raiseModuleLoadingError(M,modname); 
+                                             });
+                  });"
+             (symbol->string (ModuleLocator-name (LinkModule!-path op)))
+             (assemble-label (make-Label (LinkModule!-label op))))]
+    
+    [(InstallModuleEntry!? op)
+     (format "M.installedModules[~s]=function(){return new RT.ModuleRecord(~s,~a);}"
+             (symbol->string (ModuleLocator-name (InstallModuleEntry!-path op)))
+             (symbol->string (InstallModuleEntry!-name op))
+             (assemble-label (make-Label (InstallModuleEntry!-entry-point op))))]
+
+    [(MarkModuleInvoked!? op)
+     (format "M.modules[~s].isInvoked=true;"
+             (symbol->string (ModuleLocator-name (MarkModuleInvoked!-path op))))]
+
+
+    [(AliasModuleAsMain!? op)
+     (format "M.mainModules.push(~s);"
+             (symbol->string (ModuleLocator-name (AliasModuleAsMain!-from op))))]
+
+    [(FinalizeModuleInvokation!? op)
+     (define modname (symbol->string (ModuleLocator-name (FinalizeModuleInvokation!-path op))))
+     (string-append
+      "(function (selfMod,ns,extNs,prefix) {"
+      (string-join (for/list ([a-provide (FinalizeModuleInvokation!-provides op)])
+                     (cond [(kernel-module-name? (ModuleProvide-source a-provide))
+                            (format "ns.set(~s, M.primitives[~s]);"
+                                    (symbol->string (ModuleProvide-external-name a-provide))
+                                    (symbol->string (ModuleProvide-internal-name a-provide)))]
+                           [(equal? (ModuleLocator-name (ModuleProvide-source a-provide))
+                                    (ModuleLocator-name (FinalizeModuleInvokation!-path op)))
+                            (string-append (format "ns.set(~s, prefix[selfMod.getPrefixOffset(~s)]);"
+                                                   (symbol->string (ModuleProvide-internal-name a-provide))
+                                                   (symbol->string (ModuleProvide-internal-name a-provide)))
+                                           ;; For JS-derived code, it might be inconvenient to get the bindings by internal
+                                           ;; name.  We assign a separate mapping here to make it easier to access.
+                                           (format "extNs.set(~s, prefix[selfMod.getPrefixOffset(~s)]);"
+                                                   (symbol->string (ModuleProvide-external-name a-provide))
+                                                   (symbol->string (ModuleProvide-internal-name a-provide))))]
+                           [else
+                            (format "ns.set(~s, M.modules[~s].getExports().get(~s));" 
+                                    (symbol->string (ModuleProvide-external-name a-provide))
+                                    (symbol->string (ModuleLocator-name (ModuleProvide-source a-provide)))
+                                    (symbol->string (ModuleProvide-internal-name a-provide)))]))
+                   "")
+      (format "}(M.modules[~s],M.modules[~s].getExports(),M.modules[~s].getExternalExports(),M.modules[~s].prefix));" modname modname modname modname))]))

--- a/whalesong/selfhost/js-assembler/assemble-structs.rkt
+++ b/whalesong/selfhost/js-assembler/assemble-structs.rkt
@@ -1,0 +1,21 @@
+#lang whalesong (require "../selfhost-lang.rkt")
+; #lang typed/racket/base
+
+(provide (all-defined-out))
+
+
+(require "../compiler/il-structs.rkt")
+
+
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Assembly
+
+(define-struct: BasicBlock ([name : Symbol] 
+                            [stmts : (Listof UnlabeledStatement)]) 
+  #:transparent)
+
+
+
+;; Represents a hashtable from symbols to basic blocks
+(define-type Blockht (HashTable Symbol BasicBlock))

--- a/whalesong/selfhost/js-assembler/assemble.rkt
+++ b/whalesong/selfhost/js-assembler/assemble.rkt
@@ -1,0 +1,714 @@
+#lang whalesong (require "../selfhost-lang.rkt" whalesong/lang/for)
+; #lang typed/racket/base
+
+
+;; Assembles the statement stream into JavaScript.
+
+
+(require "assemble-structs.rkt"
+         "assemble-helpers.rkt"
+         "assemble-expression.rkt"
+         "assemble-perform-statement.rkt"
+         "fracture.rkt"
+         "../compiler/il-structs.rkt"
+         "../sets.rkt"
+         "../helpers.rkt"
+         racket/string
+         racket/list)
+; (require/typed "../logger.rkt" [log-debug (String -> Void)])
+
+(provide assemble/write-invoke
+         assemble-statement)
+
+
+
+
+
+;; Parameter that controls the generation of a trace.
+(define emit-debug-trace? #f)
+
+
+
+
+
+(: assemble/write-invoke ((Listof Statement) Output-Port (U 'no-trampoline 'without-preemption 'with-preemption) -> Void))
+;; Writes out the JavaScript code that represents the anonymous invocation expression.
+;; What's emitted is a function expression that, when invoked, runs the
+;; statements.
+(define (assemble/write-invoke stmts op trampoline-option)
+  (parameterize ([current-interned-symbol-table ((inst make-hash Symbol Symbol))]
+                 [current-interned-constant-closure-table ((inst make-hash Symbol MakeCompiledProcedure))])
+    (display "(function(M, success, fail, params) {\n" op)
+    (display "\"use strict\";\n" op)
+    (display "var param;\n" op)
+    (display "var RT = plt.runtime;\n" op)
+    
+    (define-values (basic-blocks entry-points) (fracture stmts))
+    
+    (: function-entry-and-exit-names (Setof Symbol))
+    (define function-entry-and-exit-names
+      (list->set (get-function-entry-and-exit-names stmts)))
+    
+    (: blockht : Blockht)
+    (define blockht (make-hash))
+    
+    (for ([b basic-blocks])
+      (hash-set! blockht (BasicBlock-name b) b))
+    
+    (write-blocks basic-blocks
+                  blockht
+                  (list->set entry-points)
+                  function-entry-and-exit-names
+                  op)
+    (write-linked-label-attributes stmts blockht op)
+    (display (assemble-current-interned-symbol-table) op)
+    (display (assemble-current-interned-constant-closure-table) op)
+    
+    (display "M.params.currentErrorHandler = fail;\n" op)
+    (display  #<<EOF
+for (param in params) {
+    if (Object.hasOwnProperty.call(params, param)) {
+        M.params[param] = params[param];
+    }
+}
+EOF
+              op)
+    (cond [(eq? trampoline-option 'no-trampoline)
+           ;; If it's a module statement, we just want to call it directly, to get things loaded.
+           (fprintf op "~a(M); })"
+                    (assemble-label (make-Label (BasicBlock-name (first basic-blocks)))))]
+          [else
+           ;; Otherwise, we want to run under a trampolining context.
+           (display "M.c.push(new RT.CallFrame(function(M){ setTimeout(success, 0); },M.p));\n" op)
+           (fprintf op "M.trampoline(~a, ~a); })"
+                    (assemble-label (make-Label (BasicBlock-name (first basic-blocks))))
+                    (cond [(eq? trampoline-option 'with-preemption)
+                           "false"]
+                          [(eq? trampoline-option 'without-preemption)
+                           "true"]))])))
+
+
+
+(: write-blocks ((Listof BasicBlock) Blockht (Setof Symbol) (Setof Symbol) Output-Port -> Void))
+;; Write out all the basic blocks associated to an entry point.
+(define (write-blocks blocks blockht entry-points function-entry-and-exit-names op)  
+  
+  ;; Since there may be cycles between the blocks, we cut the cycles by
+  ;; making them entry points as well.
+  (insert-cycles-as-entry-points! entry-points blockht)
+  
+  (set-for-each (lambda (s) #;([s : Symbol])
+                  (log-debug (format "Emitting code for basic block ~s" s))
+                  (assemble-basic-block (hash-ref blockht s) 
+                                        blockht
+                                        entry-points
+                                        function-entry-and-exit-names
+                                        op)
+                  (newline op))
+                entry-points))
+
+
+
+(: insert-cycles-as-entry-points! ((Setof Symbol) Blockht -> 'ok))
+(define (insert-cycles-as-entry-points! entry-points blockht)
+  (define visited ((inst new-seteq Symbol)))
+  
+  (: loop ((Listof Symbol) -> 'ok))
+  (define (loop queue)
+    (cond
+      [(empty? queue)
+       'ok]
+      [else
+       ;; Visit the next one.
+       (define next-to-visit (first queue))
+       (cond
+         [(set-contains? visited next-to-visit)
+          #;(unless (set-contains? entry-points next-to-visit)
+              (log-debug (format "Promoting ~a to an entry point" next-to-visit))
+              (set-insert! entry-points next-to-visit))
+          (loop (rest queue))]
+         [else
+          (set-insert! visited next-to-visit)
+          (set-insert! entry-points next-to-visit)
+          (loop (list-union (basic-block-out-edges (hash-ref blockht next-to-visit))
+                            (rest queue)))])]))
+  
+  (loop (set->list entry-points)))
+
+
+
+
+
+(: write-linked-label-attributes ((Listof Statement) Blockht Output-Port -> 'ok))
+(define (write-linked-label-attributes stmts blockht op)
+  (cond
+    [(empty? stmts)
+     'ok]
+    [else
+     (let ([stmt ; : Statement 
+                 (first stmts)])
+       
+       (define (next) (write-linked-label-attributes (rest stmts) blockht op))
+       
+       (cond
+         [(symbol? stmt)
+          (next)]
+         [(LinkedLabel? stmt)
+          ;; Setting up multiple-value-return.
+          ;; Optimization: in the most common case (expecting only one), we optimize away
+          ;; the assignment, because there's a distinguished instruction, and it's implied
+          ;; that if .mvr is missing, that the block only expects one.
+          (define linked-to-block (hash-ref blockht (LinkedLabel-linked-to stmt)))
+          (cond
+            [(block-looks-like-context-expected-values? linked-to-block)
+             => (lambda (expected)
+                  (cond
+                    [(= expected 1)
+                     (void)]
+                    [else
+                     (fprintf op "~a.mvr=RT.si_context_expected(~a);\n"
+                              (munge-label-name (make-Label (LinkedLabel-label stmt)))
+                              expected)]))]
+            [else
+             (fprintf op "~a.mvr=~a;\n" 
+                      (munge-label-name (make-Label (LinkedLabel-label stmt)))
+                      (assemble-label (make-Label (LinkedLabel-linked-to stmt))))])
+          (next)]
+         [(DebugPrint? stmt)
+          (next)]
+         [(MarkEntryPoint? stmt)
+          (next)]
+         [(AssignImmediate? stmt)
+          (next)]
+         [(AssignPrimOp? stmt)
+          (next)]
+         [(Perform? stmt)
+          (next)]
+         [(TestAndJump? stmt)
+          (next)]
+         [(Goto? stmt)
+          (next)]
+         [(PushEnvironment? stmt)
+          (next)]
+         [(PopEnvironment? stmt)
+          (next)]
+         [(PushImmediateOntoEnvironment? stmt)
+          (next)]
+         [(PushControlFrame/Generic? stmt)
+          (next)]
+         [(PushControlFrame/Call? stmt)
+          (next)]
+         [(PushControlFrame/Prompt? stmt)
+          (next)]
+         [(PopControlFrame? stmt)
+          (next)]
+         [(Comment? stmt)
+          (next)]))]))
+
+
+
+
+
+
+(: assemble-basic-block (BasicBlock Blockht (Setof Symbol) (Setof Symbol) Output-Port -> 'ok))
+(define (assemble-basic-block a-basic-block blockht entry-points function-entry-and-exit-names op)
+  (cond
+    [(block-looks-like-context-expected-values? a-basic-block)
+     =>
+     (lambda (expected)
+       (cond
+         [(= expected 1)
+          'ok]
+         [else
+          (fprintf op "var ~a=RT.si_context_expected(~a);\n"
+                   (munge-label-name (make-Label (BasicBlock-name a-basic-block)))
+                   expected)
+          'ok]))]
+    
+    [(block-looks-like-pop-multiple-values-and-continue? a-basic-block)
+     =>
+     (lambda (target)
+       (fprintf op "var ~a=RT.si_pop_multiple-values-and-continue(~a);"
+                (munge-label-name (make-Label (BasicBlock-name a-basic-block)))
+                target))]
+    [else
+     (default-assemble-basic-block a-basic-block blockht entry-points function-entry-and-exit-names op)]))
+
+
+
+(: default-assemble-basic-block (BasicBlock Blockht (Setof Symbol) (Setof Symbol) Output-Port -> 'ok))
+(define (default-assemble-basic-block a-basic-block blockht entry-points function-entry-and-exit-names op)
+  (fprintf op "var ~a=function(M){"
+           (assemble-label (make-Label (BasicBlock-name a-basic-block))))
+  (define is-self-looping?
+    (let ()
+      (cond [(not (empty? (BasicBlock-stmts a-basic-block)))
+             (define last-stmt
+               (last (BasicBlock-stmts a-basic-block)))
+             (cond
+               [(Goto? last-stmt)
+                (define target (Goto-target last-stmt))
+                (equal? target (make-Label (BasicBlock-name a-basic-block)))]
+               [else #f])]
+            [else #f])))
+  (cond
+    [is-self-looping?
+     (fprintf op "while(true){")
+     (when (set-contains? function-entry-and-exit-names (BasicBlock-name a-basic-block))
+       (fprintf op "if(--M.cbt<0){throw ~a;}\n"
+                (assemble-label (make-Label (BasicBlock-name a-basic-block)))))
+     
+     (assemble-block-statements (BasicBlock-name a-basic-block)
+                                (drop-right (BasicBlock-stmts a-basic-block) 1)
+                                blockht
+                                entry-points
+                                op)
+     (fprintf op "}")]
+    [else
+     (when (set-contains? function-entry-and-exit-names (BasicBlock-name a-basic-block))
+       (fprintf op "if(--M.cbt<0){throw ~a;}\n"
+                (assemble-label (make-Label (BasicBlock-name a-basic-block)))))
+     (assemble-block-statements (BasicBlock-name a-basic-block)
+                                (BasicBlock-stmts a-basic-block)
+                                blockht
+                                entry-points
+                                op)])
+  (display "};\n" op)
+  'ok)
+
+
+
+
+(: assemble-block-statements (Symbol (Listof UnlabeledStatement) Blockht (Setof Symbol) Output-Port -> 'ok))
+(define (assemble-block-statements name stmts blockht entry-points op)
+  
+  (: default (UnlabeledStatement -> 'ok))
+  (define (default stmt)
+    ;(when (and (empty? (rest stmts))
+    ;           (not (Goto? stmt)))
+    ;  (log-debug (format "Last statement of the block ~a is not a goto" name)))
+    
+    (display (assemble-statement stmt blockht) op)
+    (newline op)
+    (assemble-block-statements name
+                               (rest stmts) 
+                               blockht
+                               entry-points
+                               op))
+  
+  (cond [(empty? stmts)
+         'ok]
+        [else
+         (define stmt (first stmts))
+         (cond
+           [(MarkEntryPoint? stmt)
+            (default stmt)]
+           
+           [(DebugPrint? stmt)
+            (default stmt)]
+           
+           [(AssignImmediate? stmt)
+            (default stmt)]
+           
+           [(AssignPrimOp? stmt)
+            (default stmt)]
+           
+           [(Perform? stmt)
+            (default stmt)]
+           
+           [(TestAndJump? stmt)
+            (define test (TestAndJump-op stmt))
+            
+            (: test-code String)
+            (define test-code (cond
+                                [(TestFalse? test)
+                                 (format "if(~a===false)"
+                                         (assemble-oparg (TestFalse-operand test)
+                                                         blockht))]
+                                [(TestTrue? test)
+                                 (format "if(~a!==false)"
+                                         (assemble-oparg (TestTrue-operand test)
+                                                         blockht))]
+                                [(TestOne? test)
+                                 (format "if(~a===1)"
+                                         (assemble-oparg (TestOne-operand test)
+                                                         blockht))]
+                                [(TestZero? test)
+                                 (format "if(~a===0)"
+                                         (assemble-oparg (TestZero-operand test)
+                                                         blockht))]
+                                
+                                [(TestClosureArityMismatch? test)
+                                 (format "if(!RT.isArityMatching((~a).racketArity,~a))"
+                                         (assemble-oparg (TestClosureArityMismatch-closure test)
+                                                         blockht)
+                                         (assemble-oparg (TestClosureArityMismatch-n test)
+                                                         blockht))]))
+            (display test-code op)
+            (display "{" op)
+            (cond
+              [(set-contains? entry-points (TestAndJump-label stmt))
+               (display (assemble-jump (make-Label (TestAndJump-label stmt))
+                                       blockht) op)]
+              [else
+               (assemble-block-statements (BasicBlock-name
+                                           (hash-ref blockht (TestAndJump-label stmt)))
+                                          (BasicBlock-stmts 
+                                           (hash-ref blockht (TestAndJump-label stmt)))
+                                          blockht
+                                          entry-points
+                                          op)])
+            (display "}else{" op)
+            (assemble-block-statements name (rest stmts) blockht entry-points op)
+            (display "}" op)
+            'ok]
+           
+           [(Goto? stmt)
+            (let loop ([stmt stmt])
+              (define target (Goto-target stmt))
+              (cond
+                [(Label? target)
+                 (define target-block (hash-ref blockht (Label-name target)))
+                 (define target-name (BasicBlock-name target-block))
+                 (define target-statements (BasicBlock-stmts target-block))
+                 (cond
+                   ;; Optimization: if the target block consists of a single goto,
+                   ;; inline and follow the goto.
+                   [(and (not (empty? target-statements))
+                         (= 1 (length target-statements))
+                         (Goto? (first target-statements)))
+                    (loop (first target-statements))]
+                   [(set-contains? entry-points (Label-name target))
+                    (display (assemble-statement stmt blockht) op)
+                    'ok]
+                   [else
+                    (log-debug (format "Assembling inlined jump into ~a" (Label-name target)) )
+                    (assemble-block-statements target-name
+                                               target-statements
+                                               blockht
+                                               entry-points
+                                               op)])]
+                [(Reg? target)
+                 (display (assemble-statement stmt blockht) op)
+                 'ok]
+                [(ModuleEntry? target)
+                 (display (assemble-statement stmt blockht) op)
+                 'ok]
+                [(CompiledProcedureEntry? target)
+                 (display (assemble-statement stmt blockht) op)
+                 'ok]))]
+           
+           
+           [(PushControlFrame/Generic? stmt)
+            (default stmt)]
+           
+           [(PushControlFrame/Call? stmt)
+            (default stmt)]
+           
+           [(PushControlFrame/Prompt? stmt)
+            (default stmt)]
+           
+           [(PopControlFrame? stmt)
+            (default stmt)]
+           
+           [(PushEnvironment? stmt)
+            (default stmt)]
+           
+           [(PopEnvironment? stmt)
+            (default stmt)]
+           
+           [(PushImmediateOntoEnvironment? stmt)
+            (default stmt)]
+           [(Comment? stmt)
+            (default stmt)])]))
+
+
+
+
+(: basic-block-out-edges (BasicBlock -> (Listof Symbol)))
+;; Returns the neighboring blocks of this block.
+(define (basic-block-out-edges a-block)
+  
+  (: loop ((Listof UnlabeledStatement) -> (Listof Symbol)))
+  (define (loop stmts)
+    
+    (: default (-> (Listof Symbol)))
+    (define (default)
+      (loop (rest stmts)))
+    
+    (cond [(empty? stmts)
+           empty]
+          [else
+           (define stmt (first stmts))
+           (cond
+             [(MarkEntryPoint? stmt)
+              (default)]
+             
+             [(DebugPrint? stmt)
+              (default)]
+             
+             [(AssignImmediate? stmt)
+              (default)]
+             
+             [(AssignPrimOp? stmt)
+              (default)]
+             
+             [(Perform? stmt)
+              (default)]
+             
+             [(TestAndJump? stmt)
+              (cons (TestAndJump-label stmt)
+                    (loop (rest stmts)))]
+             
+             [(Goto? stmt)
+              (define target (Goto-target stmt))
+              (cond
+                [(Label? target)
+                 (cons (Label-name target)
+                       (loop (rest stmts)))]
+                [(Reg? target)
+                 (default)]
+                [(ModuleEntry? target)
+                 (default)]
+                [(CompiledProcedureEntry? target)
+                 (default)])]
+             
+             [(PushControlFrame/Generic? stmt)
+              (default)]
+             
+             [(PushControlFrame/Call? stmt)
+              (default)]
+             
+             [(PushControlFrame/Prompt? stmt)
+              (default)]
+             
+             [(PopControlFrame? stmt)
+              (default)]
+             
+             [(PushEnvironment? stmt)
+              (default)]
+             
+             [(PopEnvironment? stmt)
+              (default)]
+             
+             [(PushImmediateOntoEnvironment? stmt)
+              (default)]
+             [(Comment? stmt)
+              (default)])]))
+  
+  (loop (BasicBlock-stmts a-block)))
+
+
+
+
+
+
+
+
+(: assemble-statement (UnlabeledStatement Blockht -> String))
+;; Generates the code to assemble a statement.
+(define (assemble-statement stmt blockht)
+  (define assembled
+    (cond
+      [(MarkEntryPoint? stmt)
+       ;; Marking the entry point to the lambda should have no other effect.
+       ""]
+
+      [(DebugPrint? stmt)
+       (format "M.params.currentOutputPort.writeDomNode(M, $('<span/>').text(~a));"
+               (assemble-oparg (DebugPrint-value stmt)
+                               blockht))]
+      [(AssignImmediate? stmt)
+       (let ([t ; : (String -> String) 
+                (assemble-target (AssignImmediate-target stmt))]
+             [v ; : OpArg 
+                (AssignImmediate-value stmt)])
+         (t (assemble-oparg v blockht)))]
+      
+      [(AssignPrimOp? stmt)
+       ((assemble-target (AssignPrimOp-target stmt))
+        (assemble-op-expression (AssignPrimOp-op stmt)
+                                blockht))]
+      
+      [(Perform? stmt)
+       (assemble-op-statement (Perform-op stmt) blockht)]
+      
+      [(TestAndJump? stmt)
+       (let* ([test ; : PrimitiveTest 
+                    (TestAndJump-op stmt)]
+               [jump ; : String
+                     (assemble-jump 
+                               (make-Label (TestAndJump-label stmt))
+                               blockht)])
+         ;; to help localize type checks, we add a type annotation here.
+         (ann (cond
+                [(TestFalse? test)
+                 (format "if(~a===false){~a}"
+                         (assemble-oparg (TestFalse-operand test)
+                                         blockht)
+                         jump)]
+                [(TestTrue? test)
+                 (format "if(~a!==false){~a}"
+                         (assemble-oparg (TestTrue-operand test)
+                                         blockht)
+                         jump)]
+                [(TestOne? test)
+                 (format "if(~a===1){~a}"
+                         (assemble-oparg (TestOne-operand test)
+                                         blockht)
+                         jump)]
+                [(TestZero? test)
+                 (format "if(~a===0){~a}"
+                         (assemble-oparg (TestZero-operand test)
+                                         blockht)
+                         jump)]
+                [(TestClosureArityMismatch? test)
+                 (format "if(!RT.isArityMatching((~a).racketArity,~a)){~a}"
+                         (assemble-oparg (TestClosureArityMismatch-closure test)
+                                         blockht)
+                         (assemble-oparg (TestClosureArityMismatch-n test)
+                                         blockht)
+                         jump)])
+              String))]
+      
+      [(Goto? stmt)
+       (assemble-jump (Goto-target stmt)
+                      blockht)]
+      
+      [(PushControlFrame/Generic? stmt)
+       "M.c.push(new RT.Frame());"]
+      
+      [(PushControlFrame/Call? stmt)
+       (format "M.c.push(new RT.CallFrame(~a,M.p));" 
+               (let ([label ; : (U Symbol LinkedLabel)
+                            (PushControlFrame/Call-label stmt)])
+                 (cond
+                   [(symbol? label) 
+                    (assemble-label (make-Label label))]
+                   [(LinkedLabel? label) 
+                    (assemble-label (make-Label (LinkedLabel-label label)))])))]
+      
+      [(PushControlFrame/Prompt? stmt)
+       (format "M.c.push(new RT.CallFrame(~a,M.p)); M.addPrompt(~a,false,M.e.length);" 
+               (let ([label ; : (U Symbol LinkedLabel) 
+                            (PushControlFrame/Prompt-label stmt)])
+                 (cond
+                   [(symbol? label) 
+                    (assemble-label (make-Label label))]
+                   [(LinkedLabel? label) 
+                    (assemble-label (make-Label (LinkedLabel-label label)))]))
+               
+               (let ([tag ; : (U DefaultContinuationPromptTag OpArg)
+                      (PushControlFrame/Prompt-tag stmt)])
+                 (cond
+                   [(DefaultContinuationPromptTag? tag)
+                    (assemble-default-continuation-prompt-tag)]
+                   [(OpArg? tag)
+                    (assemble-oparg tag blockht)])))]
+      
+      [(PopControlFrame? stmt)
+       "M.c.pop();"]
+      
+      [(PushEnvironment? stmt)
+       (cond [(= (PushEnvironment-n stmt) 0)
+              ""]
+             [(PushEnvironment-unbox? stmt)
+              (format "M.e.push(~a);" (string-join
+                                       (build-list (PushEnvironment-n stmt) 
+                                                   (lambda (i)  ; ([i : Natural])
+                                                     "[void(0)]"))
+                                       ","))]
+             [else
+              (format "M.e.push(~a);" (string-join
+                                       (build-list (PushEnvironment-n stmt) 
+                                                   (lambda (i) ;  ([i : Natural])
+                                                     "void(0)"))
+                                       ","))
+              ;(format "M.e.length+=~a;" (PushEnvironment-n stmt))
+              ])]
+      [(PopEnvironment? stmt)
+       (let ([skip ; : OpArg
+                   (PopEnvironment-skip stmt)])
+         (cond
+           [(and (Const? skip) (= (ensure-natural (Const-const skip)) 0))
+            (cond [(equal? (PopEnvironment-n stmt)
+                           (make-Const 1))
+                   "M.e.pop();"]
+                  [else
+                   (format "M.e.length-=~a;"
+                           (assemble-oparg (PopEnvironment-n stmt) blockht))])]
+           [else
+            (define skip (PopEnvironment-skip stmt))
+            (define n (PopEnvironment-n stmt))
+            (cond
+              [(and (Const? skip) (Const? n))
+               (format "M.e.splice(M.e.length-~a,~a);"
+                       (+ (ensure-natural (Const-const skip))
+                          (ensure-natural (Const-const n)))
+                       (Const-const n))]
+              [else
+               (format "M.e.splice(M.e.length-(~a+~a),~a);"
+                       (assemble-oparg skip blockht)
+                       (assemble-oparg n blockht)
+                       (assemble-oparg n blockht))])]))]
+      
+      [(PushImmediateOntoEnvironment? stmt)
+       (format "M.e.push(~a);"
+               (let ([val-string ; : String
+                                  (cond [(PushImmediateOntoEnvironment-box? stmt)
+                                         (format "[~a]" (assemble-oparg (PushImmediateOntoEnvironment-value stmt)
+                                                                        blockht))]
+                                        [else
+                                         (assemble-oparg (PushImmediateOntoEnvironment-value stmt)
+                                                         blockht)])])
+                 val-string))]
+      [(Comment? stmt)
+       (format "//~s\n" (Comment-val stmt))]))
+  (cond
+    [emit-debug-trace?
+     (string-append 
+      (format "if(window.console!==void(0)&&typeof(window.console.log)==='function'){window.console.log(~s);\n}"
+              (format "~a" stmt))
+      assembled)]
+    [else
+     assembled]))
+
+
+; (define-predicate natural? Natural)
+
+(: ensure-natural (Any -> Natural))
+(define (ensure-natural n)
+  (if (natural? n)
+      n
+      (error 'ensure-natural)))
+
+
+
+(: get-function-entry-and-exit-names ((Listof Statement) -> (Listof Symbol)))
+(define (get-function-entry-and-exit-names stmts)
+  (cond
+    [(empty? stmts)
+     '()]
+    [else
+     (define first-stmt (first stmts))
+     (cond
+       [(MarkEntryPoint? first-stmt)
+        (cons (MarkEntryPoint-label first-stmt)
+              (get-function-entry-and-exit-names (rest stmts)))]
+       [(LinkedLabel? first-stmt)
+        (cons (LinkedLabel-label first-stmt)
+              (cons (LinkedLabel-linked-to first-stmt)
+                    (get-function-entry-and-exit-names (rest stmts))))]
+       [(AssignPrimOp? first-stmt)
+        (define op (AssignPrimOp-op first-stmt))
+        (cond
+          [(MakeCompiledProcedure? op)
+           (cons (MakeCompiledProcedure-label op)
+                 (get-function-entry-and-exit-names (rest stmts)))]
+          [(MakeCompiledProcedureShell? first-stmt)
+           (cons (MakeCompiledProcedureShell-label op)
+                 (get-function-entry-and-exit-names (rest stmts)))]
+          [else
+           (get-function-entry-and-exit-names (rest stmts))])]
+       [else
+        (get-function-entry-and-exit-names (rest stmts))])]))

--- a/whalesong/selfhost/js-assembler/cache.rkt
+++ b/whalesong/selfhost/js-assembler/cache.rkt
@@ -1,0 +1,7 @@
+#lang whalesong
+(define-struct cached-entry (real-path ;; path to a module. 
+                             whalesong-version ;; string
+                             md5   ;; md5 of the original source in real-path
+                             bytes)
+  #:transparent) ;; bytes
+

--- a/whalesong/selfhost/js-assembler/check-valid-module-source.rkt
+++ b/whalesong/selfhost/js-assembler/check-valid-module-source.rkt
@@ -1,0 +1,135 @@
+#lang racket/base
+
+(provide check-valid-module-source
+         [struct-out exn:invalid-module-source])
+
+(require syntax/kerncase
+         syntax/modresolve
+         racket/path
+         "../parameters.rkt"
+         "../parser/path-rewriter.rkt")
+
+
+(struct exn:invalid-module-source exn:fail ())
+
+
+(define (abort-abort #:reason (reason "Invalid module source"))
+  (fprintf (current-report-port) "Aborting compilation.\n")
+  (raise (exn:invalid-module-source reason
+                                    (current-continuation-marks))))
+
+
+(define ns (make-base-namespace))
+
+
+
+
+(define (looks-like-old-moby-or-js-vm? module-source-path)
+  (or (call-with-input-file* module-source-path
+                             (lambda (ip) (regexp-match #px"^\\s*#lang\\s+planet\\s+dyoo/moby" ip)))
+      (call-with-input-file* module-source-path
+                             (lambda (ip) (regexp-match #px"^\\s*#lang\\s+planet\\s+dyoo/js-vm" ip)))))
+
+
+
+
+(define (check-valid-module-source module-source-path)
+  ;; Check that the file exists.
+  (unless (file-exists? module-source-path)
+    (fprintf (current-report-port) "ERROR: Can't read a Racket module from ~e.  The file does not appear to exist.\n"
+             module-source-path)
+    (abort-abort))
+
+
+  ;; Is the file one that we know how to symbolically resolve?
+  (cond [(rewrite-path module-source-path)
+         (void)]
+        [else
+         (fprintf (current-report-port)
+                  "ERROR: The file ~e appears to be outside the root package directory ~e.  You may need to use --root-dir.\n"
+                 module-source-path
+                 (current-root-path))
+         (abort-abort)])
+
+  
+  ;; Does it look like something out of moby or js-vm?  Abort early, because if we don't do
+  ;; this up front, Racket will try to install the deprecated module, and that's bad.
+  (when (looks-like-old-moby-or-js-vm? module-source-path)
+    (fprintf (current-report-port) "ERROR: The program in ~e appears to be written using the deprecated project js-vm or Moby.\n\nPlease change the lang line to:\n\n    #lang whalesong\n\ninstead.\n"
+            module-source-path)
+    (abort-abort))
+    
+
+  ;; Check that it looks like a module.
+  (define stx
+    (with-handlers ([exn:fail?
+                     (lambda (exn)
+                       ;; We can't even get the bytecode for the file.
+                       ;; Fail immediately.
+                       (fprintf (current-report-port) "ERROR: Can't read a Racket module from ~e.  The file may be ill-formed or be written in a language that Whalesong doesn't recognize.\n"
+                               module-source-path)
+                       (fprintf (current-report-port) "\nFor reference, the error message produced when trying to read ~e is:\n\n" module-source-path)
+                       (fprintf (current-report-port) "~a\n" (exn-message exn))
+                       (abort-abort))])
+      (parameterize ([read-accept-reader #t]
+                     [read-accept-lang #t])
+        (call-with-input-file* module-source-path
+                               (lambda (ip)
+                                 (port-count-lines! ip)
+                                 (read-syntax module-source-path ip))))))
+
+  (define relative-language-stx
+    (kernel-syntax-case stx #t
+      [(module name language body ...)
+       #'language]
+      [else
+       (fprintf (current-report-port) "ERROR: Can't read a Racket module from ~e.  The file exists, but does not appear to be a Racket module.\n"
+               module-source-path)
+       (abort-abort)]))
+
+
+  ;; Check that the module is written in a language that we allow.
+  (define resolved-language-path
+    (resolve-module-path (syntax->datum relative-language-stx)
+                         module-source-path))
+  (cond
+   [(eq? resolved-language-path '#%kernel)
+    (void)]
+   [(path? resolved-language-path)
+    (define normalized-resolved-language-path
+      (normalize-path resolved-language-path))
+
+    (cond
+     [(within-root-path? normalized-resolved-language-path)
+      (void)]
+
+     [(within-whalesong-path? normalized-resolved-language-path)
+      (void)]
+
+     [else
+      ;; Something bad is about to happen, as the module is written
+      ;; in a language that we, most likely, can't compile.
+      ;;
+      ;; Let's see if we can provide a good error message here
+      (fprintf (current-report-port) "ERROR: The file ~e is a Racket module, but is written in the language ~a [~e], which Whalesong does not know how to compile.\n"
+              module-source-path
+              (syntax->datum relative-language-stx)
+              normalized-resolved-language-path)
+      (abort-abort)])])
+
+
+  ;; Once we know that the module is in a language we allow, we 
+  ;; check that the file compiles.
+  (with-handlers ([exn:fail?
+                   (lambda (exn)
+                     (fprintf (current-report-port) "ERROR: the racket module ~e raises a compile-time error during compilation." module-source-path)
+                     (fprintf (current-report-port) "\n\nFor reference, the error message produced during compilation is the following:\n\n")
+                     (fprintf (current-report-port) "~a\n" (exn-message exn))
+                     (newline (current-report-port))
+                     (abort-abort))])
+    (parameterize ([current-namespace ns]
+                   [current-load-relative-directory
+                    (path-only module-source-path)]
+                   [current-directory
+                    (path-only module-source-path)])
+      (compile stx))))

--- a/whalesong/selfhost/js-assembler/collect-jump-targets.rkt
+++ b/whalesong/selfhost/js-assembler/collect-jump-targets.rkt
@@ -1,0 +1,357 @@
+#lang whalesong (require "../selfhost-lang.rkt")
+; #lang typed/racket/base
+(require "../compiler/expression-structs.rkt"
+         "../compiler/il-structs.rkt"
+         "../compiler/lexical-structs.rkt"
+         "../helpers.rkt"
+         "../parameters.rkt"
+         racket/list)
+
+(provide collect-general-jump-targets
+         collect-entry-points)
+
+
+
+(: collect-general-jump-targets ((Listof Statement) -> (Listof Symbol)))
+;; collects all the labels that are potential targets for GOTOs or branches.
+(define (collect-general-jump-targets stmts)
+  
+  (: collect-statement (Statement -> (Listof Symbol)))
+  (define (collect-statement stmt)
+    (cond
+      [(symbol? stmt)
+       empty]
+      [(LinkedLabel? stmt)
+       (list (LinkedLabel-label stmt)
+             (LinkedLabel-linked-to stmt))]
+      [(DebugPrint? stmt)
+       empty]
+      [(MarkEntryPoint? stmt)
+       (list (MarkEntryPoint-label stmt))]
+      [(AssignImmediate? stmt)
+       (let ([v ; : OpArg 
+                (AssignImmediate-value stmt)])
+         (collect-input v))]
+      [(AssignPrimOp? stmt)
+       (collect-primitive-operator (AssignPrimOp-op stmt))]
+      [(Perform? stmt)
+       (collect-primitive-command (Perform-op stmt))]
+      [(TestAndJump? stmt)
+       (list (TestAndJump-label stmt))]
+      [(Goto? stmt)
+       (collect-input (Goto-target stmt))]
+      [(PushEnvironment? stmt)
+       empty]
+      [(PopEnvironment? stmt)
+       empty]
+      [(PushImmediateOntoEnvironment? stmt)
+       (collect-input (PushImmediateOntoEnvironment-value stmt))]
+      [(PushControlFrame/Generic? stmt)
+       empty]
+      [(PushControlFrame/Call? stmt)
+       (label->labels (PushControlFrame/Call-label stmt))]
+      [(PushControlFrame/Prompt? stmt)
+       (label->labels (PushControlFrame/Prompt-label stmt))]
+      [(PopControlFrame? stmt)
+       empty]
+      [(Comment? stmt)
+       empty]))
+  
+  
+  
+  (: collect-input (OpArg -> (Listof Symbol)))
+  (define (collect-input an-input)
+    (cond
+      [(Reg? an-input)
+       empty]
+      [(Const? an-input)
+       empty]
+      [(Label? an-input)
+       (list (Label-name an-input))]
+      [(EnvLexicalReference? an-input)
+       empty]
+      [(EnvPrefixReference? an-input)
+       empty]
+      [(EnvWholePrefixReference? an-input)
+       empty]
+      [(SubtractArg? an-input)
+       (append (collect-input (SubtractArg-lhs an-input))
+               (collect-input (SubtractArg-rhs an-input)))]
+      [(ControlStackLabel? an-input)
+       empty]
+      [(ControlStackLabel/MultipleValueReturn? an-input)
+       empty]
+      [(ControlFrameTemporary? an-input)
+       empty]
+      [(CompiledProcedureEntry? an-input)
+       (collect-input (CompiledProcedureEntry-proc an-input))]
+      [(CompiledProcedureClosureReference? an-input)
+       (collect-input (CompiledProcedureClosureReference-proc an-input))]
+      [(PrimitiveKernelValue? an-input)
+       empty]
+      [(ModuleEntry? an-input)
+       empty]
+      [(ModulePredicate? an-input)
+       empty]
+      [(VariableReference? an-input)
+       empty]))
+  
+  
+  (: collect-location ((U Reg Label) -> (Listof Symbol)))
+  (define (collect-location a-location)
+    (cond
+      [(Reg? a-location)
+       empty]
+      [(Label? a-location)
+       (list (Label-name a-location))]))
+  
+  (: collect-primitive-operator (PrimitiveOperator -> (Listof Symbol)))
+  (define (collect-primitive-operator op)
+    (cond
+      [(GetCompiledProcedureEntry? op)
+       empty]
+      [(MakeCompiledProcedure? op)
+       (list (MakeCompiledProcedure-label op))]
+      [(MakeCompiledProcedureShell? op)
+       (list (MakeCompiledProcedureShell-label op))]
+      [(ApplyPrimitiveProcedure? op)
+        empty]
+      [(CaptureEnvironment? op)
+       empty]
+      [(CaptureControl? op)
+       empty]
+      [(MakeBoxedEnvironmentValue? op)
+       empty]
+      [(CallKernelPrimitiveProcedure? op)
+       empty]
+      [(ModuleVariable? op)
+       empty]
+      [(PrimitivesReference? op)
+       empty]
+      [(GlobalsReference? op)
+       empty]))
+
+  
+  (: collect-primitive-command (PrimitiveCommand -> (Listof Symbol)))
+  (define (collect-primitive-command op)
+    (cond
+      [(InstallModuleEntry!? op)
+       (list (InstallModuleEntry!-entry-point op))]
+      [else
+       empty]))
+  
+  (: start-time Real)
+  (define start-time (current-inexact-milliseconds))
+
+  (: result (Listof Symbol))
+  (define result
+    (unique/eq?
+     (let loop ; : (Listof Symbol) 
+       ([stmts ; : (Listof Statement)
+               stmts])
+       (cond [(empty? stmts)
+              empty]
+             [else
+              (let ([stmt ; : Statement 
+                          (first stmts)])
+                (append (collect-statement stmt)
+                        (loop (rest stmts))))]))))
+
+  (: end-time Real)
+  (define end-time (current-inexact-milliseconds))
+  (fprintf (current-timing-port) "  collect-general-jump-targets: ~a milliseconds\n" (- end-time start-time))
+  result)
+
+
+
+
+
+
+
+(: collect-entry-points ((Listof Statement) -> (Listof Symbol)))
+;; collects all the labels that are general entry points.  The entry points are
+;; from the starting basic block, from functions headers, and finally return points.
+(define (collect-entry-points stmts)
+  
+  (: collect-statement (Statement -> (Listof Symbol)))
+  (define (collect-statement stmt)
+    (cond
+      [(symbol? stmt)
+       empty]
+      [(LinkedLabel? stmt)
+       (list (LinkedLabel-label stmt)
+             (LinkedLabel-linked-to stmt))]
+      [(MarkEntryPoint? stmt)
+       (list (MarkEntryPoint-label stmt))]
+      [(DebugPrint? stmt)
+       empty]
+      [(AssignImmediate? stmt)
+       (let ([v ; : OpArg 
+                (AssignImmediate-value stmt)])
+         (collect-input v))]
+      [(AssignPrimOp? stmt)
+       (collect-primitive-operator (AssignPrimOp-op stmt))]
+      [(Perform? stmt)
+       (collect-primitive-command (Perform-op stmt))]
+      [(TestAndJump? stmt)
+       empty]
+      [(Goto? stmt)
+       empty]
+      [(PushEnvironment? stmt)
+       empty]
+      [(PopEnvironment? stmt)
+       empty]
+      [(PushImmediateOntoEnvironment? stmt)
+       (collect-input (PushImmediateOntoEnvironment-value stmt))]
+      [(PushControlFrame/Generic? stmt)
+       empty]
+      [(PushControlFrame/Call? stmt)
+       (label->labels (PushControlFrame/Call-label stmt))]
+      [(PushControlFrame/Prompt? stmt)
+       (label->labels (PushControlFrame/Prompt-label stmt))]
+      [(PopControlFrame? stmt)
+       empty]
+      [(Comment? stmt)
+       empty]))
+  
+  
+  
+  (: collect-input (OpArg -> (Listof Symbol)))
+  (define (collect-input an-input)
+    (cond
+      [(Reg? an-input)
+       empty]
+      [(Const? an-input)
+       empty]
+      [(Label? an-input)
+       (list (Label-name an-input))]
+      [(EnvLexicalReference? an-input)
+       empty]
+      [(EnvPrefixReference? an-input)
+       empty]
+      [(EnvWholePrefixReference? an-input)
+       empty]
+      [(SubtractArg? an-input)
+       (append (collect-input (SubtractArg-lhs an-input))
+               (collect-input (SubtractArg-rhs an-input)))]
+      [(ControlStackLabel? an-input)
+       empty]
+      [(ControlStackLabel/MultipleValueReturn? an-input)
+       empty]
+      [(ControlFrameTemporary? an-input)
+       empty]
+      [(CompiledProcedureEntry? an-input)
+       (collect-input (CompiledProcedureEntry-proc an-input))]
+      [(CompiledProcedureClosureReference? an-input)
+       (collect-input (CompiledProcedureClosureReference-proc an-input))]
+      [(PrimitiveKernelValue? an-input)
+       empty]
+      [(ModuleEntry? an-input)
+       empty]
+      [(ModulePredicate? an-input)
+       empty]
+      [(VariableReference? an-input)
+       empty]))
+  
+  
+  (: collect-location ((U Reg Label) -> (Listof Symbol)))
+  (define (collect-location a-location)
+    (cond
+      [(Reg? a-location)
+       empty]
+      [(Label? a-location)
+       (list (Label-name a-location))]))
+  
+  (: collect-primitive-operator (PrimitiveOperator -> (Listof Symbol)))
+  (define (collect-primitive-operator op)
+    (cond
+      [(GetCompiledProcedureEntry? op)
+       empty]
+      [(MakeCompiledProcedure? op)
+       (list (MakeCompiledProcedure-label op))]
+      [(MakeCompiledProcedureShell? op)
+       (list (MakeCompiledProcedureShell-label op))]
+      [(ApplyPrimitiveProcedure? op)
+        empty]
+      [(CaptureEnvironment? op)
+       empty]
+      [(CaptureControl? op)
+       empty]
+      [(MakeBoxedEnvironmentValue? op)
+       empty]
+      [(CallKernelPrimitiveProcedure? op)
+       empty]
+      [(ModuleVariable? op)
+       empty]
+      [(PrimitivesReference? op)
+       empty]
+      [(GlobalsReference? op)
+       empty]))
+  
+  (: collect-primitive-command (PrimitiveCommand -> (Listof Symbol)))
+  (define (collect-primitive-command op)
+    (cond
+      [(InstallModuleEntry!? op)
+       (list (InstallModuleEntry!-entry-point op))]
+      [else
+       empty]
+      ;; currently written this way because I'm hitting some bad type-checking behavior.
+      #;([(CheckToplevelBound!? op)
+          empty]
+         [(CheckClosureAndArity!? op)
+          empty]
+         [(CheckPrimitiveArity!? op)
+          empty]
+         [(ExtendEnvironment/Prefix!? op)
+          empty]
+         [(InstallClosureValues!? op)
+          empty]
+         [(RestoreEnvironment!? op)
+          empty]
+         [(RestoreControl!? op)
+          empty]
+         [(SetFrameCallee!? op)
+          empty]
+         [(SpliceListIntoStack!? op)
+          empty]
+         [(UnspliceRestFromStack!? op)
+          empty]
+         [(FixClosureShellMap!? op)
+          empty]
+         [(InstallContinuationMarkEntry!? op)
+          empty]
+         [(RaiseContextExpectedValuesError!? op)
+          empty]
+         [(RaiseArityMismatchError!? op)
+          empty]
+         [(RaiseOperatorApplicationError!? op)
+          empty])))
+  
+  
+  (unique/eq?
+   (let loop ; : (Listof Symbol)
+     ([stmts ; : (Listof Statement)
+             stmts])
+     (cond [(empty? stmts)
+            empty]
+           [else
+            (let ([stmt ; : Statement
+                        (first stmts)])
+              (append (collect-statement stmt)
+                      (loop (rest stmts))))]))))
+
+
+
+
+
+
+
+(: label->labels ((U Symbol LinkedLabel) -> (Listof Symbol)))
+(define (label->labels label)
+  (cond
+    [(symbol? label)
+     (list label)]
+    [(LinkedLabel? label)
+     (list (LinkedLabel-label label)
+           (LinkedLabel-linked-to label))]))
+

--- a/whalesong/selfhost/js-assembler/find-primitive-implemented.rkt
+++ b/whalesong/selfhost/js-assembler/find-primitive-implemented.rkt
@@ -1,0 +1,51 @@
+#lang racket/base
+
+(require racket/runtime-path
+         racket/list
+         (for-syntax racket/base)
+         "../compiler/arity-structs.rkt")
+
+;; Provides a list of symbols of the function implemented primitively.  Knowing
+;; this allows us to do certain procedure applications more efficiently without
+;; touching the stack so much.
+(provide primitive-ids)
+
+(define a-regexp 
+  #px"installPrimitiveProcedure\\s*\\(\\s*['\"]([^'\"]+)['\"]\\s*,\\s*([^\n]+)\n")
+
+(define-runtime-path baselib-primitives.js
+  (build-path "runtime-src" "baselib-primitives.js"))
+
+(define ip (open-input-file baselib-primitives.js))
+
+(define (parse-arity-string s)
+  (define arity
+    (let loop ([s s])
+      (let ([s (regexp-replace #px",\\s+$" s "")])
+        (cond
+          [(regexp-match #px"^(\\d+)" s)
+           =>
+           (lambda (m) (string->number (second m)))]
+          [(regexp-match #px"^makeList\\((.+)\\)" s)
+           =>
+           (lambda (m) 
+             (map string->number (regexp-split #px"\\s*,\\s*" (second m))))]
+          [(regexp-match #px"^baselib.arity.makeArityAtLeast\\((\\d+)\\)" s)
+           =>
+           (lambda (m) 
+             (ArityAtLeast (string->number (second m))))]
+          [else
+           (error 'parse-arity-string "How to parse? ~e" s)]))))
+  arity)
+  
+(define primitive-ids
+  (let loop ()
+    (let ([a-match (regexp-match a-regexp ip)])
+      (cond
+        [a-match => (lambda (a-match)
+                      (define name (second a-match))
+                      (define arity-string (bytes->string/utf-8 (third a-match)))
+                      (define arity (parse-arity-string arity-string))
+                      (cons (cons (string->symbol (bytes->string/utf-8 name)) arity)
+                            (loop)))]
+        [else empty]))))

--- a/whalesong/selfhost/js-assembler/fracture.rkt
+++ b/whalesong/selfhost/js-assembler/fracture.rkt
@@ -1,0 +1,111 @@
+#lang whalesong (require "../selfhost-lang.rkt" whalesong/lang/for) 
+; #lang typed/racket/base
+
+(require "assemble-structs.rkt"
+         "collect-jump-targets.rkt"
+         "../compiler/il-structs.rkt"
+         "../compiler/expression-structs.rkt"
+         "../parameters.rkt"
+         racket/list)
+
+
+;; Breaks up a sequence of statements into a list of basic blocks.
+;;
+;; The first basic block is special, and represents the start of execution.
+;;
+;; A basic block consists of a sequence of straight line statements, followed by one of
+;; the following:
+;;
+;;     * A conditional jump.
+;;     * An unconditional jump.
+;;     * Termination.
+
+(provide fracture)
+
+
+
+
+;; fracture: (listof stmt) -> (listof basic-block)
+(: fracture ((Listof Statement) -> (values (Listof BasicBlock)
+                                           (Listof Symbol))))
+(define (fracture stmts)
+  
+  (define start-time (current-inexact-milliseconds))
+  
+  (define-values (blocks entries)
+    (let* ([first-block-label ; : Symbol 
+            (if (and (not (empty? stmts))
+                     (symbol? (first stmts)))
+                (first stmts)
+                (make-label 'start))]
+           [stmts ; : (Listof Statement) 
+            (if (and (not (empty? stmts))
+                     (symbol? (first stmts)))
+                (rest stmts)
+                stmts)]
+           [jump-targets ; : (Listof Symbol)
+            (cons first-block-label (collect-general-jump-targets stmts))]
+           [entry-points ; : (Listof Symbol)
+            (cons first-block-label (collect-entry-points stmts))])
+      
+      (define jump-targets-ht ((inst make-hasheq Symbol Boolean)))
+      (for ([name jump-targets])
+        (hash-set! jump-targets-ht name #t))
+      
+      (set! start-time (current-inexact-milliseconds))
+      (let loop ; : (values (Listof BasicBlock) (Listof Symbol))
+        ([name ; : Symbol 
+               first-block-label]
+         [acc ; : (Listof UnlabeledStatement)
+              '()]
+         [basic-blocks  ; : (Listof BasicBlock)
+                        '()]
+         [stmts ; : (Listof Statement)
+                stmts]
+         [last-stmt-goto? ; : Boolean 
+                          #f])
+        (cond
+          [(null? stmts)
+           (values (reverse (cons (make-BasicBlock name (reverse acc))
+                                  basic-blocks))
+                   entry-points)]
+          [else
+           (let ([first-stmt ; : Statement
+                             (car stmts)])
+             (: do-on-label (Symbol -> (values (Listof BasicBlock) (Listof Symbol))))
+             (define (do-on-label label-name)
+               (cond
+                 [(hash-has-key? jump-targets-ht label-name)
+                  (loop label-name
+                        '()
+                        (cons (make-BasicBlock 
+                               name  
+                               (if last-stmt-goto? 
+                                   (reverse acc)
+                                   (reverse (cons (make-Goto (make-Label label-name))
+                                                  acc))))
+                              basic-blocks)
+                        (cdr stmts)
+                        last-stmt-goto?)]
+                 [else
+                  (loop name
+                        acc
+                        basic-blocks
+                        (cdr stmts)
+                        last-stmt-goto?)]))
+             (cond
+               [(symbol? first-stmt)
+                (do-on-label first-stmt)]
+               [(LinkedLabel? first-stmt)
+                (do-on-label (LinkedLabel-label first-stmt))]
+               [else
+                (loop name
+                      (cons first-stmt acc)
+                      basic-blocks
+                      (cdr stmts)
+                      (Goto? (car stmts)))]))]))))
+  
+  (define end-time (current-inexact-milliseconds))
+  (fprintf (current-timing-port) "  assemble fracture: ~a milliseconds\n" (- end-time start-time))
+  
+  (values blocks entries))

--- a/whalesong/selfhost/js-assembler/get-js-vm-implemented-primitives.rkt
+++ b/whalesong/selfhost/js-assembler/get-js-vm-implemented-primitives.rkt
@@ -1,0 +1,47 @@
+#lang racket/base
+
+(require racket/runtime-path
+         racket/file
+         racket/contract
+         racket/list)
+;; Get the list of primitives implemented in js-vm-primitives.js
+
+;; (define-runtime-path js-vm-primitives.js "runtime-src/js-vm-primitives.js")
+
+(define-runtime-path whalesong-primitives.js "runtime-src/baselib-primitives.js")
+
+;; sort&unique: (listof string) -> (listof string)
+(define (sort&unique names)
+  (let ([ht (make-hash)])
+    (for ([name names])
+      (hash-set! ht name #t))
+    (sort (for/list ([name (in-hash-keys ht)])
+            name)
+          string<?)))
+        
+;; ;; primitive-names: (listof symbol)
+;; (define js-vm-primitive-names
+;;   (map string->symbol
+;;        (sort&unique
+;;         (map (lambda (a-str)
+;;                (substring a-str
+;;                           (string-length "PRIMITIVES['")
+;;                           (- (string-length a-str) (string-length "']"))))
+;;              (let ([contents (file->string js-vm-primitives.js)])
+;;                (regexp-match* #px"PRIMITIVES\\[('|\")[^\\]]*('|\")\\]" contents))))))
+
+
+
+(define whalesong-primitive-names
+  (map string->symbol
+       (sort&unique
+        (map (lambda (a-str)
+               (let ([match (regexp-match
+                             #px"installPrimitiveProcedure\\(\\s+('|\")([^\\]]*)('|\")" a-str)])
+                 (third match)))
+             (let ([contents (file->string whalesong-primitives.js)])
+               (regexp-match* #px"installPrimitiveProcedure\\(\\s+('|\")[^\\']*('|\")" contents))))))
+
+     
+(provide/contract ;[js-vm-primitive-names (listof symbol?)]
+                  [whalesong-primitive-names (listof symbol?)])

--- a/whalesong/selfhost/js-assembler/get-runtime.rkt
+++ b/whalesong/selfhost/js-assembler/get-runtime.rkt
@@ -1,0 +1,110 @@
+#lang racket/base
+
+;; Function to get the runtime library.
+;;
+;; The resulting Javascript will produce a file that loads:
+;;
+;;
+;; jquery at the the toplevel
+;; HashTable at the toplevel
+;; jsnums at the toplevel
+;;
+;; followed by the base library
+;;
+
+
+
+(require racket/contract
+         racket/runtime-path
+         racket/port)
+
+
+
+(provide/contract [get-runtime (-> string?)])
+
+
+(define-runtime-path base-path "runtime-src")
+
+
+;; The order matters here.  link needs to come near the top, because
+;; the other modules below have some circular dependencies that are resolved
+;; by link.
+(define files '(
+                top.js
+                
+                ;; jquery is special: we need to make sure it's resilient against
+                ;; multiple invokation and inclusion.
+                jquery-protect-header.js
+                jquery.js
+                jquery-protect-footer.js
+                
+                js-numbers.js
+                base64.js
+                
+                baselib.js
+                baselib-dict.js
+                baselib-frames.js
+
+                baselib-loadscript.js
+                
+                baselib-unionfind.js
+                baselib-equality.js
+                baselib-format.js
+
+                baselib-constants.js
+                baselib-numbers.js
+                baselib-lists.js
+                baselib-vectors.js
+                baselib-chars.js
+                baselib-symbols.js
+                baselib-paramz.js
+                baselib-strings.js
+                baselib-bytes.js                    
+
+                hashes-header.js
+                jshashtable-2.1_src.js
+                llrbtree.js
+                baselib-hashes.js
+                hashes-footer.js
+
+                
+                baselib-regexps.js
+                baselib-paths.js
+                baselib-boxes.js
+                baselib-placeholders.js
+                baselib-keywords.js
+                baselib-structs.js
+                baselib-srclocs.js
+                baselib-ports.js
+                baselib-functions.js
+                baselib-modules.js
+                baselib-contmarks.js
+                
+                baselib-arity.js
+                baselib-inspectors.js
+                baselib-exceptions.js
+                baselib-readergraph.js
+
+                ;; baselib-check has to come after the definitions of types,
+                ;; since it uses the type predicates immediately on init time.
+                baselib-check.js
+
+                baselib-primitives.js
+                runtime.js))
+
+
+
+(define (path->string p)
+  (call-with-input-file p
+                (lambda (ip)
+                  (port->string ip))))
+
+
+(define text (apply string-append
+                    (map (lambda (n)
+                           (path->string 
+                            (build-path base-path (symbol->string n))))
+                         files)))
+
+(define (get-runtime)
+  text)

--- a/whalesong/selfhost/js-assembler/hash-cache.rkt
+++ b/whalesong/selfhost/js-assembler/hash-cache.rkt
@@ -1,0 +1,94 @@
+#lang racket/base
+
+;; on-disk hashtable cache.
+
+(require (prefix-in whalesong: "../version.rkt")
+         racket/runtime-path
+         racket/file
+         file/md5)
+
+
+(define cache-directory-path
+  (build-path (find-system-path 'pref-dir)
+              "whalesong"))
+
+(provide cached? save-in-cache!)
+
+
+;; create-cache-directory!: -> void
+(define (create-cache-directory!)
+  (unless (directory-exists? cache-directory-path)
+    (make-directory* cache-directory-path)))
+  
+
+;; clear-cache-files!: -> void
+;; Remove all the cache files.
+(define (clear-cache-files!)
+  (for ([file (directory-list cache-directory-path)])
+    (when (file-exists? (build-path cache-directory-path file))
+      (with-handlers ([exn:fail? void])
+        (delete-file (build-path cache-directory-path file))))))
+
+
+(define whalesong-cache.scm
+  (build-path cache-directory-path 
+              (format "whalesong-cache-~a.scm"
+                      whalesong:version)))
+
+
+(define (ensure-cache-db-structure!)
+  (when (not (file-exists? whalesong-cache.scm))
+    ;; Clear existing cache files: they're obsolete.
+    (clear-cache-files!)
+    (call-with-output-file whalesong-cache.scm
+      (lambda (op)
+        (write (make-hash) op)))))
+    
+
+
+(define (get-db)
+  (hash-copy (call-with-input-file whalesong-cache.scm read)))
+
+
+(define (write-db! hash)
+  (call-with-output-file whalesong-cache.scm
+    (lambda (op) (write hash op))
+    #:exists 'replace))
+
+
+
+
+(create-cache-directory!)
+(ensure-cache-db-structure!)
+(define db (get-db))
+
+
+
+
+;; cached?: path -> (U false bytes)
+;; Returns a true value, (vector path md5-signature data), if we can
+;; find an appropriate entry in the cache, and false otherwise.
+(define (cached? path)
+  (cond
+    [(file-exists? path)
+     (hash-ref db
+               (list (path->string path)
+                     (call-with-input-file* path md5))
+               #f)]
+    [else
+     #f]))
+
+
+;; save-in-cache!: path bytes -> void
+;; Saves a record.
+(define (save-in-cache! path data)
+  (cond
+    [(file-exists? path)
+     (define signature (call-with-input-file* path md5))
+     (hash-set! db
+                (list (path->string path)
+                      signature)
+                data)
+     (write-db! db)]
+    [else
+     (error 'save-in-cache! "File ~e does not exist" path)]))

--- a/whalesong/selfhost/js-assembler/module-knowledge.rkt
+++ b/whalesong/selfhost/js-assembler/module-knowledge.rkt
@@ -1,0 +1,19 @@
+#lang racket/base
+
+;; Provides a mapping of the core bindings in kernel, so that we know statically
+;; if something is implemented as a primitive or a closure.
+(require syntax/modresolve)
+
+(provide bound-procedure-names)
+
+
+(define ns (make-base-empty-namespace))
+(define bound-procedure-names
+  (let ([path (resolve-module-path 'whalesong/lang/kernel #f)])
+    (parameterize ([current-namespace ns])
+      (namespace-require path)
+      (for/list ([name (namespace-mapped-symbols)]
+                 #:when (namespace-variable-value name #t (lambda () #f)))
+        name))))
+
+

--- a/whalesong/selfhost/js-assembler/package.rkt
+++ b/whalesong/selfhost/js-assembler/package.rkt
@@ -1,0 +1,788 @@
+#lang racket/base
+
+(require "assemble.rkt"
+         "quote-cdata.rkt"
+         "../logger.rkt"
+         "../make/make.rkt"
+         "../make/make-structs.rkt"
+         "../parameters.rkt"
+         "../compiler/expression-structs.rkt"
+         "../parser/path-rewriter.rkt"
+         "../parser/parse-bytecode.rkt"
+         "../parser/modprovide.rkt"
+         "../resource/structs.rkt"
+	 "../promise.rkt"
+         "check-valid-module-source.rkt"
+         "find-primitive-implemented.rkt"
+         (prefix-in hash-cache: "hash-cache.rkt")
+         racket/match
+         racket/list
+         racket/promise
+         racket/set
+         racket/path
+         racket/string
+         racket/port
+         syntax/modread
+         syntax/kerncase
+         syntax/modresolve
+         (prefix-in query: "../lang/js/query.rkt")
+         (prefix-in resource-query: "../resource/query.rkt")
+         (prefix-in runtime: "get-runtime.rkt")
+         (prefix-in racket: racket/base)
+         racket/runtime-path
+         json)
+
+
+
+;; There is a dynamic require for (planet dyoo/closure-compile) that's done
+;; if compression is turned on.
+
+
+;; TODO: put proper contracts here
+
+
+(provide package
+	 package-anonymous
+         package-standalone-xhtml
+         get-inert-code
+         get-standalone-code
+         write-standalone-code
+         get-runtime
+         write-runtime
+         current-on-resource
+         get-html-template)
+
+
+
+;; notify: string (listof any)* -> void
+;; Print out log message during the build process.
+(define (notify msg . args)
+  (displayln (apply format msg args)))
+
+
+
+(define primitive-identifiers-ht
+  (make-hash primitive-ids))
+
+;; Sets up the compiler parameters we need to do javascript-specific compilation.
+(define (with-compiler-params thunk)
+  (parameterize ([compile-context-preservation-enabled #t]
+                 [current-primitive-identifier?
+                  (lambda (a-name)
+                    (hash-ref primitive-identifiers-ht a-name #f))])
+    (thunk)))
+
+
+
+
+(define current-on-resource
+  (make-parameter (lambda (r)
+                    (log-debug "Resource ~s should be written"
+                               (resource-path r))
+                    (void))))
+
+
+(define-struct cached-entry (real-path ;; path to a module. 
+                             whalesong-version ;; string
+                             md5   ;; md5 of the original source in real-path
+                             bytes)
+  #:transparent) ;; bytes
+
+
+
+
+(define-struct js-impl (name ;; symbol
+                        real-path ;; path
+                        src ;; string
+                        )
+  #:transparent)
+
+
+;; Packager: produce single .js files to be included to execute a
+;; program.
+
+
+
+(define (package-anonymous source-code
+                           #:should-follow-children? should-follow?
+                           #:output-port op)
+  (fprintf op "(function() {\n")
+  (package source-code
+           #:should-follow-children? should-follow?
+           #:output-port op)
+  (fprintf op " return invoke; })\n"))
+
+
+
+;; check-valid-source: Source -> void
+;; Check to see if the file, if a module, is a valid module file.
+(define (check-valid-source src)
+  (cond
+   [(StatementsSource? src)
+    (void)]
+   [(MainModuleSource? src)
+    (check-valid-module-source (MainModuleSource-path src))]
+   [(ModuleSource? src)
+    (check-valid-module-source (ModuleSource-path src))]
+   [(SexpSource? src)
+    (void)]
+   [(UninterpretedSource? src)
+    (void)]))
+
+
+
+;; source-is-javascript-module?: Source -> boolean
+;; Returns true if the source looks like a Javascript-implemented module.
+(define (source-is-javascript-module? src)
+  (cond
+    [(StatementsSource? src)
+     #f]
+    [(MainModuleSource? src)
+     (query:has-javascript-implementation?
+      `(file ,(path->string (MainModuleSource-path src))))]
+    [(ModuleSource? src)
+     (query:has-javascript-implementation?
+      `(file ,(path->string (ModuleSource-path src))))]
+    [(SexpSource? src)
+     #f]
+    [(UninterpretedSource? src)
+     #f]))
+
+(define (source-resources src)
+  (cond
+    [(StatementsSource? src)
+     empty]
+    [(MainModuleSource? src)
+     (resource-query:query
+      `(file ,(path->string (MainModuleSource-path src))))]
+    [(ModuleSource? src)
+     (resource-query:query
+      `(file ,(path->string (ModuleSource-path src))))]
+    [(SexpSource? src)
+     empty]
+    [(UninterpretedSource? src)
+     empty]))
+
+
+
+;; get-javascript-implementation: source -> UninterpretedSource
+(define (get-javascript-implementation src)
+  
+  (define (get-provided-name-code bytecode)
+    (apply string-append
+           (for/list ([modprovide (get-provided-names bytecode)]
+                      [i (in-naturals)])
+             (string-append
+              (format "ns.set(~s,exports[~s]);\n"
+                      (symbol->string (ModuleProvide-internal-name modprovide))
+                      (symbol->string (ModuleProvide-external-name modprovide)))
+              (format "extNs.set(~s,exports[~s]);\n"
+                      (symbol->string (ModuleProvide-external-name modprovide))
+                      (symbol->string (ModuleProvide-external-name modprovide)))
+              (format "modrec.prefix[~a]=exports[~s];\n"
+                      i
+                      (symbol->string (ModuleProvide-external-name modprovide)))))))
+
+  (define (get-prefix-code bytecode)
+    (format "modrec.prefix=[~a];modrec.prefix.names=[~a];modrec.prefix.internalNames=[~a];"
+            (string-join (map (lambda (n) "void(0)")
+                              (get-provided-names bytecode))
+                         ",")
+            (string-join (map (lambda (n)
+                                (format "~s" (symbol->string
+                                              (ModuleProvide-internal-name n))))
+                              (get-provided-names bytecode))
+                         ",")
+            (string-join (map (lambda (n)
+                                (format "~s" (symbol->string
+                                              (ModuleProvide-external-name n))))
+                              (get-provided-names bytecode))
+                         ",")))
+
+  (define (get-implementation-from-path path)
+    (let* ([name (rewrite-path path)]
+	   [paths (query:query `(file ,(path->string path)))]
+	   [text (string-join
+		  (map (lambda (p)
+			 (call-with-input-file p port->string))
+		       paths)
+		  "\n")]
+	   [module-requires (query:lookup-module-requires path)]
+	   [bytecode (parse-bytecode path)])
+      (when (not (empty? module-requires))
+	    (log-debug "~a requires ~a"
+		       path
+		       module-requires))
+      (let ([module-body-text
+	     (format "
+             if(--M.cbt<0) { throw arguments.callee; }
+             var modrec = M.modules[~s];
+             var ns = modrec.getExports();
+             var extNs = modrec.getExternalExports();
+             ~a
+             var exports = {};
+             modrec.isInvoked = true;
+             (function(MACHINE, EXPORTS){~a})(M, exports);
+             ~a
+             modrec.privateExports = exports;
+             return M.c.pop().label(M);"
+		     (symbol->string name)
+                     (get-prefix-code bytecode)
+		     text
+		     (get-provided-name-code bytecode))])
+	
+	(make-UninterpretedSource
+         path
+         (format "
+M.installedModules[~s] = function() {
+    return new plt.runtime.ModuleRecord(~s,
+        function(M) {
+            ~a
+        });
+   }
+"
+		 (symbol->string name)
+		 (symbol->string name)
+		 (assemble-modinvokes+body module-requires module-body-text))
+	 
+	 (map (lambda (p) (make-ModuleSource (normalize-path p)))
+	      module-requires)))))
+
+
+
+  (cond
+    [(StatementsSource? src)
+     (error 'get-javascript-implementation src)]
+    [(MainModuleSource? src)
+     (get-implementation-from-path (MainModuleSource-path src))]
+    [(ModuleSource? src)
+     (get-implementation-from-path (ModuleSource-path src))]
+    
+    
+    [(SexpSource? src)
+     (error 'get-javascript-implementation)]
+    [(UninterpretedSource? src)
+     (error 'get-javascript-implementation)]))
+
+
+
+;; source-module-name: source -> (U symbol #f)
+;; Given a source, return its module name if it's a module.
+;; If not, return #f.
+(define (source-module-name src)
+  (cond
+   [(StatementsSource? src)
+    #f]
+   [(MainModuleSource? src)
+    (rewrite-path (MainModuleSource-path src))]
+   [(ModuleSource? src)
+    (rewrite-path (ModuleSource-path src))]
+   [(SexpSource? src)
+    #f]
+   [(UninterpretedSource? src)
+    (rewrite-path (UninterpretedSource-path src))]))
+
+
+
+(define (assemble-modinvokes+body paths after)
+  (cond
+    [(empty? paths)
+     after]
+    [(empty? (rest paths))
+     (assemble-modinvoke (first paths) after)]
+    [else
+     (assemble-modinvoke (first paths)
+                         (assemble-modinvokes+body (rest paths) after))]))
+
+
+(define (assemble-modinvoke path after)
+  (let ([name (rewrite-path (path->string path))]
+        [afterName (gensym 'afterName)])
+    (format "
+        var ~a = function() { ~a };
+        plt.runtime.PAUSE(function(restart) {
+             var modName = ~s;
+             plt.runtime.currentModuleLoader(M,
+                                             modName,
+                                             function() {
+                                                restart(function(M) {
+                                                    M.modules[modName] = M.installedModules[modName]();
+                                                    if (! M.modules[modName].isInvoked) {
+                                                        M.modules[modName].internalInvoke(M,
+                                                                                     ~a,
+                                                                                      M.params.currentErrorHandler);
+                                                    } else {
+                                                        ~a();
+                                                    }
+                                                })
+                                             },
+                                             function() {
+                                                alert('Could not load ' + modName);
+                                             })
+       });     "
+            afterName
+            after
+            (symbol->string name)
+            afterName
+            afterName)))
+
+
+
+
+;; package: Source (path -> boolean) output-port -> void
+
+;; Compile package for the given source program.
+;;
+;; should-follow-children?  indicates whether we should continue
+;; following module paths of a source's dependencies.
+;;
+;; The generated output defines a function called 'invoke' with
+;; four arguments (M, SUCCESS, FAIL, PARAMS).  When called, it will
+;; execute the code to either run standalone expressions or
+;; load in modules.
+(define (package source-code
+                 #:should-follow-children? should-follow?
+                 #:output-port op
+                 #:next-file-path (next-file-path (lambda (module-name) (error 'package))))
+  (define resources (set))
+  
+  
+  ;; wrap-source: source -> source
+  ;; Translate all JavaScript-implemented sources into uninterpreted sources;
+  ;; we'll leave its interpretation to on-visit-src.
+  (define (wrap-source src)
+    (log-debug "Checking valid source")
+    (check-valid-source src)
+    
+    (log-debug "Checking if the source has a JavaScript implementation")
+    (cond
+      [(source-is-javascript-module? src)
+       (log-debug "Replacing implementation with JavaScript one.")
+       (get-javascript-implementation src)]
+      [else
+       src]))
+  
+
+  ;; maybe-with-fresh-file: source (-> any) -> any
+  ;; Call thunk, perhaps in the dynamic extent where op is a new file.
+  (define (maybe-with-fresh-file src thunk)
+    (cond
+     [(current-one-module-per-file?)
+      (define old-port op)
+      (define temp-string (open-output-string))
+      (set! op temp-string)
+      (thunk)
+      (set! op old-port)
+      (define fresh-name (next-file-path (source-module-name src)))
+      (call-with-output-file fresh-name
+        (lambda (op)
+          (display (compress (get-output-string temp-string)) op))
+        #:exists 'replace)]
+     [else
+      (thunk)]))
+
+  
+  (define (on-visit-src src ast stmts)
+    ;; Record the use of resources on source module visitation...
+    (set! resources (set-union resources (list->set (source-resources src))))
+
+    (maybe-with-fresh-file
+     src
+     (lambda ()
+       (fprintf op "\n// ** Visiting ~a\n" (source-name src))
+       (define start-time (current-inexact-milliseconds))
+       (cond
+        [(UninterpretedSource? src)
+         (fprintf op "(function(M) {\n\"use strict\";\n ~a }(plt.runtime.currentMachine));" (UninterpretedSource-datum src))]
+        [else      
+         (fprintf op "(")
+         (on-source src stmts op)
+         (fprintf op ")(plt.runtime.currentMachine,
+                     function() {
+                          if (window.console && window.console.log) {
+                              window.console.log('loaded ' + ~s);
+                          }
+                     },
+                     function(M, err) {
+                          if (window.console && window.console.log) {
+                              window.console.log('error: unable to load ' + ~s);
+                              if (err && err.stack) { console.log(err.stack); }
+                         }
+                     },
+                     {});"
+                  (format "~a" (source-name src))
+                  (format "~a" (source-name src)))
+         (define stop-time (current-inexact-milliseconds))
+         (fprintf (current-timing-port) "  assembly: ~s milliseconds\n" (- stop-time start-time))
+         (void)]))))
+  
+  
+  (define (after-visit-src src)
+    (void))
+  
+  
+  (define (on-last-src)
+    (void))
+
+  
+  
+  (define packaging-configuration
+    (make-Configuration
+     wrap-source
+     
+     should-follow?
+     
+     ;; on
+     on-visit-src
+     
+     ;; after
+     after-visit-src
+     
+     ;; last
+     on-last-src))
+  
+  (with-compiler-params
+   (lambda () (make (list source-code) packaging-configuration)))
+  
+  (for ([r resources])
+    ((current-on-resource) r)))
+
+
+
+;; on-source: Source (Promise (Listof Statement)) OutputPort -> void
+;; Generates the source for the statements here.
+;; Optimization: if we've seen this source before, we may be able to pull
+;; it from the cache.
+(define (on-source src stmts op)
+  (define (on-path path)
+    (cond
+      [(current-with-cache?)
+       (cond
+         [(cached? path)
+          =>
+          (lambda (bytes)
+            (display bytes op))]
+         [(cacheable? path)
+          (define string-op (open-output-bytes))
+          (assemble/write-invoke (my-force stmts) string-op 'no-trampoline)
+          (save-in-cache! path (get-output-bytes string-op))
+          (display (get-output-string string-op) op)]
+         [else
+          (assemble/write-invoke (my-force stmts) op 'no-trampoline)])]
+      [else
+       (assemble/write-invoke (my-force stmts) op 'no-trampoline)]))
+  (cond
+   [(ModuleSource? src)
+    (on-path (ModuleSource-path src))]
+   [(MainModuleSource? src)
+    (on-path (MainModuleSource-path src))]
+   [else
+    (assemble/write-invoke (my-force stmts) op 'without-preemption)]))
+
+
+;; cached?: path -> (U false bytes)
+;; Returns a true value (the cached bytes) if we've seen this path
+;; and know its JavaScript-compiled bytes.
+(define (cached? path)
+  (hash-cache:cached? path))
+
+
+
+;; cacheable?: path -> boolean
+;; Produces true if the file should be cached.
+;; At the current time, only cache modules that are provided
+;; by whalesong itself.
+(define (cacheable? path)
+  (within-whalesong-path? path))
+
+
+;; save-in-cache!: path bytes -> void
+;; Saves the bytes in the cache, associated with that path.
+;; TODO: Needs to sign with the internal version of Whalesong, and
+;; the md5sum of the path's content.
+(define (save-in-cache! path bytes)
+  (hash-cache:save-in-cache! path bytes))
+
+
+
+
+;; package-standalone-xhtml: X output-port -> void
+(define (package-standalone-xhtml source-code op)
+  (display (get-header) op)
+  (display (quote-cdata
+            (string-append (get-runtime)
+                           (get-inert-code source-code
+                                           (lambda () (error 'package-standalone-xhtml)))
+                           invoke-main-module-code)) op)
+  (display *footer* op))
+
+
+
+;; write-runtime: output-port -> void
+(define (write-runtime op)
+  
+  (define (wrap-source src) src)
+  (let ([packaging-configuration
+         (make-Configuration
+          
+          wrap-source
+          
+          ;; should-follow-children?
+          (lambda (src) #t)
+          ;; on
+          (lambda (src ast stmts)
+            (on-source src stmts op)
+            (fprintf op "(M, function() { "))
+          
+          ;; after
+          (lambda (src)
+            (fprintf op " }, FAIL, PARAMS);"))
+          
+          ;; last
+          (lambda ()
+            (fprintf op "SUCCESS();")))])
+    
+    (display (runtime:get-runtime) op)
+    
+    (newline op)
+    (fprintf op "(function(M, SUCCESS, FAIL, PARAMS) {")
+    (with-compiler-params
+     (lambda ()
+       (make (list (my-force only-bootstrapped-code)) packaging-configuration)))
+    (fprintf op "})(plt.runtime.currentMachine,\nfunction(){ plt.runtime.setReadyTrue(); },\nfunction(){},\n{});\n")))
+
+
+(define closure-compile-ns (make-base-namespace))
+(define (compress x)
+  (cond [(current-compress-javascript?)
+         (log-debug "compressing javascript...")
+         (parameterize ([current-namespace closure-compile-ns])
+           (define closure-compile (dynamic-require '(planet dyoo/closure-compile) 'closure-compile))
+           (closure-compile x))]
+        [else
+         (log-debug "not compressing javascript...")
+         x]))
+
+
+
+(define *the-runtime*
+  (delay (let ([buffer (open-output-string)])
+           (write-runtime buffer)
+           (compress
+            (get-output-string buffer)))))
+
+
+;; get-runtime: -> string
+(define (get-runtime)
+  (force *the-runtime*))
+
+
+(define (append-text-files paths)
+  (string-join (map (λ (p) (if (file-exists? p)
+                               (bytes->string/utf-8 (call-with-input-file p port->bytes))
+                               ""))
+                    paths)
+               "\n"))
+
+
+
+;; get-header : -> string
+(define (get-header)  
+    (format
+  #<<EOF
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
+  <head>
+    <meta name="viewport" content="initial-scale=1.0, width=device-width, height=device-height, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+    <meta charset="utf-8"/>
+    <title></title>
+    ~a
+  </head>
+  <script>
+
+EOF
+  (append-text-files (current-header-scripts))))
+
+
+;; get-html-template: (listof string) (#:manifest path) -> string
+(define (get-html-template js-files
+                           #:manifest (manifest #f)
+                           #:with-legacy-ie-support? (with-legacy-ie-support? #t)
+                           #:title (title "")
+                           #:module-mappings (module-mappings (make-hash)))
+  (format #<<EOF
+<!DOCTYPE html>
+<html ~a>
+  <head>
+    ~a
+    <meta name="viewport" content="initial-scale=1.0, width=device-width, height=device-height, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black" />
+    <meta charset="utf-8"/>
+    <title>~a</title>
+~a
+~a
+  <script>
+     plt.runtime.currentModuleLoader = plt.runtime.makeLocalFileModuleLoader(~a);
+  </script>
+  <script>
+  ~a
+  </script>
+  </head>
+  <body>
+  </body>
+  </html>
+EOF
+  (if manifest (format "manifest=~s" (path->string manifest)) "")
+  (if with-legacy-ie-support?
+      "<meta http-equiv='X-UA-Compatible' content='IE=7,chrome=1'><!--[if lt IE 9]><script src='excanvas.js' type='text/javascript'></script><script src='canvas.text.js'></script><script src='optimer-normal-normal.js'></script><![endif]-->"
+      "")
+  title
+  (append-text-files (current-header-scripts))
+  (string-join (map (lambda (js)
+                      (format "  <script src='~a'></script>\n" js))
+                    js-files)
+               "")
+  (jsexpr->string module-mappings)
+  invoke-main-module-code))
+
+
+;; get-inert-code: source (-> path) -> string
+(define (get-inert-code source-code next-file-path)
+  (let ([buffer (open-output-string)])
+    (package source-code
+             #:should-follow-children? (lambda (src) #t)
+             #:output-port buffer
+             #:next-file-path next-file-path)
+    (compress
+     (get-output-string buffer))))
+
+
+
+;; get-standalone-code: source -> string
+(define (get-standalone-code source-code)
+  (let ([buffer (open-output-string)])
+    (write-standalone-code source-code buffer)
+    (compress
+     (get-output-string buffer))))
+
+
+;; write-standalone-code: source output-port -> void
+(define (write-standalone-code source-code op)
+  (package source-code
+           #:should-follow-children? (lambda (src) #t)
+           #:output-port op))
+
+
+
+
+
+
+(define invoke-main-module-code
+  #<<EOF
+var invokeMainModule = function() {
+    var M = plt.runtime.currentMachine;
+    var startTime = new Date().valueOf();
+    plt.runtime.invokeMains(
+        M,
+        function() {
+            // On main module invokation success:
+            var stopTime = new Date().valueOf();                                
+            if (window.console && window.console.log) {
+                window.console.log('evaluation took ' + (stopTime - startTime) + ' milliseconds');
+            }
+        },
+        function(e) {
+            var contMarkSet, context, i, appName, contextDiv, srclocProcedure;
+
+            var displayContext = function() {
+                var subcontextDiv = $('<div/>').css('color', 'red');
+                subcontextDiv.append("Stacktrace:\n");
+                if (contMarkSet) {
+                    context = contMarkSet.getContext(M);
+                    for (i = 0; i < context.length; i++) {
+                        if (plt.runtime.isVector(context[i])) {
+                                $('<div/>').text('at ' + context[i].elts[0] +
+                                                 ', line ' + context[i].elts[2] +
+                                                 ', column ' + context[i].elts[3])
+                                    .addClass('stacktrace')
+                                    .css('margin-left', '10px')
+                                    .css('whitespace', 'pre')
+                                    .appendTo(subcontextDiv);
+                        } else if (plt.runtime.isProcedure(context[i])) {
+                            if (context[i].displayName) {
+                                $('<div/>').text('in ' + context[i].displayName)
+                                        .addClass('stacktrace')
+                                        .css('margin-left', '10px')
+                                        .css('whitespace', 'pre')
+                                        .appendTo(subcontextDiv);
+                            }
+                        }                                     
+                    }
+                }
+                contextDiv.append(subcontextDiv);
+                M.params.currentErrorDisplayer(M, contextDiv);
+            };
+
+
+            // On main module invokation failure
+            if (window.console && window.console.log) {
+                window.console.log(e.stack || e);
+            }
+            
+            M.params.currentErrorDisplayer(
+                M, $(plt.baselib.format.toDomNode(e.stack || e)).css('color', 'red'));
+
+            if (Object.hasOwnProperty.call(e,'racketError') &&
+                plt.baselib.exceptions.isExn(e.racketError)) {
+                contMarkSet = plt.baselib.exceptions.exnContMarks(e.racketError);
+                contextDiv = $('<div/>');
+
+                if (e.racketError.structType &&
+                    plt.baselib.structs.supportsStructureTypeProperty(
+                        e.racketError.structType,
+                        plt.baselib.structs.propExnSrcloc)) {
+                    srclocProcedure = plt.baselib.functions.asJavaScriptFunction(
+                              plt.baselib.structs.lookupStructureTypeProperty(
+                                  e.racketError.structType,
+                                  plt.baselib.structs.propExnSrcloc),
+                              M);
+                    srclocProcedure(function(v) {
+                                        if (plt.baselib.lists.isList(v)) {
+                                            while(v !== plt.baselib.lists.EMPTY) {
+                                                if (plt.baselib.srclocs.isSrcloc(v.first)) {
+                                                    $('<div/>').text('at ' + plt.baselib.srclocs.srclocSource(v.first) +
+                                                                     ', line ' + plt.baselib.srclocs.srclocLine(v.first) +
+                                                                     ', column ' + plt.baselib.srclocs.srclocColumn(v.first))
+                                                               .addClass('srcloc')
+                                                               .css('margin-left', '10px')
+                                                               .css('whitespace', 'pre')
+                                                               .css('color', 'red')
+                                                               .appendTo(contextDiv);
+                                                }
+                                                v = v.rest;
+                                            }
+                                        }
+                                        displayContext();
+                                    },
+                                    function(err) {
+                                        displayContext();
+                                    },
+                                    e.racketError);
+                } else {
+                    displayContext();
+                }
+            }
+        });
+};
+  $(document).ready(invokeMainModule);
+EOF
+  )
+
+(define *footer*
+  #<<EOF
+  </script>
+  <body></body>
+</html>
+EOF
+  )

--- a/whalesong/selfhost/js-assembler/package.rkt
+++ b/whalesong/selfhost/js-assembler/package.rkt
@@ -1,7 +1,6 @@
 #lang racket/base
 
 (require "assemble.rkt"
-         "quote-cdata.rkt"
          "../logger.rkt"
          "../make/make.rkt"
          "../make/make-structs.rkt"
@@ -43,7 +42,7 @@
 
 (provide package
 	 package-anonymous
-         package-standalone-xhtml
+         package-standalone-html
          get-inert-code
          get-standalone-code
          write-standalone-code
@@ -506,14 +505,13 @@ M.installedModules[~s] = function() {
 
 
 
-;; package-standalone-xhtml: X output-port -> void
-(define (package-standalone-xhtml source-code op)
+;; package-standalone-html: X output-port -> void
+(define (package-standalone-html source-code op)
   (display (get-header) op)
-  (display (quote-cdata
-            (string-append (get-runtime)
-                           (get-inert-code source-code
-                                           (lambda () (error 'package-standalone-xhtml)))
-                           invoke-main-module-code)) op)
+  (display (string-append (get-runtime)
+                          (get-inert-code source-code
+                                          (lambda () (error 'package-standalone-html)))
+                          invoke-main-module-code) op)
   (display *footer* op))
 
 
@@ -591,7 +589,7 @@ M.installedModules[~s] = function() {
     (format
   #<<EOF
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
+<html xml:lang="en">
   <head>
     <meta name="viewport" content="initial-scale=1.0, width=device-width, height=device-height, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no" />
     <meta charset="utf-8"/>

--- a/whalesong/selfhost/js-assembler/quote-cdata.rkt
+++ b/whalesong/selfhost/js-assembler/quote-cdata.rkt
@@ -1,0 +1,58 @@
+#lang whalesong (require "../selfhost-lang.rkt" "../selfhost-strings.rkt")
+; #lang typed/racket/base
+
+;; quoting cdata for script tags.  This is used to help generate SCRIPT bodies in XHTML.
+;; Note that this won't help too much in regular HTML5 documents.
+
+(provide quote-cdata)
+
+; CDATA (character data) sequence begins with
+;                <![CDATA[
+; and ends with  ]]>
+
+; A CDATA section can not contain ]]> 
+; To encode, say, ]]> one would write <![CDATA[]]]]><![CDATA[>]]>
+; I.e. replace all occurences of ]]> with ]]]]><![CDATA[>
+; which stops and restarts the cdata sequence.
+
+(: quote-cdata (String -> String))
+#;(define (quote-cdata s)
+  (string-append "<![CDATA["
+                 (regexp-replace* #rx"]]>"             ; pattern
+                                  s                    ; input
+                                  "]]]]><![CDATA[>")   ; insert
+                 "]]>"))
+
+(define (quote-cdata s)
+  (string-append "<![CDATA["
+                 (string-replace "]]>"
+                                 "]]]]><![CDATA[>"
+                                 s)
+                 "]]>"))
+                                  
+
+;; (: quote-cdata (String -> String))
+;; (define (quote-cdata str)
+;;   (let ([chunks (regexp-split #rx"\\]\\]>" str)])
+;;     (apply string-append (map wrap (process chunks)))))
+
+
+;; (: get-cdata-chunks (String -> (Listof String)))
+;; (define (get-cdata-chunks s)
+;;   (let ([chunks (regexp-split #rx"\\]\\]>" s)])
+;;     (process chunks)))
+
+
+;; (: process ((Listof String) -> (Listof String)))
+;; (define (process lst)
+;;   (cond
+;;     [(empty? (rest lst))
+;;      lst]
+;;     [else
+;;      (cons (string-append (first lst) "]]")
+;;            (process (cons (string-append ">" (second lst))
+;;                           (rest (rest lst)))))]))
+
+;; (: wrap (String -> String))          
+;; (define (wrap s)
+;;   (string-append "<![CDATA[" s "]]>"))

--- a/whalesong/selfhost/parameters.rkt
+++ b/whalesong/selfhost/parameters.rkt
@@ -1,0 +1,126 @@
+#lang racket/base
+;;; TODO (for selfhost) 
+;;;   - change to #lang whalesong
+;;;   - first implmenet "paths"
+
+(require "selfhost-parameters.rkt")
+
+(require "compiler/expression-structs.rkt"
+         "compiler/lexical-structs.rkt"
+         "compiler/arity-structs.rkt"
+         "sets.rkt"
+         racket/path
+         racket/port)
+
+#;(require/typed "logger.rkt"
+               [log-warning (String -> Void)])
+
+
+
+(provide current-defined-name
+         current-module-path
+         current-root-path
+         current-warn-unimplemented-kernel-primitive
+         current-seen-unimplemented-kernel-primitives
+
+
+         current-primitive-identifier?
+         
+         current-compress-javascript?
+         current-one-module-per-file?
+         current-with-cache?
+         current-with-legacy-ie-support?
+         current-header-scripts         
+         
+         current-report-port
+         current-timing-port
+         )
+
+
+
+;(: current-module-path (Parameterof (U False Path)))
+(define current-module-path 
+  (make-parameter (build-path (current-directory) "anonymous-module.rkt")))
+
+
+;(: current-root-path (Parameterof Path))
+(define current-root-path
+  (make-parameter (normalize-path (current-directory))))
+
+
+
+;(: current-warn-unimplemented-kernel-primitive (Parameterof (Symbol -> Void)))
+(define current-warn-unimplemented-kernel-primitive
+  (make-parameter
+   (lambda (id) #;([id : Symbol])
+            (log-warning
+             (format "WARNING: Primitive Kernel Value ~s has not been implemented\n"
+                     id)))))
+
+
+
+
+
+;(: current-primitive-identifier? (Parameterof (Symbol -> (U False Arity))))
+(define current-primitive-identifier? (make-parameter (lambda (name) #;([name : Symbol]) #f)))
+
+
+;(: current-compress-javascript? (Parameterof Boolean))
+(define current-compress-javascript? (make-parameter #f))
+
+
+;; Turn this one so that js-assembler/package generates a file per module, as
+;; opposed to trying to bundle them all together.
+;(: current-one-module-per-file? (Parameterof Boolean))
+(define current-one-module-per-file? (make-parameter #f))
+
+
+;; Turns on caching of compiled programs, so that repeated compilations
+;; will reuse existing work.
+;(: current-with-cache? (Parameterof Boolean))
+(define current-with-cache? (make-parameter #f))
+
+
+;; Turns on ie legacy support; includes excanvas and other helper libraries
+;; to smooth out compatibility issues.
+;(: current-with-legacy-ie-support? (Parameterof Boolean))
+(define current-with-legacy-ie-support? (make-parameter #t))
+
+
+;; Keeps list of Javascript files to be included in the header.
+;(: current-header-scripts (Parameterof (Listof Path)))
+(define current-header-scripts (make-parameter '()))
+
+
+;(: current-report-port (Parameterof Output-Port))
+(define current-report-port (make-parameter (current-output-port)))
+
+
+;(: current-timing-port (Parameterof Output-Port))
+(define current-timing-port (make-parameter (open-output-nowhere) ;(current-output-port)
+                                            ))
+
+
+
+
+;;; Do not touch the following parameters: they're used internally by package
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;(: current-seen-unimplemented-kernel-primitives (Parameterof (Setof Symbol)))
+(define current-seen-unimplemented-kernel-primitives
+  (make-parameter
+   (new-seteq)))
+
+
+
+
+
+;;; These parameters below will probably go away soon.
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;; Workaround for what appears to be a bug in 5.3.1 pre-release
+;(: UNKNOWN Symbol)
+(define UNKNOWN 'unknown)
+
+;(: current-defined-name (Parameterof (U Symbol LamPositionalName)))
+(define current-defined-name (make-parameter UNKNOWN))

--- a/whalesong/selfhost/parser/modprovide.rkt
+++ b/whalesong/selfhost/parser/modprovide.rkt
@@ -1,0 +1,13 @@
+#lang whalesong (require "../selfhost-lang.rkt")
+(require racket/match
+         "../compiler/expression-structs.rkt")
+
+(provide get-provided-names)
+
+;; get-provided-names: bytecode -> (listof ModuleProvide)
+(define (get-provided-names bytecode)
+  (match bytecode
+    [(struct Top [_ (struct Module (name path prefix requires provides code))])
+     provides]
+    [else
+     '()]))

--- a/whalesong/selfhost/selfhost-lang.rkt
+++ b/whalesong/selfhost/selfhost-lang.rkt
@@ -16,11 +16,13 @@
          sort
          natural?
          vector-copy
+         bytes->string/utf-8 ; is values
+         path->string
          ; no-ops
          :
+         ann
          log-debug
-         ensure-type-subsetof
-         )
+         ensure-type-subsetof)
 
 (require "selfhost-parameters.rkt")
 (require (for-syntax racket/base))
@@ -66,6 +68,7 @@
 (define-syntax (define-type stx) #'(void))
 (define-syntax (: stx) #'(void))
 (define-syntax (ensure-type-subsetof stx) #'(void))
+(define-syntax (ann stx) (syntax-case stx () [(_ expr type) #'expr]))
 
 (define-syntax (inst stx)
   (syntax-case stx ()
@@ -86,3 +89,7 @@
     (vector-set! v j (vector-ref vec i)))
   v)
 
+(define bytes->string/utf-8 values)
+
+(define (path->string x)
+  (error 'todo-implement-me))

--- a/whalesong/selfhost/selfhost-lang.rkt
+++ b/whalesong/selfhost/selfhost-lang.rkt
@@ -1,0 +1,76 @@
+#lang whalesong
+;;;
+;;;
+;;;
+
+;;; Note: define-predicate is not defined as a no-op here.
+;;;       We need the error message to find where to add our own predicates.
+
+(provide define-struct:
+         define-type
+         inst
+         make-parameter
+         parameterize
+         bytes?
+         path?
+         sort
+         natural?
+         ; no-ops
+         :
+         log-debug
+         ensure-type-subsetof
+         )
+
+(require "selfhost-parameters.rkt")
+(require (for-syntax racket/base))
+
+(define (bytes? o) #f)  ; TODO
+(define (path? o) #f)   ; TODO
+
+(define (sort xs <<)
+  (define (merge xs ys)
+    (cond 
+      [(empty? xs) ys]
+      [(empty? ys) xs]
+      [else (define x (first xs))
+            (define y (first ys))
+            (if (<< x y)
+                (cons x (merge (rest xs) ys))
+                (cons y (merge xs (rest ys))))]))
+  (define (split xs)
+    (define n (length xs))
+    (cond [(<= n 1) (list xs '())]
+          [else     (let loop ([ys '()] [xs xs] [i 0])
+                      (if (> (* 2 i) (- n 1))
+                          (list ys xs)
+                          (loop (cons (first xs) ys) (rest xs) (+ i 1))))]))
+  (define n (length xs))
+  (cond [(< n 2) xs]
+        [else (define halves (split xs))                  
+              (merge (sort (first halves) <<)
+                     (sort (second halves) <<))]))
+
+
+
+
+; define-struct: uses the same syntax as the one from typed/racket, but it 
+; simply discards the types and expand into standard Whalesong define-struct.
+
+(define-syntax (define-struct: stx)
+  (syntax-case stx (:)
+    [(ds: struct-name ([field-name : type] ...) options ...)
+     #'(define-struct struct-name (field-name ...) options ...)]))
+
+
+(define-syntax (define-type stx) #'(void))
+(define-syntax (: stx) #'(void))
+(define-syntax (ensure-type-subsetof stx) #'(void))
+
+(define-syntax (inst stx)
+  (syntax-case stx ()
+    [(_ e ignore ...)
+     #'e]))
+
+(define (log-debug . _) (void))
+
+(define (natural? o) (and (number? o) (integer? o) (not (negative? o))))

--- a/whalesong/selfhost/selfhost-lang.rkt
+++ b/whalesong/selfhost/selfhost-lang.rkt
@@ -15,6 +15,7 @@
          path?
          sort
          natural?
+         vector-copy
          ; no-ops
          :
          log-debug
@@ -74,3 +75,14 @@
 (define (log-debug . _) (void))
 
 (define (natural? o) (and (number? o) (integer? o) (not (negative? o))))
+
+(require whalesong/lang/for)
+
+(define (vector-copy vec [start 0] [end (vector-length vec)])
+  (define n (- end start))
+  (define v (make-vector n #\space))
+  (for ([i (in-range start end)]
+        [j (in-range 0 n)])
+    (vector-set! v j (vector-ref vec i)))
+  v)
+

--- a/whalesong/selfhost/selfhost-parameters.rkt
+++ b/whalesong/selfhost/selfhost-parameters.rkt
@@ -32,7 +32,9 @@
 
 (define-syntax (parameterize stx)
   (syntax-case stx ()
-    [(_ ([param-expr val-expr]) body ...)
+    [(_ () body ...) 
+     #'(let () body ...)]
+    [(_ ([param-expr val-expr] more ...) body ...)
      #'(let ()
          (define proc param-expr)
          (define p (find-parameter proc))
@@ -41,5 +43,5 @@
          (define vs (cons v old))
          (set-parameter-values! p vs)
          (begin0
-           body ...
+           (parameterize (more ...) body ...)
            (set-parameter-values! p old)))]))

--- a/whalesong/selfhost/selfhost-parameters.rkt
+++ b/whalesong/selfhost/selfhost-parameters.rkt
@@ -1,0 +1,45 @@
+#lang whalesong
+(require (for-syntax racket/base))
+(provide make-parameter
+         parameterize)
+
+(require (for-syntax syntax/parse))
+
+(struct parameter (values) #:mutable)
+
+(define *parameters* '())
+(define *ids* '())
+
+(define-syntax (push! stx)
+  (syntax-case stx ()
+    [(_ val)
+     #'(set! *parameters* (cons val *parameters*))]))
+
+(define (find-parameter id)
+  (cond
+    [(assq id *parameters*) => cdr]
+    [else (error 'find-parameter "parameter not found, got id: ~a" id)]))
+
+(define (make-parameter val)
+  (define p (parameter (list val)))
+  (define proc (case-lambda
+                 [()  (first (parameter-values (find-parameter proc)))]
+                 [(v) (define p (find-parameter proc))
+                      (define vs (cons v (parameter-values p)))
+                      (set-parameter-values! p vs)]))
+  (push! (cons proc p))
+  proc)
+
+(define-syntax (parameterize stx)
+  (syntax-case stx ()
+    [(_ ([param-expr val-expr]) body ...)
+     #'(let ()
+         (define proc param-expr)
+         (define p (find-parameter proc))
+         (define v  val-expr)
+         (define old (parameter-values p))
+         (define vs (cons v old))
+         (set-parameter-values! p vs)
+         (begin0
+           body ...
+           (set-parameter-values! p old)))]))

--- a/whalesong/selfhost/selfhost-strings.rkt
+++ b/whalesong/selfhost/selfhost-strings.rkt
@@ -1,6 +1,11 @@
 #lang whalesong (require "selfhost-lang.rkt" whalesong/lang/for)
 
-(provide string-replace) ; (string-replace k r s) replace all occurences of k in s with r
+(provide string-replace ; (string-replace k r s) replace all occurences of k in s with r
+         string-split-at-non-alphanumeric
+         string-join
+         string-titlecase)
+
+(define string-titlecase values) ; for now XXX todo: used in munge-label
 
 ; string-index : string string [integer] -> integer
 ;   return the index of the first occurence of k in the string s
@@ -39,13 +44,51 @@
 
 ; Test must evaluate to #t
 #;(and (= (string-index "bar" "foobarbazbar")
-        (string-index "bar" "foobarbazbar" 1)
-        (string-index "bar" "foobarbazbar" 2)
-        (string-index "bar" "foobarbazbar" 3) 
-        3)
-     (= (string-index "bar" "foobarbazbar" 4) 9)
-     (equal? (string-index "bar" "foobarbazbar" 10) #f))
+          (string-index "bar" "foobarbazbar" 1)
+          (string-index "bar" "foobarbazbar" 2)
+          (string-index "bar" "foobarbazbar" 3) 
+          3)
+       (= (string-index "bar" "foobarbazbar" 4) 9)
+       (equal? (string-index "bar" "foobarbazbar" 10) #f))
 
 ; (string-replace "foo" "_" "abfoocdfoooo")
+
+(define non-splitters
+  (let ()
+    (define alpha "qwertyuiopasdfghjklzxcvbnm")
+    (define ALPHA "QWERTYUIOPASDFGHJKLZXCVBNM")
+    (define nums  "0123456789")
+    (string->list (string-append alpha ALPHA nums))))
+
+; (regexp-split #rx"[^a-zA-Z0-9]+" s)
+(define (string-split-at-non-alphanumeric s)
+  (define (splitter? c) (not (memq c non-splitters)))
+  (define chunks
+    (reverse
+     (let loop ([chunks '()] [current '()] [xs (string->list s)])
+       (cond 
+         [(and (empty? xs) (empty? current))
+          chunks]
+         [(empty? xs)
+          (cons (reverse current) chunks)]
+         [(splitter? (car xs))
+          (loop (cons (reverse current) chunks) '() (cdr xs))]
+         [else 
+          (loop chunks (cons (car xs) current) (cdr xs))]))))
+  (map list->string chunks))
+
+
+(define (string-join strs [sep #f])
+  (apply string-append
+    (cond
+      [(empty? strs) '("")]
+      [(not sep)     strs]
+      [else          (let loop ([xs (list (car strs))] [ys (rest strs)])
+                       (if (empty? ys)
+                           (reverse xs)
+                           (loop (cons (car ys) (cons sep xs))
+                                 (cdr ys))))])))
+
+
 
 

--- a/whalesong/selfhost/selfhost-strings.rkt
+++ b/whalesong/selfhost/selfhost-strings.rkt
@@ -1,0 +1,51 @@
+#lang whalesong (require "selfhost-lang.rkt" whalesong/lang/for)
+
+(provide string-replace) ; (string-replace k r s) replace all occurences of k in s with r
+
+; string-index : string string [integer] -> integer
+;   return the index of the first occurence of k in the string s
+;   whose index is from or greater
+(define (string-index k s [from 0])
+  (define kn (string-length k))
+  (define sn (string-length s))
+  (and (<= (+ from kn) sn)
+       (for/or ([i (in-range from (- sn kn -1))])
+         (and (for/and ([j (in-range i (+ i kn))] [l (in-range kn)])
+                (char=? (string-ref s j) (string-ref k l)))
+              i))))
+
+; a new string is returned where occurences of the string k (the key)
+; are replaced with the string r (the replacement) in the string s.
+(define (string-replace k r s)
+  (define kn (string-length k))
+  (define sn (string-length s))
+  (let loop ([start 0] [from 0] [chunks '()])
+    (define i (string-index k s from))
+    (displayln (list 'loop start from chunks i))
+    (cond
+      [i    
+       (define new-start (+ i kn))
+       (loop new-start
+             new-start
+             (cons r (cons (substring s start i) chunks)))]
+      [(empty? chunks) 
+       (string-copy s)]
+      [else
+       (apply string-append
+         (reverse (cons (if (<= start sn)
+                            (substring s start)
+                            "")
+                        chunks)))])))
+
+; Test must evaluate to #t
+#;(and (= (string-index "bar" "foobarbazbar")
+        (string-index "bar" "foobarbazbar" 1)
+        (string-index "bar" "foobarbazbar" 2)
+        (string-index "bar" "foobarbazbar" 3) 
+        3)
+     (= (string-index "bar" "foobarbazbar" 4) 9)
+     (equal? (string-index "bar" "foobarbazbar" 10) #f))
+
+; (string-replace "foo" "_" "abfoocdfoooo")
+
+

--- a/whalesong/selfhost/sets.rkt
+++ b/whalesong/selfhost/sets.rkt
@@ -1,0 +1,59 @@
+#lang whalesong (require "selfhost-lang.rkt")
+
+(provide ; Setof 
+         new-set new-seteq
+         set-insert! set-remove! set-contains? 
+         set-for-each set-map
+         set->list list->set)
+
+; (define-struct: (A) set ([ht : (HashTable A Boolean)]))
+(define-struct set (ht))
+(define-type (Setof A) (set A))
+
+(: new-set (All (A) (->  (Setof A))))
+(define (new-set)
+  (make-set ((inst make-hash A Boolean))))
+
+(: new-seteq (All (A) (->  (Setof A))))
+(define (new-seteq)
+  (make-set ((inst make-hasheq A Boolean))))
+
+(: set-insert! (All (A) ((Setof A) A -> Void)))
+(define (set-insert! s elt)
+  (hash-set! (set-ht s) elt #t)
+  (void))
+  
+(: set-remove! (All (A) ((Setof A) A -> Void)))
+(define (set-remove! s elt)
+  ((inst hash-remove! A Boolean) (set-ht s) elt)
+  (void))
+
+(: set-contains? (All (A) ((Setof A) A -> Boolean)))
+(define (set-contains? s elt)
+  (hash-has-key? (set-ht s) elt))
+
+(: set-for-each (All (A) ((A -> Any) (Setof A) -> Void)))
+(define (set-for-each f s)
+  ((inst hash-for-each A Boolean Any)
+   (set-ht s)
+   (lambda (k v) ; ([k : A] [v : Boolean])
+            (f k)))
+  (void))
+
+
+(: set-map (All (A B) ((A -> B) (Setof A) -> (Listof B))))
+(define (set-map f s)
+  ((inst hash-map A Boolean B) (set-ht s) (lambda (k v) ; ([k : A] [v : Boolean])
+                                                   (f k))))
+
+(: set->list (All (A) ((Setof A) -> (Listof A))))
+(define (set->list a-set)
+  (set-map (lambda (k) #;([k : A]) k) a-set))
+
+(: list->set (All (A) ((Listof A) -> (Setof A))))
+(define (list->set a-lst)
+  (let ([a-set (new-set)]) ; : (Setof A) 
+    (for-each (lambda (k) #;([k : A])
+                (set-insert! a-set k))
+              a-lst)
+        a-set))

--- a/whalesong/selfhost/union-find.rkt
+++ b/whalesong/selfhost/union-find.rkt
@@ -1,0 +1,91 @@
+#lang typed/racket/base
+
+
+;; Union-find hardcoded to do symbols.
+
+(provide (all-defined-out))
+
+
+;; A forest contains a collection of its nodes keyed by element.
+;; The elements are compared by eq?
+(define-struct: forest 
+  ([ht : (HashTable Symbol node)]))
+
+
+;; A node is an element, a parent node, and a numeric rank.
+(define-struct: node 
+  ([elt : Symbol] 
+   [p : (U False node)]
+   [rank : Natural])
+  #:mutable)
+
+
+
+;; Builds a new, empty forest.
+(: new-forest (-> forest))
+(define (new-forest)
+  (make-forest (make-hash))) 
+
+
+;; lookup-node: forest X -> node
+;; Returns the node that's associated with this element.
+(: lookup-node (forest Symbol -> node))
+(define (lookup-node a-forest an-elt)
+  (unless (hash-has-key? (forest-ht a-forest) an-elt)
+    (make-set a-forest an-elt))
+  (hash-ref (forest-ht a-forest)
+            an-elt))
+
+
+
+;; make-set: forest X -> void
+;; Adds a new set into the forest.
+(: make-set (forest Symbol -> Void))
+(define (make-set a-forest an-elt)
+  (unless (hash-has-key? (forest-ht a-forest) an-elt)
+    (let ([a-node (make-node an-elt #f 0)])
+      (set-node-p! a-node a-node)
+      (hash-set! (forest-ht a-forest) an-elt a-node))))
+
+
+
+(: find-set (forest Symbol -> Symbol))
+;; Returns the representative element of elt.
+(define (find-set a-forest an-elt)
+  (let ([a-node (lookup-node a-forest an-elt)])
+    (node-elt (get-representative-node a-node))))
+
+
+
+(: get-representative-node (node -> node))
+;; Returns the representative node of a-node, doing path
+;; compression if we have to follow links.
+(define (get-representative-node a-node)
+  (let ([p (node-p a-node)])
+    (cond [(eq? a-node p)
+           a-node]
+          [(node? p)
+           (let ([rep (get-representative-node p)])
+             ;; Path compression is here:
+             (set-node-p! a-node rep)
+             rep)]
+          [else
+           ;; impossible situation
+           (error 'get-representative-node)])))
+
+
+(: union-set (forest Symbol Symbol -> Void))
+;; Joins the two elements into the same set.
+(define (union-set a-forest elt1 elt2)
+  (let ([rep1 (get-representative-node
+               (lookup-node a-forest elt1))]
+        [rep2 (get-representative-node
+               (lookup-node a-forest elt2))])
+    (cond
+      [(< (node-rank rep1) (node-rank rep2))
+       (set-node-p! rep1 rep2)]
+      [(> (node-rank rep1) (node-rank rep2))
+       (set-node-p! rep2 rep1)]
+      [else
+       (set-node-p! rep1 rep2)
+       (set-node-rank! rep1 (add1 (node-rank rep1)))])))

--- a/whalesong/tests/test-assemble.rkt
+++ b/whalesong/tests/test-assemble.rkt
@@ -69,7 +69,7 @@
                             (display "var M = new plt.runtime.Machine();\n" op)                           
                             (display "(function() { " op)
                             (display "var myInvoke = " op)
-                            (assemble/write-invoke a-statement op)
+                            (assemble/write-invoke a-statement op 'with-preemption)
                             (display ";" op)
                             (fprintf op 
                                      "return function(succ, fail, params) {

--- a/whalesong/tests/test-images.rkt
+++ b/whalesong/tests/test-images.rkt
@@ -601,8 +601,34 @@ Australia2
  (flip-horizontal
   (rotate 30 (square 50 "solid" "blue"))))
 
-"A solid blue triangle, rotated 30 degrees. Should be flush left"
-(rotate 30 (triangle 100 "solid" "blue"))
+(define blue-tri (triangle 100 "solid" "blue"))
+"A solid blue triangle, rotated 0 degrees. Should be pointing up."
+(rotate 0 blue-tri)
+"A solid blue triangle, rotated 30 degrees ccw. Should be flush left"
+(rotate 30 blue-tri)
+"A solid blue triangle, rotated 90 degrees ccw. Should be pointing left."
+(rotate 90 blue-tri)
+"A solid blue triangle, rotated 180 degrees ccw. Should be pointing down."
+(rotate 180 blue-tri)
+"A solid blue triangle, rotated 270 degrees ccw. Should be pointing right."
+(rotate 270 blue-tri)
+"A solid blue triangle, rotated 630 degrees ccw. Should be pointing right."
+(rotate 630 blue-tri)
+"A solid blue triangle, rotated 360 degrees ccw. Should be pointing up."
+(rotate 360 blue-tri)
+"A solid blue triangle, rotated 360.1 degrees ccw. Should be approximately pointing up."
+(rotate 360.1 blue-tri)
+"A solid blue triangle, rotated 720.5 degrees ccw. Should be approximately pointing up."
+(rotate 720.5 blue-tri)
+"A solid blue triangle, rotated 1.5 degrees cw. Should be approximately pointing up."
+(rotate -1.5 blue-tri)
+"A solid blue triangle, rotated -90 degrees ccw (90 cw). Should be pointing right."
+(rotate -90 blue-tri)
+"A solid blue triangle, rotated -450 degrees ccw (450 cw). Should be pointing right."
+(rotate -450 blue-tri)
+"A solid blue triangle, rotated -810 degrees ccw (810 cw). Should be pointing right."
+(rotate -810 blue-tri)
+
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; SCALE & SCALE/XY

--- a/whalesong/tests/test-images.rkt
+++ b/whalesong/tests/test-images.rkt
@@ -1,0 +1,897 @@
+#lang whalesong
+
+(require whalesong/world)
+(require whalesong/image)
+
+;(play-sound "http://www.html5tutorial.info/media/vincent.mp3" true)
+
+;; "Checking Empty scene"
+;; (empty-scene 40 50 "red")
+"These three circles (red, green, blue) should be left aligned"
+(above/align "left"
+             (circle 30 "solid" "red")
+             (above/align "left" (circle 50 'solid 'green) (circle 20 'solid 'blue)))
+
+
+"These three circles (red, green, blue) should be right aligned"
+(above/align "right"
+             (circle 30 "solid" "red")
+             (above/align "right" (circle 50 'solid 'green) (circle 20 'solid 'blue)))
+
+
+"These three circles (red, green, blue) should be middle aligned, vertically"
+(above/align "middle"
+             (circle 30 "solid" "red")
+             (above/align "middle" (circle 50 'solid 'green) (circle 20 'solid 'blue)))
+
+
+
+"These three circles (red, green, blue) should be top-aligned"
+(beside/align "top"
+             (circle 30 "solid" "red")
+             (beside/align "top" (circle 50 'solid 'green) (circle 20 'solid 'blue)))
+
+"These three circles (red, green, blue) should be bottom-aligned"
+(beside/align "bottom"
+             (circle 30 "solid" "red")
+             (beside/align "bottom" (circle 50 'solid 'green) (circle 20 'solid 'blue)))
+
+"These three circles (red, green, blue) should be middle-aligned, horizontally"
+(beside/align "middle"
+             (circle 30 "solid" "red")
+             (beside/align "middle" (circle 50 'solid 'green) (circle 20 'solid 'blue)))
+
+
+
+
+
+"should be a bar graph"
+(define (make-stars number)
+  (cond [(eq? number 1) (star 12 "solid" "purple")]
+        [true (beside (star 12 "solid" "purple") (make-stars (- number 1)))] ))
+(define (bar-graph l1)
+  (cond [(empty? l1) (circle 0 "outline" "blue")]
+        [true (above/align "left" (make-stars (car l1)) (bar-graph (cdr l1)))]))
+(bar-graph '(1 3 5 3 9 5 3 4 4 3 5 2))
+
+
+
+(check-expect (image? 'blue) #f)
+(check-expect (image? (circle 20 "solid" "green")) #t)
+
+"should be a solid green circle: " (circle 20 "solid" "green")
+
+"should be an outline turquoise rectangle: " (rectangle 20 30 "outline" "turquoise")
+
+"should be a solid, mostly-translucent red rectangle: " (rectangle 200 300 10 "red")
+"should be an outline red rectangle: " (rectangle 200 300 "outline" "red")
+"should be an *invisible* red rectangle: " (rectangle 200 300 0 "red")
+
+(define halfred (make-color 255 0 0 128))
+(define quarterred (make-color 255 0 0 64))
+"should be a solid red triangle" (triangle 50 "solid" "red")
+"should be a solid triangle made from a half-transparent red" (triangle 50 "solid" halfred)
+"should be a solid, half-alpha triangle made from a half-transparent red" (triangle 50 128 halfred)
+"should be a solid triangle made from a quater-trasparent red" (triangle 50 "solid" quarterred)
+
+;(check-expect (color? (make-color 3 4 5)))
+
+(check-expect (color-red (make-color 3 4 5)) 3)
+(check-expect (color-green (make-color 3 4 5)) 4)
+(check-expect (color-blue (make-color 3 4 5)) 5)
+
+(check-expect (image? (empty-scene 20 50)) true)
+
+(check-expect (image? (place-image (circle 50 'solid 'blue)
+                                   50
+                                   50
+                                   (empty-scene 100 100)))
+              true)
+
+"should be a blue circle in a scene with a border: " (place-image (circle 50 'solid 'blue)
+                                                                  50
+                                                                  50
+                                                                  (empty-scene 100 100))
+
+"should be a blue circle in the UR of a scene with a border: " (put-image (circle 50 'solid 'blue)
+                                                                  100
+                                                                  100
+                                                                  (empty-scene 100 100))
+
+(check-expect (image?
+               (rectangle 20 20 'solid 'green))
+              true)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; TEXT & TEXT/FONT
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+"simple text functionality" 
+(text "hello world" 20 'black)
+(text (string-copy "hello world") 30 'purple)
+(text "hello world" 40 'red)
+
+
+"test font-weight"
+(text/font "Hello" 24 "purple"
+           "Gill Sans" 'swiss 'normal 'bold #f)
+(text/font "Hello" 24 "green"
+           "Gill Sans" 'swiss 'normal 'light #f)
+
+"test font-style"
+(text/font "Goodbye" 48 "indigo"
+           "Helvetica" 'modern 'italic 'normal #f)
+(text/font "Goodbye" 48 "indigo"
+           "Helvetica" 'modern 'normal 'normal #f)
+
+"test underline-height calculation"
+(text/font "test this!" 80 "purple"
+           "Helvetica" 'roman 'normal 'normal #t)
+
+(text/font "low-hanging glyphs" 36 "blue"
+           "Times" 'roman 'normal 'bold #t)  
+
+(text/font "teeny-tiny text" 8 "black"
+           "Times" 'roman 'normal 'bold #t)  
+
+(text/font "not really a link" 36 "blue"
+           "Courier" 'roman 'italic 'normal #t)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; IMAGE-URL & VIDEO-URL
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+"importing images and video"
+(image-url "http://www.bootstrapworld.org/images/icon.png")
+(open-image-url "http://www.bootstrapworld.org/images/icon.png")
+
+;(video/url "http://www.quirksmode.org/html5/videos/big_buck_bunny.mp4")
+#;(overlay (circle 20 "solid" "red")
+  (video/url "http://www.quirksmode.org/html5/videos/big_buck_bunny.mp4"))
+#;(rotate 45
+  (video/url "http://www.quirksmode.org/html5/videos/big_buck_bunny.mp4"))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; OVERLAY
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+"the next two images should be identical"
+(overlay (circle 20 "solid" (make-color  50  50 255))
+         (square 40 "solid" (make-color 100 100 255)))
+         
+
+(overlay (circle 20 "solid" (make-color  50  50 255))
+         (regular-polygon 40 4 "solid" (make-color 100 100 255)))
+
+(overlay (ellipse 10 10 "solid" "red")
+         (ellipse 20 20 "solid" "black")
+         (ellipse 30 30 "solid" "red")
+         (ellipse 40 40 "solid" "black")
+         (ellipse 50 50 "solid" "red")
+         (ellipse 60 60 "solid" "black"))
+
+"the next two images should be identical"
+(overlay (square 20 "solid" (make-color  50  50 255))
+         (square 26 "solid" (make-color 100 100 255))
+         (square 32 "solid" (make-color 150 150 255))
+         (square 38 "solid" (make-color 200 200 255))
+         (square 44 "solid" (make-color 250 250 255)))
+(overlay (regular-polygon 20 4 "solid" (make-color  50  50 255))
+         (regular-polygon 26 4 "solid" (make-color 100 100 255))
+         (regular-polygon 32 4 "solid" (make-color 150 150 255))
+         (regular-polygon 38 4 "solid" (make-color 200 200 255))
+         (regular-polygon 44 4 "solid" (make-color 250 250 255)))
+
+"overlay with place-image - target should be centered"
+ (place-image (overlay (ellipse 10 10 "solid" "white")
+                    (ellipse 20 20 "solid" "black")                   
+                     (ellipse 30 30 "solid" "white")                    
+                      (ellipse 40 40 "solid" "black")       
+                       (ellipse 50 50 "solid" "white")
+                        (ellipse 60 60 "solid" "black"))
+ 150 100
+ (rectangle 300 200 "solid" "black"))
+
+
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; OVERLAY/XY
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+"should be some overlay/xys"
+(overlay/xy (rectangle 20 20 "outline" "black")
+            20 0
+            (rectangle 20 20 "outline" "black"))
+(overlay/xy (rectangle 20 20 "solid" "red")
+            20 20
+            (rectangle 20 20 "solid" "black"))
+(overlay/xy (rectangle 20 20 "solid" "red")
+            -20 -20
+            (rectangle 20 20 "solid" "black"))
+(overlay/xy
+ (overlay/xy (ellipse 40 40 "outline" "black")
+             10
+             15
+             (ellipse 10 10 "solid" "forestgreen"))
+ 20
+ 15
+ (ellipse 10 10 "solid" "forestgreen"))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; OVERLAY/ALIGN
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+"some examples of overlay/align"
+(overlay/align "middle" "middle"
+               (ellipse 60 30 "solid" "purple")
+               (rectangle 30 60 "solid" "orange"))
+(overlay/align "right" "top"
+               (ellipse 60 30 "solid" "purple")
+               (rectangle 30 60 "solid" "orange"))
+(overlay/align "left" "bottom"
+               (ellipse 60 30 "solid" "purple")
+               (rectangle 30 60 "solid" "orange"))
+
+(overlay/align "right" "bottom"
+               (rectangle 20 20 "solid" "silver")
+               (rectangle 30 30 "solid" "seagreen")
+               (rectangle 40 40 "solid" "silver")
+               (rectangle 50 50 "solid" "seagreen"))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; UNDERLAY
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+"some underlays"
+(underlay (circle 20 'solid 'green)
+          (rectangle 10 20 'solid 'blue))
+
+(underlay (ellipse 10 60 "solid" "red")
+          (ellipse 20 50 "solid" "black")
+          (ellipse 30 40 "solid" "red")
+          (ellipse 40 30 "solid" "black")
+          (ellipse 50 20 "solid" "red")
+          (ellipse 60 10 "solid" "black"))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; UNDERLAY/XY & UNDERLAY/ALIGN
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+"examples of underlay and underlay/align"
+(underlay/xy (circle 20 'solid 'green)
+             30 10
+             (rectangle 10 20 'solid 'blue))
+
+
+
+;; color list
+"the following should be a blue circle, but by using color-list->image"
+(let ([circle-color-list (image->color-list (circle 20 'solid 'blue))])
+  ;; fixme: add tests for number of colors
+  (color-list->image circle-color-list 40 40 0 0))
+
+
+
+
+(underlay/align "middle" "middle"
+                (ellipse 60 30 "solid" "purple")
+                (rectangle 30 60 "solid" "orange"))
+(underlay/align "right" "top"
+                (ellipse 60 30 "solid" "purple")
+                (rectangle 30 60 "solid" "orange"))
+(underlay/align "left" "bottom"
+                (ellipse 60 30 "solid" "purple")
+                (rectangle 30 60 "solid" "orange"))
+
+(underlay/align "right" "bottom"
+                (rectangle 50 50 "solid" "silver")
+                (rectangle 40 40 "solid" "seagreen")
+                (rectangle 30 30 "solid" "silver")
+                (rectangle 20 20 "solid" "seagreen"))
+
+"This is issue 40 https://github.com/dyoo/WeScheme/issues/40"
+(underlay/align "left" "middle"
+                (rectangle 30 60 "solid" "orange")
+                (ellipse 60 30 "solid" "purple"))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; BESIDE & BESIDE/ALIGN
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+"examples of beside and beside/align"
+(beside (ellipse 20 70 "solid" "gray")
+        (ellipse 20 50 "solid" "darkgray")
+        (ellipse 20 30 "solid" "dimgray")
+        (ellipse 20 10 "solid" "black"))
+
+(beside/align "bottom"
+              (ellipse 20 70 "solid" "lightsteelblue")
+              (ellipse 20 50 "solid" "mediumslateblue")
+              (ellipse 20 30 "solid" "slateblue")
+              (ellipse 20 10 "solid" "navy"))
+
+(beside/align "top"
+              (ellipse 20 70 "solid" "mediumorchid")
+              (ellipse 20 50 "solid" "darkorchid")
+              (ellipse 20 30 "solid" "purple")
+              (ellipse 20 10 "solid" "indigo"))
+
+"align these text images on their baselines"
+(beside/align "baseline"
+              (text "ijy" 18 "black")
+              (text "ijy" 24 "black"))               
+
+
+"issue 25 https://github.com/dyoo/WeScheme/issues/25"
+(beside/align "top"
+              (rectangle 20 100 "solid" "black")
+              (rectangle 20 120 "solid" "black")
+              (rectangle 20 80 "solid" "black"))
+
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; ABOVE & ABOVE/ALIGN
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+"should be some examples of above and above/align"
+(above (ellipse 70 20 "solid" "gray")
+       (ellipse 50 20 "solid" "darkgray")
+       (ellipse 30 20 "solid" "dimgray")
+       (ellipse 10 20 "solid" "black"))
+
+(above/align "right"
+             (ellipse 70 20 "solid" "gold")
+             (ellipse 50 20 "solid" "goldenrod")
+             (ellipse 30 20 "solid" "darkgoldenrod")
+             (ellipse 10 20 "solid" "sienna"))
+(above/align "left"
+             (ellipse 70 20 "solid" "yellowgreen")
+             (ellipse 50 20 "solid" "olivedrab")
+             (ellipse 30 20 "solid" "darkolivegreen")
+             (ellipse 10 20 "solid" "darkgreen"))
+
+
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; PLACE-IMAGE/ALIGN
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+"should be right in the center"
+(place-image/align (circle 16 "solid" "yellow")
+                   32 32 "center" "center"
+                   (rectangle 64 64 "solid" "goldenrod"))
+
+"should be at the bottom-right corner"
+(place-image/align (circle 16 "solid" "yellow")
+                   32 32 "left" "top"
+                   (rectangle 64 64 "solid" "goldenrod"))
+
+"should be at the upper-left corner"
+(place-image/align (circle 16 "solid" "yellow")
+                   32 32 "right" "bottom"
+                   (rectangle 64 64 "solid" "goldenrod"))  
+
+"test 'beside' with scenes -- from the DrRacket documentation"
+(beside (place-image/align (circle 8 "solid" "tomato")
+                           0 0 "center" "center"
+                           (rectangle 32 32 "outline" "black"))
+        (place-image/align (circle 8 "solid" "tomato")
+                           8 8 "center" "center"
+                           (rectangle 32 32 "outline" "black"))
+        (place-image/align (circle 8 "solid" "tomato")
+                           16 16 "center" "center"
+                           (rectangle 32 32 "outline" "black"))
+        (place-image/align (circle 8 "solid" "tomato")
+                           24 24 "center" "center"
+                           (rectangle 32 32 "outline" "black"))
+        (place-image/align (circle 8 "solid" "tomato")
+                           32 32 "center" "center"
+                           (rectangle 32 32 "outline" "black")))   
+
+"some overlay and place-image stress tests"                           
+(define flag2
+  (place-image
+   (rotate 90
+              (underlay/align
+               "center" "center"
+               (rectangle 50 450 "solid" "white")
+               (rotate 90
+                       (rectangle 50 450 "solid" "white"))
+               (rotate 90 
+                       (rectangle 30 450 "solid" "red"))
+               (rotate 180
+                       (rectangle 30 450 "solid" "red"))))
+           
+   200 100
+   (place-image
+    (rotate 65
+           (underlay/align
+            "center" "center"
+            (rectangle 15 450 "solid" "red")       
+            (rotate 50
+                    (rectangle 15 450 "solid" "red"))))
+   200 100
+    (place-image
+     (rotate 65
+             (underlay/align
+             "center" "center"
+             (rectangle 40 450 "solid" "white")
+             (rotate 50
+                     (rectangle 40 450 "solid" "white"))))
+     200 100
+    (rectangle 400 200 "solid" "navy")))))
+   
+
+(define Australia2
+  (place-image
+   flag2
+   200 100
+   (place-image
+    (star-polygon 30 7 3 "solid" "white")
+   650 60
+   (place-image 
+    (star-polygon 50 7 3 "solid" "white")
+   200 300
+    (place-image 
+    (star-polygon 40 7 3 "solid" "white")
+   60 20
+     (place-image 
+    (star-polygon 40 7 3 "solid" "white")
+   68 124
+   (rectangle 900 400 "solid" "navy")))))))
+   flag2
+Australia2
+
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; TRIANGLE, RIGHT TRIANGLE & ISOSCELES-TRIANGLE
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+"Three triangles of various sizes and fills"
+(triangle 36 "solid" "darkslategray")
+(triangle  4 "solid" "purple")
+(triangle 30 "outline" "cornflowerblue")
+
+"Triangles side by side"
+(beside (triangle 36 "solid" "darkslategray")
+        (triangle 30 "solid" "cornflowerblue"))
+
+"Triangles above."
+(above (triangle 36 "solid" "darkslategray")
+       (triangle 30 "solid" "cornflowerblue"))
+
+"Three right triangles of various sizes and fills"
+(right-triangle 36 48 "solid" "darkslategray")
+(right-triangle  4 60 "solid" "purple")
+(right-triangle 30 40 "solid" "cornflowerblue")
+
+"Three isosceles triangles of various sizes and fills"
+
+(isosceles-triangle 60 30 "solid" "aquamarine")
+(isosceles-triangle 200 170 "outline" "seagreen")
+(isosceles-triangle 60 330 "solid" "lightseagreen")
+
+"Trying ASA triangle (30 40 60)"
+(triangle/asa 30 40 60 "solid" "blue")
+
+"Trying AAS triangle (30 60 40)"
+(triangle/aas 30 60 40 "outline" "green")
+
+"Trying SAA triangle (100 30 90)"
+(triangle/saa 100 30 90 "solid" "red")
+
+"Trying SSA triangle (60 60 40)"
+(triangle/ass 60 60 40 "outline" "turquoise")
+
+"Trying ASS triangle (60 80 90)"
+(triangle/ass 60 80 90 "solid" "maroon")
+
+"Trying SSS triangle (60 60 60)"
+(triangle/sss 60 60 60 "outline" "red")
+   
+"Trying SAS triangle (60 30 60)"
+(triangle/sas 60 30 60 "solid" "brown")
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; STAR, RADIAL-STAR & STAR-POLYGON
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+"old star implementation"
+
+(star 5  8  4 "solid"   "darkslategray")
+(star 5 30 15 "outline" "black")
+(star 5 20 10 "solid"   "red")
+
+"new star implementation"
+(star 8 "solid"    "darkslategray")
+(star 30 "outline" "black")
+(star 20 "solid"   "red")
+
+"radial star"
+(radial-star 8 8 64 "solid" "darkslategray")
+(radial-star 32 30 40 "outline" "black")
+(radial-star 5 20 40 "solid" "red")
+
+"star-polygon"
+(star-polygon 40 5 2 "solid" "seagreen")
+(star-polygon 40 7 3 "outline" "darkred")
+(star-polygon 20 10 3 "solid" "cornflowerblue")
+"should look like a pentagon"
+(star-polygon 20 5 1 "solid" "darkblue")
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; SQUARE
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+"Three squares of various sizes and fills"
+(square 60 "outline" "black")
+(square 200 "solid" "seagreen")
+(square 100 "outline" "blue")
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; RHOMBUS 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+"Three rhombuses of various sizes and fills"
+(rhombus 40 45 "solid" "magenta")
+(rhombus 100 200 "solid" "orange")
+(rhombus 80 330 "outline" "seagreen")
+
+"rhombuses beside each other"
+(beside (rhombus 40 45 "solid" "magenta")
+        (rhombus 100 200 "solid" "orange")
+        (rhombus 80 330 "outline" "seagreen"))
+
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; REGULAR-POLYGON
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+"Some regular polygons..."
+"A triangle of side-length 20: should be 20x17"
+(regular-polygon 20 3 "solid" "purple")
+"A square of side-length 40: should be 40x40"
+(regular-polygon 40 4 "solid" "aquamarine")
+"A pentagon of side-length 30: should be 49x46"
+(regular-polygon 30 5 "solid" "pink")
+"A hexagon of side-length 20: should be 40x35"
+(regular-polygon 20 6 "solid" "gold")
+"A septagon of side-length 40: should be 90x88"
+(regular-polygon 40 7 "solid" "goldenrod")
+"An octagon of side-length 30: should be 72x72"
+(regular-polygon 30 8 "solid" "darkgoldenrod")
+"A nonagon of side-length 20: should be 58x57"
+(regular-polygon 20 9 "solid" "sienna")
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; POLYGON
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+"Some polygons defined with posns..."
+#;(polygon (list (make-posn 0 0)
+                (make-posn -10 20)
+                (make-posn 60 0)
+                (make-posn -10 -20))
+          "solid"
+          "burlywood")
+          
+#;(polygon (list (make-posn 0 0)
+                 (make-posn 0 40)
+                 (make-posn 20 40)
+                 (make-posn 20 60)
+                 (make-posn 40 60)
+                 (make-posn 40 20)
+                 (make-posn 20 20)
+                 (make-posn 20 0))
+           "solid"
+           "plum")
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; ROTATE
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+"Three images at 30, 60, 90 degree rotation:"
+(rotate 30 (image-url "http://www.bootstrapworld.org/images/icon.png"))
+(rotate 60 (image-url "http://www.bootstrapworld.org/images/icon.png"))
+(rotate 90 (image-url "http://www.bootstrapworld.org/images/icon.png"))
+
+"Rotated, huge image"
+(rotate 30 (scale 3 (image-url "http://www.bootstrapworld.org/images/icon.png")))
+
+"From the Racket documentation:"
+(rotate 45 (ellipse 60 20 "solid" "olivedrab"))
+(rotate 5 (rectangle 50 50 "outline" "black"))
+"unrotated T"
+(beside/align
+         "center"
+         (rectangle 40 20 "solid" "darkseagreen")
+         (rectangle 20 100 "solid" "darkseagreen"))
+"rotate 45 degrees"
+(rotate 45
+        (beside/align
+         "center"
+         (rectangle 40 20 "solid" "darkseagreen")
+         (rectangle 20 100 "solid" "darkseagreen")))
+
+(beside
+ (rotate 30 (square 50 "solid" "red"))
+ (flip-horizontal
+  (rotate 30 (square 50 "solid" "blue"))))
+
+"A solid blue triangle, rotated 30 degrees. Should be flush left"
+(rotate 30 (triangle 100 "solid" "blue"))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; SCALE & SCALE/XY
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;       
+"scaling small and large"
+(scale 1/2 (image-url "http://www.bootstrapworld.org/images/icon.png"))
+(scale 2 (image-url "http://www.bootstrapworld.org/images/icon.png"))
+
+(scale/xy 1 2 (image-url "http://www.bootstrapworld.org/images/icon.png"))
+(scale/xy 2 1 (image-url "http://www.bootstrapworld.org/images/icon.png"))
+
+"This should be the normal image"
+(scale/xy 1 1 (image-url "http://www.bootstrapworld.org/images/icon.png"))
+
+"From the Racket documentation: two identical ellipses, and a circle"
+(scale 2 (ellipse 20 30 "solid" "blue"))
+(ellipse 40 60 "solid" "blue")
+(scale/xy  3
+           2
+           (ellipse 20 30 "solid" "blue"))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; FRAME AND CROP
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;       
+"frame and crop examples from DrRacket documentation"
+(frame (ellipse 20 20 "outline" "black"))
+
+(beside
+ (ellipse 20 70 "solid" "lightsteelblue")
+ (frame (ellipse 20 50 "solid" "mediumslateblue"))
+ (ellipse 20 30 "solid" "slateblue")
+ (ellipse 20 10 "solid" "navy"))
+
+(crop 0 0 40 40 (circle 40 "solid" "chocolate"))
+(crop 40 60 40 60 (ellipse 80 120 "solid" "dodgerblue"))
+(above
+ (beside (crop 40 40 40 40 (circle 40 "solid" "palevioletred"))
+         (crop 0 40 40 40 (circle 40 "solid" "lightcoral")))
+ (beside (crop 40 0 40 40 (circle 40 "solid" "lightcoral"))
+         (crop 0 0 40 40 (circle 40 "solid" "palevioletred"))))
+
+"should be a quarter of a circle, inscribed in a square"
+(place-image
+ (crop 0 0 20 20 (circle 20 "solid" "Magenta"))
+ 10 10
+ (rectangle 40 40 "solid" "blue"))
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; LINE, ADD-LINE & SCENE+LINE
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+"Three tests for line"
+(line 30 30 "black")
+
+(line -30 20 "red")
+
+(line 30 -20 "red")
+
+"Three tests for add-line"
+(add-line (ellipse 40 40 "outline" "maroon")
+          0 40 40 0 "maroon")
+
+(add-line (rectangle 40 40 "solid" "gray")
+          -10 50 50 -10 "maroon")
+
+(add-line
+ (rectangle 100 100 "solid" "darkolivegreen")
+ 25 25 100 100
+ "goldenrod")
+
+"Three tests for scene+line: should be identical to above, but cropped around base image"
+(scene+line (ellipse 40 40 "outline" "maroon")
+            0 40 40 0 "maroon")
+
+(scene+line (rectangle 40 40 "solid" "gray")
+            -10 50 50 -10 "maroon")
+
+(scene+line
+ (rectangle 100 100 "solid" "darkolivegreen")
+ 25 25 100 100
+ "goldenrod")
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; FLIP-VERTICAL & FLIP-HORIZONTAL
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+"a red triangle, a blue one flippled horizontally and a green one flippled vertically"
+(right-triangle 30 40 "solid" "red")
+(flip-horizontal (right-triangle 30 40 "solid" "blue"))
+(flip-vertical (right-triangle 30 40 "solid" "green"))
+
+"those three triangles beside each other"
+(beside (right-triangle 30 40 "solid" "red")
+        (flip-horizontal (right-triangle 30 40 "solid" "blue"))
+        (flip-vertical (right-triangle 30 40 "solid" "green")))
+
+
+
+"one image flipped vertically, and one flipped horizontally"
+(flip-vertical (image-url "http://www.bootstrapworld.org/images/icon.png"))
+(flip-horizontal (image-url "http://www.bootstrapworld.org/images/icon.png"))
+
+"BESIDE: reference image"
+(beside (square 20 "solid" (make-color  50  50 255))
+        (square 34 "solid" (make-color 150 150 255)))
+
+"flip the second one horizontally"          
+(beside (square 20 "solid" (make-color  50  50 255))
+        (flip-horizontal (square 34 "solid" (make-color 150 150 255))))
+
+"flip the second one vertically"          
+(beside (square 20 "solid" (make-color  50  50 255))
+        (flip-vertical (square 34 "solid" (make-color 150 150 255))))
+
+"flip the first one horizontally"          
+(beside (flip-horizontal (square 20 "solid" (make-color  50  50 255)))
+        (square 34 "solid" (make-color 150 150 255)))
+
+"flip the first one vertically"          
+(beside (flip-vertical (square 20 "solid" (make-color  50  50 255)))
+        (square 34 "solid" (make-color 150 150 255)))
+
+"ABOVE: reference image"
+(above (square 20 "solid" (make-color  50  50 255))
+       (square 34 "solid" (make-color 150 150 255)))
+
+"flip the second one horizontally"          
+(above (square 20 "solid" (make-color  50  50 255))
+       (flip-horizontal (square 34 "solid" (make-color 150 150 255))))
+
+"flip the second one vertically"          
+(above (square 20 "solid" (make-color  50  50 255))
+       (flip-vertical (square 34 "solid" (make-color 150 150 255))))
+
+"flip the first one horizontally"          
+(above (flip-horizontal (square 20 "solid" (make-color  50  50 255)))
+       (square 34 "solid" (make-color 150 150 255)))
+
+"flip the first one vertically"          
+(above (flip-vertical (square 20 "solid" (make-color  50  50 255)))
+       (square 34 "solid" (make-color 150 150 255)))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; IMAGE EQUALITY
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+"checking a circle against a rectangle"
+(check-expect (image=? (circle 50 "solid" "blue")
+                       (rectangle 20 30 "outline" "turquoise"))
+              #f)
+(check-expect (image=? (empty-scene 20 50) (empty-scene 20 50)) true)
+
+"checking a circle against a different one"
+(check-expect (image=? (circle 50 "solid" "blue")
+                       (circle 50 "solid" "turquoise"))
+              #f)
+
+"checking a triangle against a different one"
+(check-expect (image=? (triangle 50 "solid" "blue")
+                       (triangle 50 "outline" "blue"))
+              #f)
+
+"checking a circle against a different one"
+(check-expect (image=? (circle 50 "solid" "blue")
+                       (circle 50 "solid" "turquoise"))
+              #f)
+
+"checking a textImage against a different one"
+(check-expect (image=? (text "purple" 50 "blue")
+                       (text "purple" 50 "red"))
+              #f)
+
+"checking a textImage against itself"
+(check-expect (image=? (text "purple" 50 "blue")
+                       (text "purple" 50 "blue"))
+              #t)
+
+"checking a bitmap against itself"
+(check-expect (image=? (bitmap/url "http://www.bootstrapworld.org/images/icon.gif")
+                       (bitmap/url "http://www.bootstrapworld.org/images/icon.gif"))
+              #t)
+
+"checking a bitmap against a shape of the same size"
+(check-expect (image=? (bitmap/url "http://www.bootstrapworld.org/images/icon.gif")
+                       (rectangle 150 150 "solid" "pink"))
+              #f)
+
+"checking a bitmap against a shape of a different size"
+(check-expect (image=? (bitmap/url "http://www.bootstrapworld.org/images/icon.gif")
+                       (rectangle 100 100 "solid" "pink"))
+              #f)
+
+"checking a bitmap against a different one"
+(check-expect (image=? (bitmap/url "http://www.bootstrapworld.org/images/icon.gif")
+                       (bitmap/url "http://www.bootstrapworld.org/images/icon.png"))
+              #f)
+
+"checking a rectangle against itself"
+(check-expect (image=? (rectangle 100 50 "solid" "blue")
+                       (rectangle 100 50 "solid" "blue"))
+              #t)
+
+"checking a rhombus against itself"
+(check-expect (image=? (rhombus 100 50 "solid" "blue")
+                       (rhombus 100 50 "solid" "blue"))
+              #t)
+
+"checking a square against a 2x larger one that's been scaled by 1/2"
+(check-expect (image=? (scale 1/2 (square 100 "solid" "blue"))
+                       (square 50 "solid" "blue"))
+              #t)
+
+"checking a square against a 2x larger one that's been scaled by 1/3"
+(check-expect (image=? (scale 1/3 (square 100 "solid" "blue"))
+                       (square 50 "solid" "blue"))
+              #f)
+
+"checking a rectangle against its equivalent polygon"
+(check-expect (image=? (regular-polygon 40 4 "solid" "black")
+                       (rectangle 40 40 "solid" "black"))
+              #t)
+
+"checking a circle against its equivalent ellipse"
+(check-expect (image=? (circle 50 90 "orange")
+                       (ellipse 100 100 90 "orange"))
+              #t)
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; IMAGE PROPERTIES
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+"(image-width (ellipse 30 40 'solid' 'orange'))"
+(image-width (ellipse 30 40 "solid" "orange"))
+
+"(image-width (circle 30 'solid' 'orange'))"
+(image-width (circle 30 "solid" "orange"))
+
+"(image-width (beside (circle 20 'solid' 'orange') (circle 20 'solid' 'purple')))"
+(image-width (beside (circle 20 "solid" "orange") (circle 20 "solid" "purple")))
+
+"(image-height (overlay (circle 20 'solid' 'orange') (circle 30 'solid' 'purple')))"
+(image-height (overlay (circle 20 "solid" "orange") (circle 30 "solid" "purple")))
+
+"(image-height (rectangle 10 0 'solid' 'purple'))"
+(image-height (rectangle 10 0 "solid" "purple"))
+
+"(image-baseline (text 'Hello' 24 'black'))"
+(image-baseline (text "Hello" 24 "black"))
+
+"(image-baseline (text/font 'Goodbye' 48 'indigo' 'Helvetica' 'modern 'normal 'normal #f))"
+(image-baseline (text/font "Goodbye" 48 "indigo" "Helvetica" 'modern 'normal 'normal #f))
+
+
+"(image-height (text/font 'Goodbye' 48 'indigo' 'Helvetica' 'modern 'normal 'normal #f))"
+(image-height (text/font "Goodbye" 48 "indigo" "Helvetica" 'modern 'normal 'normal #f))
+
+"(image-baseline (rectangle 100 100 'solid' 'black'))"
+(image-baseline (rectangle 100 100 "solid" "black"))
+
+"(image-height (rectangle 100 100 'solid' 'black'))"
+(image-height (rectangle 100 100 "solid" "black"))
+
+
+"(mode? 'outline')"
+(mode? "outline")
+
+"(mode? 'checkered')"
+(mode? "checkered")
+
+"(image-color? 'pink')"
+(image-color? "pink")
+
+"(image-color? 'puke')"
+(image-color? "puke")
+
+"(y-place? 'middle')"
+(y-place? "middle")
+
+"(x-place? 'up-top')"
+(x-place? "up-top")
+
+"(angle? 290)"
+(angle? 290)
+
+"(angle? -290)"
+(angle? -290)
+
+"(side-count? 20)"
+(side-count? 20)
+
+"(side-count? 2)"
+(side-count? 2)
+
+"(step-count? 2)"
+(step-count? 2)
+
+"(step-count? 0)"
+(step-count? 0)

--- a/whalesong/tests/test-parse-bytecode.rkt
+++ b/whalesong/tests/test-parse-bytecode.rkt
@@ -117,7 +117,6 @@
                 (make-LocalRef 0 #f)))
 
 
-
 ;; let1's
 (check-equal? (run-my-parse #'(let ([y (f)])
                                 'ok))
@@ -194,7 +193,6 @@
                         (make-Branch (make-ToplevelRef 0 0 #f #t)
                                      (make-ToplevelRef 0 1 #f #t)
                                      (make-Constant (void)))))
-
 
 
 
@@ -383,7 +381,8 @@
 
 
 ;; todo: see what it would take to run a typed/racket/base language.
-(void 
+; This test currently breaks rewrite-path in path-rewriter.rkt
+#;(void 
  (run-my-parse '(module foo typed/racket/base 
                         (provide x) 
                         (: x Number)

--- a/whalesong/tests/test-parse.rkt
+++ b/whalesong/tests/test-parse.rkt
@@ -1,9 +1,16 @@
 #lang racket/base
-
-(require "../parser/baby-parser.rkt"
+(require (rename-in "../parser/baby-parser.rkt"
+                    [parse baby-parse])
          "../compiler/lexical-structs.rkt"
          "../compiler/expression-structs.rkt"
          (for-syntax racket/base))
+
+
+(define (parse x)
+  (parameterize ([current-short-labels? #f])
+    (reset-make-label-counter)
+    (baby-parse x)))
+
 
 (printf "test-parse.rkt\n");
 

--- a/whalesong/whalesong-cmd.rkt
+++ b/whalesong/whalesong-cmd.rkt
@@ -200,7 +200,7 @@
                       (current-verbose? #t)]
                      [("--debug-show-timings")
                       ("Display debug messages about compilation time.")
-                      (current-timing-port (current-output-port))]
+                      (current-timing-port (current-error-port))]
                      [("--enable-profiling")
                       ("Enable profiling to standard output")
                       (with-profiling? #t)]

--- a/whalesong/whalesong-cmd.rkt
+++ b/whalesong/whalesong-cmd.rkt
@@ -17,7 +17,7 @@
 
 ;; Usage:
 ;;
-;; * Build standalone .xhtml application.
+;; * Build standalone .html application.
 ;;
 ;;     $ whalesong build main-module-name.rkt
 ;;
@@ -102,8 +102,8 @@
              dest-dir
              ("Set destination directory (default: current-directory)")
              (current-output-dir dest-dir)]
-            [("--as-standalone-xhtml")
-             ("Write single standalone xhtml file")
+            [("--as-standalone-html")
+             ("Write single standalone html file")
              (as-standalone-html? #t)]
             #:multi
             [("--include-script")
@@ -115,7 +115,7 @@
 
             (maybe-with-profiling
              (if (as-standalone-html?)
-                 (build-standalone-xhtml path)
+                 (build-standalone-html path)
                  (build-html-and-javascript path)))]
 
    ["print-il" "print the intermediate translation of a module"

--- a/whalesong/whalesong-helpers.rkt
+++ b/whalesong/whalesong-helpers.rkt
@@ -94,7 +94,7 @@
                            (flush-output (current-report-port))]))
                       (loop)))))))
 
-(define (build-standalone-xhtml f)
+(define (build-standalone-html f)
   (with-catchall-exception-handler
    (lambda ()
      (turn-on-logger!)
@@ -104,7 +104,7 @@
               (build-path
                (regexp-replace #rx"[.](rkt|ss)$"
                                (path->string filename)
-                               ".xhtml"))])
+                               ".html"))])
          (unless (directory-exists? (current-output-dir))
            (fprintf (current-report-port) "Creating destination directory ~s\n" (current-output-dir))
            (make-directory* (current-output-dir)))
@@ -129,10 +129,10 @@
                                         (build-path (current-output-dir)
                                                     (resource-key r)))]))])
            (fprintf (current-report-port)
-                    (format "Writing program ~s\n" (build-path (current-output-port) output-filename)))
+                    (format "Writing program ~s\n" (build-path (current-output-dir) output-filename)))
            (call-with-output-file* (build-path (current-output-dir) output-filename)
                                    (lambda (op)
-                                     (package-standalone-xhtml
+                                     (package-standalone-html
                                       (make-MainModuleSource 
                                        (normalize-path (build-path f)))
                                       op))

--- a/whalesong/world.rkt
+++ b/whalesong/world.rkt
@@ -1,4 +1,7 @@
 #lang s-exp "lang/base.rkt"
-(require "world/main.rkt")
 
-(provide (all-from-out "world/main.rkt"))
+(require "world/main.rkt")
+(require "world/types.rkt")
+
+(provide (all-from-out "world/main.rkt")
+         (all-from-out "world/types.rkt"))

--- a/whalesong/world.rkt
+++ b/whalesong/world.rkt
@@ -1,7 +1,5 @@
 #lang s-exp "lang/base.rkt"
 
 (require "world/main.rkt")
-(require "world/types.rkt")
 
-(provide (all-from-out "world/main.rkt")
-         (all-from-out "world/types.rkt"))
+(provide (all-from-out "world/main.rkt"))

--- a/whalesong/world/impl.rkt
+++ b/whalesong/world/impl.rkt
@@ -1,0 +1,27 @@
+#lang s-exp "../lang/js/js.rkt"
+
+(require "../image.rkt"
+         "types.rkt")
+
+(declare-implementation
+ #:racket "racket-impl.rkt"
+ #:javascript (
+               ;; the raw implementation doesn't know anything about
+               ;; Whalesong.
+               "raw-jsworld.js"  
+
+               ;; We add Whalesong-specific things here.
+               "kernel.js"
+               "js-impl.js"
+               )
+ #:provided-values (big-bang
+                    on-tick
+                    on-key
+                    on-release
+                    on-mouse
+                    key=?
+                    to-draw
+                    stop-when))
+
+
+

--- a/whalesong/world/js-impl.js
+++ b/whalesong/world/js-impl.js
@@ -32,7 +32,10 @@ var checkHandler = plt.baselib.check.makeCheckArgumentType(
     isWorldConfigOption,
     "world configuration handler");
 
-
+var worldNamespace = MACHINE.modules['whalesong/world/types.rkt'].getExternalExports();
+var stopWithStruct = worldNamespace.get('struct:stop-with');
+var isStopWithStruct = stopWithStruct.predicate
+var stopWithWorld = function(s) { return stopWithStruct.accessor(s, 0); }
 
 
 // The default tick delay is 28 times a second.

--- a/whalesong/world/js-impl.js
+++ b/whalesong/world/js-impl.js
@@ -103,6 +103,15 @@ EXPORTS['on-key'] =
             return new OnKey(f);
         });
 
+EXPORTS['on-release'] =
+    makePrimitiveProcedure(
+        'on-release',
+        1,
+        function(MACHINE) {
+            var f = checkProcedureWithKey(MACHINE, "on-key", 0);
+            return new OnRelease(f);
+        });
+
 EXPORTS['on-mouse'] =
     makePrimitiveProcedure(
         'on-mouse',

--- a/whalesong/world/js-impl.js
+++ b/whalesong/world/js-impl.js
@@ -87,10 +87,16 @@ EXPORTS['to-draw'] =
 EXPORTS['stop-when'] =
     makePrimitiveProcedure(
         'stop-when',
-        1,
+        plt.baselib.lists.makeList(1, 2),
         function(MACHINE) {
             var f = checkProcedure1(MACHINE, "on-tick", 0);
-            return new StopWhen(f);
+            if (MACHINE.a === 2) {
+                var lp = checkProcedure1(MACHINE, "to-draw", 1);
+            } else {
+                var lp = null;
+            }
+
+            return new StopWhen(f, lp);
         });
 
 

--- a/whalesong/world/kernel.js
+++ b/whalesong/world/kernel.js
@@ -377,7 +377,7 @@ DefaultDrawingOutput.prototype.toRawHandler = function(MACHINE, toplevelNode) {
 var StopWhen = function(handler, last_picture) {
     WorldConfigOption.call(this, 'stop-when');
     this.handler = handler;
-    this.last_picture = new ToDraw(last_picture);
+    this.last_picture = last_picture && new ToDraw(last_picture);
 };
 
 StopWhen.prototype = plt.baselib.heir(WorldConfigOption.prototype);
@@ -385,6 +385,6 @@ StopWhen.prototype = plt.baselib.heir(WorldConfigOption.prototype);
 StopWhen.prototype.toRawHandler = function(MACHINE, toplevelNode) {
     var that = this;
     var worldFunction = adaptWorldFunction(that.handler);
-    var lastPictureHandler = that.last_picture.toRawHandler(MACHINE, toplevelNode);
+    var lastPictureHandler = that.last_picture && that.last_picture.toRawHandler(MACHINE, toplevelNode);
     return rawJsworld.stop_when(worldFunction, undefined, lastPictureHandler);
 };

--- a/whalesong/world/kernel.js
+++ b/whalesong/world/kernel.js
@@ -168,6 +168,22 @@ OnKey.prototype.toRawHandler = function(MACHINE, toplevelNode) {
         });
 };
 
+var OnRelease = function(handler) {
+    WorldConfigOption.call(this, 'on-release');
+    this.handler = handler;
+}
+
+OnRelease.prototype = plt.baselib.heir(WorldConfigOption.prototype);
+ 
+OnRelease.prototype.toRawHandler = function(MACHINE, toplevelNode) {
+    var that = this;
+    var worldFunction = adaptWorldFunction(that.handler);
+    return rawJsworld.on_release(
+        function(w, e, success) {
+            worldFunction(w, getKeyCodeName(e), success);
+        });
+};
+
 
 var getKeyCodeName = function(e) {
     var code = e.charCode || e.keyCode;

--- a/whalesong/world/kernel.js
+++ b/whalesong/world/kernel.js
@@ -282,8 +282,6 @@ ToDraw.prototype = plt.baselib.heir(OutputConfig.prototype);
  
 ToDraw.prototype.toRawHandler = function(MACHINE, toplevelNode) {
     var that = this;
-    var reusableCanvas;
-    var reusableCanvasNode;
     var adaptedWorldFunction = adaptWorldFunction(this.handler);
 
     var worldFunction = function(world, success) {
@@ -291,6 +289,12 @@ ToDraw.prototype.toRawHandler = function(MACHINE, toplevelNode) {
         adaptedWorldFunction(
             world,
             function(v) {
+                var reusableCanvas = toplevelNode.getElementsByTagName('canvas')[0];
+                var reusableCanvasNode;
+                if (reusableCanvas) {
+                    reusableCanvasNode = rawJsworld.node_to_tree(reusableCanvas);
+                }
+
                 // fixme: once jsworld supports fail continuations, use them
                 // to check the status of the scene object and make sure it's an
                 // image.
@@ -325,6 +329,7 @@ ToDraw.prototype.toRawHandler = function(MACHINE, toplevelNode) {
     };
 
     var cssFunction = function(w, k) { 
+        var reusableCanvas = toplevelNode.getElementsByTagName('canvas')[0];
         if (reusableCanvas) {
  	    k([[reusableCanvas, 
                 ["padding", "0px"],
@@ -369,9 +374,10 @@ DefaultDrawingOutput.prototype.toRawHandler = function(MACHINE, toplevelNode) {
 
 
 
-var StopWhen = function(handler) {
+var StopWhen = function(handler, last_picture) {
     WorldConfigOption.call(this, 'stop-when');
     this.handler = handler;
+    this.last_picture = new ToDraw(last_picture);
 };
 
 StopWhen.prototype = plt.baselib.heir(WorldConfigOption.prototype);
@@ -379,5 +385,6 @@ StopWhen.prototype = plt.baselib.heir(WorldConfigOption.prototype);
 StopWhen.prototype.toRawHandler = function(MACHINE, toplevelNode) {
     var that = this;
     var worldFunction = adaptWorldFunction(that.handler);
-    return rawJsworld.stop_when(worldFunction);
+    var lastPictureHandler = that.last_picture.toRawHandler(MACHINE, toplevelNode);
+    return rawJsworld.stop_when(worldFunction, undefined, lastPictureHandler);
 };

--- a/whalesong/world/kernel.js
+++ b/whalesong/world/kernel.js
@@ -315,6 +315,7 @@ ToDraw.prototype.toRawHandler = function(MACHINE, toplevelNode) {
                         reusableCanvas.height = height;
                     }
 		    var ctx = reusableCanvas.getContext("2d");
+                    ctx.clearRect(0, 0, width, height);
 		    v.render(ctx, 0, 0);
 		    success([toplevelNode, reusableCanvasNode]);
 		} else {

--- a/whalesong/world/main.rkt
+++ b/whalesong/world/main.rkt
@@ -1,27 +1,7 @@
-#lang s-exp "../lang/js/js.rkt"
+#lang s-exp "../lang/base.rkt"
 
-(require "../image.rkt"
+(require "impl.rkt"
          "types.rkt")
 
-(declare-implementation
- #:racket "racket-impl.rkt"
- #:javascript (
-               ;; the raw implementation doesn't know anything about
-               ;; Whalesong.
-               "raw-jsworld.js"  
-
-               ;; We add Whalesong-specific things here.
-               "kernel.js"
-               "js-impl.js"
-               )
- #:provided-values (big-bang
-                    on-tick
-                    on-key
-                    on-release
-                    on-mouse
-                    key=?
-                    to-draw
-                    stop-when))
-
-
-
+(provide (all-from-out "impl.rkt")
+         (all-from-out "types.rkt"))

--- a/whalesong/world/main.rkt
+++ b/whalesong/world/main.rkt
@@ -16,6 +16,7 @@
  #:provided-values (big-bang
                     on-tick
                     on-key
+                    on-release
                     on-mouse
                     key=?
                     to-draw

--- a/whalesong/world/main.rkt
+++ b/whalesong/world/main.rkt
@@ -1,6 +1,7 @@
 #lang s-exp "../lang/js/js.rkt"
 
-(require "../image.rkt")
+(require "../image.rkt"
+         "types.rkt")
 
 (declare-implementation
  #:racket "racket-impl.rkt"

--- a/whalesong/world/racket-impl.rkt
+++ b/whalesong/world/racket-impl.rkt
@@ -1,5 +1,7 @@
 #lang s-exp "../lang/base.rkt"
 
+(require "types.rkt")
+
 (provide big-bang
          to-draw
          on-tick

--- a/whalesong/world/racket-impl.rkt
+++ b/whalesong/world/racket-impl.rkt
@@ -5,6 +5,7 @@
          on-tick
          on-mouse
          on-key
+         on-release
          key=?
          stop-when)
 
@@ -32,6 +33,9 @@
 
 (define (on-key handler)
   (error 'on-key "must be run in JavaScript context"))
+
+(define (on-release handler)
+  (error 'on-release "must be run in JavaScript context"))
 
 (define (key=? key-1 key-2)
   (error 'key=? "must be run in JavaScript context"))

--- a/whalesong/world/racket-impl.rkt
+++ b/whalesong/world/racket-impl.rkt
@@ -40,5 +40,8 @@
 (define (key=? key-1 key-2)
   (error 'key=? "must be run in JavaScript context"))
 
-(define (stop-when handler)
-  (error 'stop-when "must be run in JavaScript context"))
+(define stop-when
+  (case-lambda [(handler)
+                (error 'stop-when "must be run in JavaScript context")]
+               [(handler last-picture)
+                (error 'stop-when "must be run in JavaScript context")]))

--- a/whalesong/world/raw-jsworld.js
+++ b/whalesong/world/raw-jsworld.js
@@ -663,12 +663,16 @@ var rawJsworld = {};
             stopWhen.test(w,
                           function(stop) {
                               if (stop) {
-                                  var handler = stopWhen.last_picture_handler();
-                                  handler.onRegister(top);
-                                  handler._listener(w, oldW, function(v) {
+                                  if (stopWhen.last_picture_handler) {
+                                      var handler = stopWhen.last_picture_handler();
+                                      handler.onRegister(top);
+                                      handler._listener(w, oldW, function(v) {
+                                          Jsworld.shutdown({cleanShutdown: true});
+                                          k2();
+                                      })
+                                  } else {
                                       Jsworld.shutdown({cleanShutdown: true});
-                                      k2();
-                                  })
+                                  }
                               } else { k2(); }
                           });
         };

--- a/whalesong/world/raw-jsworld.js
+++ b/whalesong/world/raw-jsworld.js
@@ -743,7 +743,27 @@ var rawJsworld = {};
     }
     Jsworld.on_key = on_key;
 
-
+    function on_release(release) {
+        return function() {
+            var wrappedRelease = function(e) {
+                preventDefault(e);
+                stopPropagation(e);
+                change_world(function(w, k) { release(w, e, k); }, doNothing);
+            };
+            return {
+                onRegister: function(top) {
+                    //http://www.w3.org/TR/html5/editing.html#sequential-focus-navigation-and-the-tabindex-attribue
+                    jQuery(top).attr('tabindex', 1);
+                    jQuery(top).focus();
+                    attachEvent(top, 'keyup', wrappedRelease);
+                },
+                onUnregister: function(top) {
+                    detachEvent(top, 'keyup', wrappedRelease);
+                }
+            };
+        };
+    }
+    Jsworld.on_release = on_release;
 
 
     // http://www.quirksmode.org/js/events_mouse.html

--- a/whalesong/world/raw-jsworld.js
+++ b/whalesong/world/raw-jsworld.js
@@ -663,9 +663,13 @@ var rawJsworld = {};
             stopWhen.test(w,
                           function(stop) {
                               if (stop) {
-                                  Jsworld.shutdown({cleanShutdown: true});
-                              }
-                              else { k2(); }
+                                  var handler = stopWhen.last_picture_handler();
+                                  handler.onRegister(top);
+                                  handler._listener(w, oldW, function(v) {
+                                      Jsworld.shutdown({cleanShutdown: true});
+                                      k2();
+                                  })
+                              } else { k2(); }
                           });
         };
         add_world_listener(watchForTermination);
@@ -863,17 +867,18 @@ var rawJsworld = {};
 
 
 
-    StopWhenHandler = function(test, receiver) {
+    StopWhenHandler = function(test, receiver, last_picture_handler) {
         this.test = test;
         this.receiver = receiver;
+        this.last_picture_handler = last_picture_handler;
     };
     // stop_when: CPS(world -> boolean) CPS(world -> boolean) -> handler
-    function stop_when(test, receiver) {
+    function stop_when(test, receiver, last_picture_handler) {
         return function() {
             if (receiver === undefined) {
                 receiver = function(w, k) { k(w); };
             }
-            return new StopWhenHandler(test, receiver);
+            return new StopWhenHandler(test, receiver, last_picture_handler);
         };
     }
     Jsworld.stop_when = stop_when;

--- a/whalesong/world/types.rkt
+++ b/whalesong/world/types.rkt
@@ -1,0 +1,5 @@
+#lang s-exp "../lang/base.rkt"
+
+(provide (struct-out stop-with))
+
+(define-struct stop-with (world))


### PR DESCRIPTION
The latest version of Racket has introduced an "undefined" value.
If the undefined value is referenced an exception is thrown.
This affects letrec, which no longer allows the (letrec ((x x)) x) trick that occurs 
in the Whalesong song source, where an undefined value is needed.

A temporary fix is to redefine letrec and letrec-values to use the old semantics.
This PR does just that.

A longer term fix would be to introduce a new type of runtime value to represent
the undefined value.
